### PR TITLE
feat: track MCP usage in Plausible via server-side events API

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -20,10 +20,46 @@ import {
 } from "../database/database";
 import type { Flight } from "../types";
 import { normalizeFlightNumber } from "../utils/constants";
-import { info } from "../utils/logger";
+import { debug, info } from "../utils/logger";
 
 // Protocol versions we support (newest first)
 const SUPPORTED_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26"];
+
+// Plausible server-side event tracking (client-side JS won't fire for API calls)
+const PLAUSIBLE_URL = "https://analytics.martinamps.com/api/event";
+const PLAUSIBLE_DOMAIN = "unitedstarlinktracker.com";
+
+/**
+ * Fire-and-forget Plausible event. Never awaited — analytics must not
+ * block or fail MCP responses.
+ *
+ * Uses a custom "MCP" goal with props so you can break down by tool in the
+ * Plausible dashboard (Behaviors → Goal Conversions → MCP → props).
+ */
+function trackMcpEvent(req: Request, props: { method: string; tool?: string }): void {
+  // Forward the client's UA and IP so Plausible can do bot filtering and
+  // unique-visitor counting as if this were a page view.
+  const ua = req.headers.get("user-agent") || "mcp-client/unknown";
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0].trim() || req.headers.get("x-real-ip") || "";
+
+  fetch(PLAUSIBLE_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": ua,
+      ...(ip ? { "X-Forwarded-For": ip } : {}),
+    },
+    body: JSON.stringify({
+      name: "MCP",
+      url: `https://${PLAUSIBLE_DOMAIN}/mcp`,
+      domain: PLAUSIBLE_DOMAIN,
+      props,
+    }),
+  }).catch((err) => {
+    debug(`Plausible event failed (non-fatal): ${err instanceof Error ? err.message : err}`);
+  });
+}
 
 // ============================================================================
 // JSON-RPC types
@@ -513,6 +549,14 @@ export async function handleMcpRequest(req: Request, db: Database): Promise<Resp
     const message = err instanceof Error ? err.message : String(err);
     info(`MCP handler error: ${message}`);
     response = rpcError(msg.id ?? null, -32603, `Internal error: ${message}`);
+  }
+
+  // Track meaningful MCP usage in Plausible (skip ping & notifications — noise)
+  if (msg.method === "initialize" || msg.method === "tools/list") {
+    trackMcpEvent(req, { method: msg.method });
+  } else if (msg.method === "tools/call") {
+    const toolName = typeof msg.params?.name === "string" ? msg.params.name : "unknown";
+    trackMcpEvent(req, { method: "tools/call", tool: toolName });
   }
 
   // Notification (no id) → 202 Accepted, empty body


### PR DESCRIPTION
## Problem

Client-side Plausible script only fires when a browser renders HTML. MCP clients POST JSON — never load HTML — so MCP traffic is invisible in analytics (same as `/api/*` endpoints).

## Fix

Server-side fire-and-forget calls to the [Plausible Events API](https://plausible.io/docs/events-api) for meaningful MCP methods:

| Method | Tracked? | Props |
|--------|----------|-------|
| `initialize` | ✅ | `{method: "initialize"}` |
| `tools/list` | ✅ | `{method: "tools/list"}` |
| `tools/call` | ✅ | `{method: "tools/call", tool: "check_flight"}` |
| `ping` | ❌ | noise |
| `notifications/initialized` | ❌ | noise |

**Design:**
- **Non-blocking** — never awaited, `.catch()` only logs at debug level
- **Forwards client UA + IP** (`X-Forwarded-For`) for Plausible's bot filtering and unique-visitor counting
- **Single "MCP" goal** with props — low cardinality, breaks down nicely in dashboard

## Dashboard

After deploy, events show up under **Behaviors → Goal Conversions → MCP**. Click through to see `tool` prop breakdown (`check_flight`, `get_fleet_stats`, etc.).

You may need to add `MCP` as a custom event goal in Plausible settings if not already configured.

## Testing

```
✓ tools/call → event fired, response unchanged
✓ initialize → event fired, response unchanged  
✓ ping → NO event fired (correctly skipped)
✓ No errors in server log (fetch succeeded)
✓ TypeScript clean, lint clean
```