### PR TITLE
fix: allow mismatched planes to self-heal via re-verification

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -261,7 +261,7 @@ const staticFiles = [
 ];
 
 // Generate routes
-const routes: Record<string, Response | ((req: Request) => Response)> = {};
+const routes: Record<string, Response | ((req: Request) => Response | Promise<Response>)> = {};
 
 // Add static file routes
 for (const file of staticFiles) {
@@ -349,13 +349,24 @@ routes["/api/check-flight"] = tracedRoute("/api/check-flight", (req) => {
   const flightNumberVariants: string[] = [normalizedFlightNumber];
 
   // If user entered a UA number, also search for operating carrier equivalents
-  if (normalizedFlightNumber.startsWith("UA")) {
+  // (FR24 stores callsigns/alternates which use various prefix formats)
+  if (/^UA\d+$/.test(normalizedFlightNumber)) {
     const numericPart = normalizedFlightNumber.slice(2);
-    // ICAO codes used in FR24 data
-    const icaoCarriers = ["SKW", "ASH", "RPA", "GJS", "PDT", "ACA", "ENY"];
-    // IATA codes also found in DB
-    const iataCarriers = ["OO", "YX", "YV", "G7"];
-    for (const carrier of [...icaoCarriers, ...iataCarriers]) {
+    const carrierPrefixes = [
+      "UAL", // United mainline ICAO callsign
+      "SKW",
+      "ASH",
+      "RPA",
+      "GJS",
+      "PDT",
+      "ACA",
+      "ENY", // Express ICAO
+      "OO",
+      "YX",
+      "YV",
+      "G7", // Express IATA
+    ];
+    for (const carrier of carrierPrefixes) {
       flightNumberVariants.push(`${carrier}${numericPart}`);
     }
   }
@@ -651,7 +662,7 @@ async function handleRequest(req: Request): Promise<Response> {
 
   // Check Flight page (also handles /check-flight/UA123/2026-01-24 for shared links)
   if (url.pathname === "/check-flight" || url.pathname.startsWith("/check-flight/")) {
-    if (req.method !== "GET") {
+    if (req.method !== "GET" && req.method !== "HEAD") {
       return new Response("Method not allowed", {
         status: 405,
         headers: { "Content-Type": "text/plain" },
@@ -710,7 +721,7 @@ async function handleRequest(req: Request): Promise<Response> {
 
   // Home page
   if (url.pathname === "/") {
-    if (req.method !== "GET") {
+    if (req.method !== "GET" && req.method !== "HEAD") {
       return new Response("Method not allowed", {
         status: 405,
         headers: { "Content-Type": "text/plain" },

--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 import {
-  getStarlinkPlanes,
+  getAllStarlinkPlanes,
   initializeDatabase,
   needsFlightCheck,
   updateFlights,
@@ -230,7 +230,8 @@ export async function updateAllFlights() {
   }
 
   const db = initializeDatabase();
-  const planes = getStarlinkPlanes(db);
+  // Include mismatched planes so they keep getting fresh flight data for re-verification
+  const planes = getAllStarlinkPlanes(db);
   db.close();
 
   info(`Checking flight updates for ${planes.length} Starlink aircraft...`);
@@ -339,8 +340,8 @@ export function startFlightUpdater() {
 
           const db = initializeDatabase();
 
-          // Find a plane that needs updating
-          const planes = getStarlinkPlanes(db);
+          // Find a plane that needs updating (includes mismatches so they can be re-verified later)
+          const planes = getAllStarlinkPlanes(db);
           let planeToUpdate: Aircraft | null = null;
 
           for (const plane of planes) {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -398,6 +398,31 @@ export function getStarlinkPlanes(db: Database): Aircraft[] {
     .all() as Aircraft[];
 }
 
+/**
+ * Get ALL starlink_planes including mismatches (verified_wifi = 'None'/'Panasonic'/etc).
+ * Used by the verifier and flight-updater so mismatched planes can still be
+ * re-verified and self-heal if United's data changes.
+ */
+export function getAllStarlinkPlanes(db: Database): Aircraft[] {
+  return db
+    .query(
+      `
+      SELECT aircraft as Aircraft,
+             wifi as WiFi,
+             sheet_gid,
+             sheet_type,
+             DateFound,
+             TailNumber,
+             OperatedBy,
+             fleet,
+             verified_wifi
+      FROM starlink_planes
+      ORDER BY DateFound DESC
+    `
+    )
+    .all() as Aircraft[];
+}
+
 export function getFleetStats(db: Database): FleetStats {
   // Get totals from spreadsheet data (accurate for fleet size)
   const expressTotal = getMetaValue(db, "expressTotal", 0);
@@ -865,10 +890,11 @@ export function getWifiMismatches(db: Database): WifiMismatch[] {
       WHERE verified_wifi IS NOT NULL
         AND (
           -- Spreadsheet says Starlink but verification says None or other provider
-          (wifi = 'StrLnk' AND verified_wifi != 'Starlink')
+          -- (express sheets use 'StrLnk', mainline sheets use 'Starlink')
+          (wifi IN ('StrLnk', 'Starlink') AND verified_wifi != 'Starlink')
           OR
           -- Spreadsheet says no Starlink but verification found it
-          (wifi != 'StrLnk' AND verified_wifi = 'Starlink')
+          (wifi NOT IN ('StrLnk', 'Starlink') AND verified_wifi = 'Starlink')
         )
       ORDER BY verified_at DESC
     `)
@@ -885,7 +911,7 @@ export function clearMismatchVerifications(db: Database): number {
     UPDATE starlink_planes
     SET verified_wifi = NULL, verified_at = NULL
     WHERE verified_wifi IS NOT NULL
-      AND wifi = 'StrLnk'
+      AND wifi IN ('StrLnk', 'Starlink')
       AND verified_wifi != 'Starlink'
   `)
     .run();
@@ -932,8 +958,8 @@ export function getVerificationSummary(db: Database): {
         SUM(CASE WHEN verified_wifi IS NOT NULL THEN 1 ELSE 0 END) as verified_count,
         SUM(CASE WHEN verified_wifi IS NULL THEN 1 ELSE 0 END) as unverified_count,
         SUM(CASE WHEN verified_wifi IS NOT NULL AND (
-          (wifi = 'StrLnk' AND verified_wifi != 'Starlink')
-          OR (wifi != 'StrLnk' AND verified_wifi = 'Starlink')
+          (wifi IN ('StrLnk', 'Starlink') AND verified_wifi != 'Starlink')
+          OR (wifi NOT IN ('StrLnk', 'Starlink') AND verified_wifi = 'Starlink')
         ) THEN 1 ELSE 0 END) as mismatches_count,
         SUM(CASE WHEN verified_wifi = 'Starlink' THEN 1 ELSE 0 END) as verified_starlink,
         SUM(CASE WHEN verified_wifi = 'None' THEN 1 ELSE 0 END) as verified_none,

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -173,10 +173,17 @@ async function verifyPlane(
           span.setTag("result", "starlink");
           metrics.increment(COUNTERS.VERIFICATION_CHECK, { result: "success" });
           metrics.increment(COUNTERS.PLANES_STARLINK_DETECTED);
-        } else {
+        } else if (result.wifiProvider) {
+          // We got a definite answer (None/Panasonic/Viasat/Thales/Gogo)
           starlinkStatus = "negative";
           span.setTag("result", "not_starlink");
           metrics.increment(COUNTERS.VERIFICATION_CHECK, { result: "success" });
+        } else {
+          // wifiProvider was null — couldn't determine (unknown provider, page didn't load fully)
+          // Keep existing status, don't wrongly mark as negative
+          starlinkStatus = plane.starlink_status as StarlinkStatus;
+          span.setTag("result", "unknown");
+          metrics.increment(COUNTERS.VERIFICATION_CHECK, { result: "unknown" });
         }
 
         span.setTag("wifi_provider", result.wifiProvider || "unknown");

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -1,13 +1,13 @@
 /**
  * Starlink Verification Runner
  * Verifies Starlink status for planes using United.com with rate limiting
- * Fetches plane/flight data from unitedstarlinktracker.com API
+ * Reads plane/flight data from local SQLite (including mismatched planes so they can self-heal)
  */
 
 import type { Database } from "bun:sqlite";
 import {
-  type VerificationSource,
-  getLastVerification,
+  getAllStarlinkPlanes,
+  getUpcomingFlights,
   getVerificationStats,
   initializeDatabase,
   logVerification,
@@ -20,7 +20,6 @@ import type { StarlinkCheckResult } from "./united-starlink-checker";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
 
 const VERIFICATION_DELAY_MS = 5000; // 5 seconds between checks to be polite
-const API_BASE_URL = "https://unitedstarlinktracker.com";
 
 /**
  * Convert ICAO airport code to IATA (remove K prefix for US airports)
@@ -64,49 +63,40 @@ interface Plane {
   fleet: string;
 }
 
-interface ApiDataResponse {
-  totalCount: number;
-  starlinkPlanes: Plane[];
-  lastUpdated: string;
-  flightsByTail: Record<string, Flight[]>;
-}
-
 /**
- * Fetch data from unitedstarlinktracker.com API
- */
-async function fetchTrackerData(): Promise<ApiDataResponse | null> {
-  try {
-    const response = await fetch(`${API_BASE_URL}/api/data`);
-    if (!response.ok) {
-      throw new Error(`API returned ${response.status}`);
-    }
-    return await response.json();
-  } catch (error) {
-    verifierLog.error("Failed to fetch tracker data", error);
-    return null;
-  }
-}
-
-/**
- * Get planes that need United verification based on local verification log
+ * Get planes that need United verification.
+ * Queries the local DB directly (including mismatched planes with
+ * verified_wifi != 'Starlink') so they can self-heal on re-verification.
+ *
+ * Previously this pulled from /api/data which filters out mismatches —
+ * creating a one-way door where a single false-negative permanently
+ * hid a plane.
  */
 function getPlanesNeedingVerification(
   db: Database,
-  planes: Plane[],
-  flightsByTail: Record<string, Flight[]>,
   limit: number,
   forceAll = false
 ): Array<{ plane: Plane; flight: Flight }> {
   const result: Array<{ plane: Plane; flight: Flight }> = [];
   const now = Math.floor(Date.now() / 1000);
 
+  // Pull ALL planes from starlink_planes (including mismatches)
+  const planes = getAllStarlinkPlanes(db) as Plane[];
+  const allFlights = getUpcomingFlights(db);
+
+  // Group flights by tail number
+  const flightsByTail = new Map<string, Flight[]>();
+  for (const f of allFlights) {
+    if (!flightsByTail.has(f.tail_number)) {
+      flightsByTail.set(f.tail_number, []);
+    }
+    flightsByTail.get(f.tail_number)!.push(f);
+  }
+
   for (const plane of planes) {
     if (result.length >= limit) break;
 
-    // Check if this plane has upcoming flights
-    const flights = flightsByTail[plane.TailNumber] || [];
-    if (flights.length === 0) continue;
-
+    const flights = flightsByTail.get(plane.TailNumber) || [];
     const futureFlights = flights.filter((f) => f.departure_time > now);
     if (futureFlights.length === 0) continue;
 
@@ -114,7 +104,6 @@ function getPlanesNeedingVerification(
       continue;
     }
 
-    // Use the first upcoming flight
     result.push({ plane, flight: futureFlights[0] });
   }
 
@@ -164,6 +153,11 @@ export async function verifyPlaneStarlink(
         const tailMatches = actualTail && actualTail.toUpperCase() === tailNumber.toUpperCase();
         const tailMismatch = actualTail && !tailMatches;
 
+        // If we couldn't extract a tail number from the page, we can't confirm
+        // the aircraft wasn't swapped. Only trust a POSITIVE Starlink result in
+        // that case (can't falsely hide a plane, only falsely show one — less bad).
+        const tailUnknown = !actualTail;
+
         if (tailMismatch) {
           verifierLog.warn(
             `Aircraft mismatch: expected ${tailNumber} but flight has ${actualTail} - skipping verification update`
@@ -186,9 +180,21 @@ export async function verifyPlaneStarlink(
         // Update the plane's verified_wifi status ONLY if:
         // 1. No error
         // 2. We got a wifiProvider
-        // 3. The tail number matches (or we couldn't extract tail from page)
-        if (!result.error && result.wifiProvider && !tailMismatch) {
+        // 3. The tail number matches (not swapped to a different plane)
+        // 4. If tail wasn't extracted, only trust positive Starlink results
+        //    (prevents hiding planes due to unconfirmed aircraft swaps)
+        const canTrustResult =
+          !result.error &&
+          result.wifiProvider &&
+          !tailMismatch &&
+          (!tailUnknown || result.wifiProvider === "Starlink");
+
+        if (canTrustResult) {
           updateVerifiedWifi(db, tailNumber, result.wifiProvider);
+        } else if (tailUnknown && result.wifiProvider && result.wifiProvider !== "Starlink") {
+          verifierLog.warn(
+            `${tailNumber}: got "${result.wifiProvider}" but couldn't confirm tail number — skipping update to avoid false negative`
+          );
         }
 
         // Emit metrics
@@ -270,26 +276,8 @@ export async function runVerificationBatch(
   const stats = { checked: 0, starlink: 0, notStarlink: 0, errors: 0, skipped: 0 };
 
   try {
-    // Fetch data from the API
-    verifierLog.debug(`Fetching data from ${API_BASE_URL}/api/data`);
-    const data = await fetchTrackerData();
-
-    if (!data) {
-      verifierLog.error("Failed to fetch tracker data");
-      return stats;
-    }
-
-    const flightCount = Object.values(data.flightsByTail).flat().length;
-    verifierLog.debug(`Found ${data.starlinkPlanes.length} planes, ${flightCount} flights`);
-
-    // Get planes that need verification
-    const toVerify = getPlanesNeedingVerification(
-      db,
-      data.starlinkPlanes,
-      data.flightsByTail,
-      maxPlanes,
-      forceAll
-    );
+    // Get planes that need verification (from local DB, includes mismatches so they can self-heal)
+    const toVerify = getPlanesNeedingVerification(db, maxPlanes, forceAll);
 
     if (toVerify.length === 0) {
       verifierLog.debug("No planes need verification at this time");

--- a/src/scripts/united-starlink-checker.ts
+++ b/src/scripts/united-starlink-checker.ts
@@ -154,11 +154,23 @@ export async function checkStarlinkStatus(
 
     // Check if flight was found
     const pageContent = await page.content();
-    if (pageContent.includes("We couldn't find") || pageContent.includes("No flights found")) {
-      result.error = "No upcoming flights available";
-      // Save debug HTML for analysis
-      const bodyText = await page.evaluate(() => document.body.innerText);
-      result.debugFile = saveDebugHtml("unknown", flightNumber, pageContent, bodyText);
+    const bodyTextForErrors = await page.evaluate(() => document.body.innerText);
+
+    // If United redirected to the search page, the flight wasn't found
+    // (too far in future, wrong date, or no longer scheduled)
+    const redirectedToSearch =
+      bodyTextForErrors.includes("Search by Route or Flight Number") ||
+      bodyTextForErrors.includes("Flight status\nSearch by");
+
+    if (
+      pageContent.includes("We couldn't find") ||
+      pageContent.includes("No flights found") ||
+      redirectedToSearch
+    ) {
+      result.error = redirectedToSearch
+        ? "Flight not found (redirected to search page)"
+        : "No upcoming flights available";
+      result.debugFile = saveDebugHtml("unknown", flightNumber, pageContent, bodyTextForErrors);
       return result;
     }
 
@@ -176,6 +188,8 @@ export async function checkStarlinkStatus(
         bodyText.includes("Internet by Panasonic") || bodyText.includes("by Panasonic");
       const hasViasatText =
         bodyText.includes("Internet by Viasat") || bodyText.includes("by Viasat");
+      const hasThalesText =
+        bodyText.includes("Internet by Thales") || bodyText.includes("by Thales");
       const hasGogoText = bodyText.includes("by Gogo") || bodyText.includes("Gogo Wi-Fi");
 
       // Check for no WiFi
@@ -190,22 +204,27 @@ export async function checkStarlinkStatus(
         wifiProvider = "Panasonic";
       } else if (hasViasatText) {
         wifiProvider = "Viasat";
+      } else if (hasThalesText) {
+        wifiProvider = "Thales";
       } else if (hasGogoText) {
         wifiProvider = "Gogo";
       } else if (hasNoWifi) {
         wifiProvider = "None";
       }
 
-      // Extract tail number - look for pattern like "#N164SY" or "#3991"
+      // Extract tail number from "Aircraft details" section
+      // Express planes show registration directly: "Embraer E-175 | #N164SY"
+      // Mainline planes show ship number: "Boeing 737-700 | #3731" (NOT the tail number!)
+      // Only trust it if it looks like a US registration (N + 1-5 alphanumerics, not pure digits)
       let tailNumber: string | null = null;
       const tailMatch = bodyText.match(/\|\s*#([A-Z0-9]+)/);
       if (tailMatch) {
         const extracted = tailMatch[1];
-        // If it's just digits, it might be a ship number, prefix with N
-        tailNumber = extracted.match(/^\d+$/) ? `N${extracted}` : extracted;
-        // Ensure it starts with N for US registration
-        if (!tailNumber.startsWith("N")) {
-          tailNumber = `N${tailNumber}`;
+        // Only accept if it looks like a real N-number (starts with N, not just digits)
+        // Ship numbers like "3731" are NOT tail numbers — leave as null so the
+        // verifier's tail-mismatch protection doesn't get bypassed or confused.
+        if (/^N[0-9][0-9A-Z]{1,4}$/.test(extracted)) {
+          tailNumber = extracted;
         }
       }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,23 +15,40 @@ export type FlightDataSource = "flightradar24" | "flightaware";
 export const FLIGHT_DATA_SOURCE: FlightDataSource =
   (process.env.FLIGHT_DATA_SOURCE as FlightDataSource) || "flightradar24";
 
-// United Express operating carrier codes that should be normalized to UA
-const UNITED_EXPRESS_CARRIERS = ["SKW", "ASH", "RPA", "GJS", "PDT", "ACA", "ENY"];
+// United Express operating carrier prefixes that should be normalized to UA
+// ICAO 3-letter codes (from FR24 callsigns) and IATA 2-letter codes (from FR24 number.alternative)
+// Ordered longest-first so prefix matching works (UAL before UA, etc.)
+const UNITED_CARRIER_PREFIXES = [
+  // ICAO 3-letter (callsign format)
+  "UAL", // United Airlines mainline
+  "SKW", // SkyWest
+  "ASH", // Mesa
+  "RPA", // Republic
+  "GJS", // GoJet
+  "PDT", // Piedmont
+  "ACA", // Air Canada (codeshare)
+  "ENY", // Envoy
+  // IATA 2-letter
+  "OO", // SkyWest
+  "YX", // Republic
+  "YV", // Mesa
+  "G7", // GoJet
+];
 
 /**
  * Normalize flight numbers to UA marketing code
- * Converts operating carrier codes (SKW5882, ASH4054, RPA3712, GJS4467) to UA prefix
+ * Converts operating carrier codes (SKW5882, ASH4054, UAL544, OO4680) to UA prefix
  * This matches what customers see on their tickets
  */
 export function normalizeFlightNumber(flightNumber: string): string {
   if (!flightNumber) return flightNumber;
 
-  // Already UA-prefixed, return as-is
-  if (flightNumber.startsWith("UA")) return flightNumber;
+  // Already exact UA#### format (not UAL####), return as-is
+  if (/^UA\d+$/.test(flightNumber)) return flightNumber;
 
-  // Check if it starts with a known United Express carrier code
-  for (const carrier of UNITED_EXPRESS_CARRIERS) {
-    if (flightNumber.startsWith(carrier)) {
+  // Check if it starts with a known carrier prefix followed by digits
+  for (const carrier of UNITED_CARRIER_PREFIXES) {
+    if (flightNumber.startsWith(carrier) && /^\d+$/.test(flightNumber.slice(carrier.length))) {
       return `UA${flightNumber.slice(carrier.length)}`;
     }
   }


### PR DESCRIPTION
## Problem

Production has **84 planes** stuck in a mismatched state (spreadsheet says Starlink, United.com said None). Once marked, they were permanently hidden with no recovery path.

### Root cause: verification death spiral

1. `getStarlinkPlanes()` filters out planes where `verified_wifi != 'Starlink'`
2. The verifier pulls planes from `/api/data` (which uses `getStarlinkPlanes()`)
3. → Once a plane is marked as a mismatch, **it's never re-verified again**

A single false-negative (aircraft swap, page load glitch, stale United data) permanently hides a plane.

## Fix

**Verifier and flight-updater now pull from DB directly** via new `getAllStarlinkPlanes()` — including mismatched planes. They'll get fresh flight data and be re-verified on the normal 48-96hr cadence.

No manual DB intervention needed — system **self-heals after deploy**:
- Flight-updater picks up mismatched planes → fresh flight data within hours
- Verifier picks them up on next cycle (all 84 are well past threshold) → re-checked
- If United now shows Starlink → `verified_wifi = 'Starlink'` → unhidden
- If still None → stays mismatched (correctly)

## Other bugs fixed during audit

| Bug | Fix | Impact |
|-----|-----|--------|
| Checker didn't recognize Thales WiFi → `wifiProvider: null` | Added Thales detection | Mainline planes now correctly classified |
| Checker returned null/null (no error) when United redirected to search page | Detect redirect, return proper error | Prevents silent failures for flights >2d out |
| Checker treated mainline ship # (`#3731`) as tail number (`N3731`) | Only accept `N[0-9][0-9A-Z]{1,4}` pattern | Fixes aircraft-swap detection for mainline |
| Verifier trusted negative results even when tail wasn't extracted | Require tail extraction for negative verifications | Prevents hiding planes from unconfirmed swaps |
| fleet-discovery marked planes "negative" when wifiProvider was null | Keep existing status when indeterminate | Prevents wrongly marking unknown as not-Starlink |
| `normalizeFlightNumber` didn't handle `UAL###`, `OO###`, `YX###`, `YV###`, `G7###` | Added prefixes | Production DB has 1100+ flights in these formats — ua_flight_number now displays correctly |
| Mismatch SQL only checked `wifi = 'StrLnk'` (express) not `'Starlink'` (mainline) | Use `IN ('StrLnk', 'Starlink')` | Mainline planes no longer falsely flagged |
| `HEAD /` returned 405 | Allow HEAD on HTML pages | Minor — fixes `curl -I` |
| Routes type didn't allow async handlers | `Promise<Response>` | TypeScript only |

## Testing

```
✓ Google Sheets scraper: 342 planes
✓ FR24 API: returns flight data
✓ United checker (express Starlink): hasStarlink=true, tail=N574GJ ✓
✓ United checker (Thales mainline): wifiProvider="Thales", tail=null (ship# correctly ignored)
✓ United checker (fake flight): error="Flight not found (redirected to search page)"
✓ normalizeFlightNumber: 10/10 test cases pass (UAL544→UA544, OO4680→UA4680, etc.)
✓ Local server: /api/data, HEAD /, /api/check-flight all working
✓ Lint: clean
✓ TypeScript: clean (5 pre-existing route type errors now fixed)
```

Compared against production `https://unitedstarlinktracker.com/api/*` throughout.