### PR TITLE
feat: add /mcp docs page, homepage nav, Tools & Integrations section

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,7 +539,21 @@
         "name": "Does my United flight have Starlink?",
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": "Search by flight number, tail number, or airport code on our tracker. You can also install our Chrome extension to see Starlink badges directly on Google Flights, or visit our check a flight page."
+          "text": "Check a flight by number and date — if it's within 2 days you'll get a firm answer, otherwise a probability estimate based on 12,000+ historical aircraft assignments. You can also search the tracker by tail number or route, install our Chrome extension for Google Flights, or use the Route Planner to find the best Starlink routing."
+        }
+      },{
+        "@type": "Question",
+        "name": "How do I maximize my chances of getting Starlink?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Use the Route Planner to compare direct flights and 1-stop connections ranked by Starlink probability. Express flights (UA3000-6999, regional jets) have much higher coverage than mainline — a connection through a hub can beat a direct mainline flight. For example: DEN→ORD direct is ~2%, but DEN→ASE→ORD is ~90% Starlink on both legs."
+        }
+      },{
+        "@type": "Question",
+        "name": "Can I use this with Claude, ChatGPT, or other AI assistants?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes — there's a free MCP server at https://unitedstarlinktracker.com/mcp that works with Claude Desktop, Cursor, and any MCP-compatible client. Once connected, you can ask your AI assistant to check flights, predict Starlink probability, or plan routes using live tracker data."
         }
       },{
         "@type": "Question",

--- a/server.ts
+++ b/server.ts
@@ -97,6 +97,7 @@ process.on("uncaughtException", (err) => {
 import { checkNewPlanes, startFlightUpdater } from "./src/api/flight-updater";
 import { handleMcpRequest } from "./src/api/mcp-server";
 import CheckFlightPage from "./src/components/check-flight-page";
+import McpPage from "./src/components/mcp-page";
 import Page from "./src/components/page";
 import RoutePlannerPage from "./src/components/route-planner-page";
 import {
@@ -614,8 +615,33 @@ routes["/api/fleet-discovery"] = tracedRoute("/api/fleet-discovery", (req) => {
 });
 
 // MCP (Model Context Protocol) endpoint for AI assistants
-// Stateless streamable HTTP server — no sessions, tools-only
-routes["/mcp"] = tracedRoute("/mcp", (req) => handleMcpRequest(req, db));
+// Content-negotiated: browsers (Accept: text/html) get docs page,
+// MCP clients (POST with application/json) get JSON-RPC.
+// Stateless streamable HTTP — no sessions, tools-only.
+routes["/mcp"] = tracedRoute("/mcp", async (req) => {
+  // Browsers navigate with GET + Accept: text/html. Serve docs page.
+  // MCP clients: POST (JSON-RPC) or GET (SSE attempt → 405 from handleMcpRequest).
+  const accept = req.headers.get("accept") || "";
+  if (req.method === "GET" && accept.includes("text/html")) {
+    const host = req.headers.get("host") || "unitedstarlinktracker.com";
+    return renderSubPage(
+      McpPage,
+      "/mcp",
+      {
+        siteTitle: "United Starlink MCP Server — Connect Claude, Cursor & AI Assistants",
+        siteDescription:
+          "Free MCP server for United Starlink tracker data. Connect Claude Desktop, Cursor, or any MCP client to check flights, predict Starlink probability, and plan routes with AI assistants.",
+        keywords:
+          "united starlink mcp server, starlink mcp, claude united starlink, model context protocol starlink, ai assistant starlink flights, cursor starlink integration",
+        ogTitle: "MCP Server — United Starlink Tracker",
+        ogDescription:
+          "Connect your AI assistant to live United Starlink data. Check flights, predict probability, plan routes — via Model Context Protocol.",
+      },
+      host
+    );
+  }
+  return handleMcpRequest(req, db);
+});
 
 // robots.txt route
 routes["/robots.txt"] = new Response(
@@ -668,7 +694,8 @@ United Airlines began installing SpaceX Starlink WiFi on March 7, 2025. The serv
 
 ## MCP Server (for AI assistants)
 
-- [MCP Endpoint](https://unitedstarlinktracker.com/mcp): Model Context Protocol server with tools for check_flight, predict_flight_starlink, plan_starlink_itinerary, predict_route_starlink, get_fleet_stats, list_starlink_aircraft, search_starlink_flights. Transport: streamable HTTP (stateless).
+- [MCP Docs & Setup](https://unitedstarlinktracker.com/mcp): Setup instructions for Claude Desktop, Cursor, and other MCP clients
+- [MCP Endpoint](https://unitedstarlinktracker.com/mcp): Model Context Protocol server (POST with application/json). Tools: check_flight, predict_flight_starlink, plan_starlink_itinerary, predict_route_starlink, get_fleet_stats, list_starlink_aircraft, search_starlink_flights. Transport: streamable HTTP (stateless).
 
 ## Chrome Extension
 
@@ -707,6 +734,12 @@ routes["/sitemap.xml"] = tracedRoute("/sitemap.xml", (req) => {
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>${baseUrl}/mcp</loc>
+    <lastmod>${new Date().toISOString()}</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>`;
 
   return new Response(sitemap, {
@@ -716,6 +749,64 @@ routes["/sitemap.xml"] = tracedRoute("/sitemap.xml", (req) => {
     },
   });
 });
+
+interface PageMeta {
+  siteTitle: string;
+  siteDescription: string;
+  keywords: string;
+  ogTitle: string;
+  ogDescription: string;
+}
+
+/**
+ * Render a sub-page (check-flight, route-planner, mcp) with shared boilerplate:
+ * fleet stats, template loading, canonical/og:url overrides.
+ */
+async function renderSubPage(
+  component: React.ComponentType,
+  canonicalPath: string,
+  meta: PageMeta,
+  host: string
+): Promise<Response> {
+  const reactHtml = ReactDOMServer.renderToString(React.createElement(component));
+
+  const fleetStats = getFleetStats(db);
+  const totalCount = getTotalCount(db);
+  const starlinkPlanes = getStarlinkPlanes(db);
+  const starlinkCount = starlinkPlanes.length;
+  const percentage = totalCount > 0 ? ((starlinkCount / totalCount) * 100).toFixed(2) : "0.00";
+
+  const htmlVariables: Record<string, string> = {
+    ...meta,
+    analyticsUrl: isUnitedDomain(host) ? "unitedstarlinktracker.com" : "airlinestarlinktracker.com",
+    html: reactHtml,
+    host,
+    totalCount: starlinkCount.toString(),
+    totalAircraftCount: totalCount.toString(),
+    lastUpdated: getLastUpdated(db),
+    isUnited: "true",
+    currentDate: new Date().toLocaleDateString(),
+    isoDate: new Date().toISOString(),
+    mainlineCount: (fleetStats?.mainline.starlink || 0).toString(),
+    expressCount: (fleetStats?.express.starlink || 0).toString(),
+    percentage: percentage,
+    mainlinePercentage: (fleetStats?.mainline.percentage || 0).toFixed(2),
+    expressPercentage: (fleetStats?.express.percentage || 0).toFixed(2),
+  };
+
+  let template = await getHtmlTemplate();
+  template = template
+    .replace(
+      `<link rel="canonical" href="https://{{host}}/" />`,
+      `<link rel="canonical" href="https://{{host}}${canonicalPath}" />`
+    )
+    .replace(
+      `<meta property="og:url" content="https://{{host}}/" />`,
+      `<meta property="og:url" content="https://{{host}}${canonicalPath}" />`
+    );
+  const html = renderHtml(template, htmlVariables);
+  return new Response(html, { headers: SECURITY_HEADERS.html });
+}
 
 // Request handler for home page and static files
 async function handleRequest(req: Request): Promise<Response> {
@@ -730,55 +821,21 @@ async function handleRequest(req: Request): Promise<Response> {
         headers: { "Content-Type": "text/plain" },
       });
     }
-
-    const reactHtml = ReactDOMServer.renderToString(React.createElement(CheckFlightPage));
-
-    const fleetStats = getFleetStats(db);
-    const totalCount = getTotalCount(db);
-    const starlinkPlanes = getStarlinkPlanes(db);
-    const starlinkCount = starlinkPlanes.length;
-    const percentage = totalCount > 0 ? ((starlinkCount / totalCount) * 100).toFixed(2) : "0.00";
-
-    const htmlVariables: Record<string, string> = {
-      siteTitle: "Check If Your United Flight Has Starlink WiFi | United Starlink Tracker",
-      siteDescription:
-        "Enter your United Airlines flight number and date to check if your aircraft has free Starlink WiFi. Instant results from our live database of Starlink-equipped planes.",
-      keywords:
-        "check united flight starlink, does my united flight have starlink, united starlink checker, united wifi check",
-      ogTitle: "Check If Your United Flight Has Starlink WiFi",
-      ogDescription:
-        "Enter your flight number and date to check if your United Airlines aircraft has free Starlink WiFi.",
-      analyticsUrl: isUnitedDomain(host)
-        ? "unitedstarlinktracker.com"
-        : "airlinestarlinktracker.com",
-      html: reactHtml,
-      host,
-      totalCount: starlinkCount.toString(),
-      totalAircraftCount: totalCount.toString(),
-      lastUpdated: getLastUpdated(db),
-      isUnited: "true",
-      currentDate: new Date().toLocaleDateString(),
-      isoDate: new Date().toISOString(),
-      mainlineCount: (fleetStats?.mainline.starlink || 0).toString(),
-      expressCount: (fleetStats?.express.starlink || 0).toString(),
-      percentage: percentage,
-      mainlinePercentage: (fleetStats?.mainline.percentage || 0).toFixed(2),
-      expressPercentage: (fleetStats?.express.percentage || 0).toFixed(2),
-    };
-
-    let template = await getHtmlTemplate();
-    // Override canonical and og:url for this page
-    template = template
-      .replace(
-        `<link rel="canonical" href="https://{{host}}/" />`,
-        `<link rel="canonical" href="https://{{host}}/check-flight" />`
-      )
-      .replace(
-        `<meta property="og:url" content="https://{{host}}/" />`,
-        `<meta property="og:url" content="https://{{host}}/check-flight" />`
-      );
-    const html = renderHtml(template, htmlVariables);
-    return new Response(html, { headers: SECURITY_HEADERS.html });
+    return renderSubPage(
+      CheckFlightPage,
+      "/check-flight",
+      {
+        siteTitle: "Check If Your United Flight Has Starlink WiFi | United Starlink Tracker",
+        siteDescription:
+          "Enter your United Airlines flight number and date to check if your aircraft has free Starlink WiFi. Instant results from our live database — or a probability estimate if your flight is more than 2 days out.",
+        keywords:
+          "check united flight starlink, does my united flight have starlink, united starlink checker, united wifi check, united starlink probability",
+        ogTitle: "Check If Your United Flight Has Starlink WiFi",
+        ogDescription:
+          "Enter your flight number and date to check if your United Airlines aircraft has free Starlink WiFi.",
+      },
+      host
+    );
   }
 
   // Route Planner page (also handles /route-planner/SFO/JAX for shared links)
@@ -789,54 +846,21 @@ async function handleRequest(req: Request): Promise<Response> {
         headers: { "Content-Type": "text/plain" },
       });
     }
-
-    const reactHtml = ReactDOMServer.renderToString(React.createElement(RoutePlannerPage));
-
-    const fleetStats = getFleetStats(db);
-    const totalCount = getTotalCount(db);
-    const starlinkPlanes = getStarlinkPlanes(db);
-    const starlinkCount = starlinkPlanes.length;
-    const percentage = totalCount > 0 ? ((starlinkCount / totalCount) * 100).toFixed(2) : "0.00";
-
-    const htmlVariables: Record<string, string> = {
-      siteTitle: "Starlink Route Planner — Find United Flights With Starlink WiFi",
-      siteDescription:
-        "Find the best way to fly United with Starlink WiFi. Compare direct flights and smart connections ranked by Starlink probability. Plan productive travel with full-coverage routings.",
-      keywords:
-        "united starlink route planner, best united route for starlink, plan united starlink trip, starlink flight connections, united wifi routing",
-      ogTitle: "Starlink Route Planner — United Airlines",
-      ogDescription:
-        "Find direct flights and smart connections with the highest Starlink probability. Sometimes DEN→ASE→ORD beats flying direct.",
-      analyticsUrl: isUnitedDomain(host)
-        ? "unitedstarlinktracker.com"
-        : "airlinestarlinktracker.com",
-      html: reactHtml,
-      host,
-      totalCount: starlinkCount.toString(),
-      totalAircraftCount: totalCount.toString(),
-      lastUpdated: getLastUpdated(db),
-      isUnited: "true",
-      currentDate: new Date().toLocaleDateString(),
-      isoDate: new Date().toISOString(),
-      mainlineCount: (fleetStats?.mainline.starlink || 0).toString(),
-      expressCount: (fleetStats?.express.starlink || 0).toString(),
-      percentage: percentage,
-      mainlinePercentage: (fleetStats?.mainline.percentage || 0).toFixed(2),
-      expressPercentage: (fleetStats?.express.percentage || 0).toFixed(2),
-    };
-
-    let template = await getHtmlTemplate();
-    template = template
-      .replace(
-        `<link rel="canonical" href="https://{{host}}/" />`,
-        `<link rel="canonical" href="https://{{host}}/route-planner" />`
-      )
-      .replace(
-        `<meta property="og:url" content="https://{{host}}/" />`,
-        `<meta property="og:url" content="https://{{host}}/route-planner" />`
-      );
-    const html = renderHtml(template, htmlVariables);
-    return new Response(html, { headers: SECURITY_HEADERS.html });
+    return renderSubPage(
+      RoutePlannerPage,
+      "/route-planner",
+      {
+        siteTitle: "Starlink Route Planner — Find United Flights With Starlink WiFi",
+        siteDescription:
+          "Find the best way to fly United with Starlink WiFi. Compare direct flights and smart connections ranked by Starlink probability. Plan productive travel with full-coverage routings.",
+        keywords:
+          "united starlink route planner, best united route for starlink, plan united starlink trip, starlink flight connections, united wifi routing",
+        ogTitle: "Starlink Route Planner — United Airlines",
+        ogDescription:
+          "Find direct flights and smart connections with the highest Starlink probability. Sometimes DEN→ASE→ORD beats flying direct.",
+      },
+      host
+    );
   }
 
   // Home page

--- a/src/components/mcp-page.tsx
+++ b/src/components/mcp-page.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+
+const MCP_ENDPOINT = "https://unitedstarlinktracker.com/mcp";
+
+const CLAUDE_DESKTOP_CONFIG = `{
+  "mcpServers": {
+    "ua-starlink": {
+      "url": "${MCP_ENDPOINT}",
+      "transport": "http"
+    }
+  }
+}`;
+
+const TOOLS = [
+  {
+    name: "check_flight",
+    desc: "Firm answer: is this flight scheduled on a Starlink plane? (~2-day window)",
+    example: "Does UA4680 tomorrow have Starlink?",
+  },
+  {
+    name: "predict_flight_starlink",
+    desc: "Probability estimate for flights beyond our firm schedule window, based on 12k+ historical observations",
+    example: "What's the Starlink probability for UA3561 next month?",
+  },
+  {
+    name: "plan_starlink_itinerary",
+    desc: "Find direct flights + 1-stop connections ranked by Starlink probability — full and partial coverage options",
+    example: "Best way to fly SFO to JAX with Starlink?",
+  },
+  {
+    name: "predict_route_starlink",
+    desc: "List flight numbers on a route ranked by Starlink probability",
+    example: "Which flights to Denver usually get Starlink planes?",
+  },
+  {
+    name: "search_starlink_flights",
+    desc: "Confirmed Starlink flights in the next ~2 days from/to an airport",
+    example: "What Starlink flights leave ORD today?",
+  },
+  {
+    name: "get_fleet_stats",
+    desc: "Installation progress: how many aircraft have Starlink by fleet",
+    example: "What percentage of United's fleet has Starlink?",
+  },
+  {
+    name: "list_starlink_aircraft",
+    desc: "Enumerate all equipped aircraft with tail numbers and types",
+    example: "List all Starlink-equipped 737s",
+  },
+];
+
+export default function McpPage() {
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 md:px-8 bg-base min-h-screen flex flex-col relative">
+      <div className="absolute inset-0 grid-pattern opacity-50 pointer-events-none" />
+
+      <header className="relative py-5 sm:py-6 text-center mb-6">
+        <a href="/" className="block">
+          <h1 className="font-display text-3xl sm:text-4xl font-bold text-primary mb-2 tracking-tight hover:text-accent transition-colors">
+            MCP Server for AI Assistants
+          </h1>
+        </a>
+        <p className="text-base text-secondary font-display max-w-2xl mx-auto">
+          Connect Claude, Cursor, or any MCP-compatible client to live United Starlink tracker data
+        </p>
+      </header>
+
+      {/* Quick connect */}
+      <div className="relative max-w-2xl mx-auto w-full mb-8">
+        <div className="bg-surface rounded-lg border border-subtle p-6 glow-accent">
+          <div className="text-xs font-mono text-muted uppercase tracking-wider mb-2">Endpoint</div>
+          <div className="font-mono text-sm text-accent break-all mb-4">{MCP_ENDPOINT}</div>
+          <div className="text-xs font-mono text-muted uppercase tracking-wider mb-2">
+            Transport
+          </div>
+          <div className="font-mono text-sm text-secondary">
+            Streamable HTTP · Stateless · No auth required
+          </div>
+        </div>
+      </div>
+
+      {/* Setup instructions */}
+      <div className="relative max-w-2xl mx-auto w-full mb-8">
+        <div className="bg-surface rounded-lg border border-subtle p-6">
+          <h2 className="font-display text-lg font-semibold text-primary mb-4">Setup</h2>
+
+          <div className="mb-6">
+            <h3 className="font-display text-sm font-medium text-secondary mb-2">Claude Desktop</h3>
+            <p className="text-xs text-muted mb-2">
+              Add to{" "}
+              <span className="font-mono text-secondary">
+                ~/Library/Application Support/Claude/claude_desktop_config.json
+              </span>{" "}
+              (macOS) or{" "}
+              <span className="font-mono text-secondary">
+                %APPDATA%\Claude\claude_desktop_config.json
+              </span>{" "}
+              (Windows):
+            </p>
+            <pre className="bg-base border border-subtle rounded p-3 text-xs font-mono text-secondary overflow-x-auto">
+              {CLAUDE_DESKTOP_CONFIG}
+            </pre>
+            <p className="text-xs text-muted mt-2">
+              Restart Claude Desktop. You'll see the tracker tools available in conversations.
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <h3 className="font-display text-sm font-medium text-secondary mb-2">
+              Cursor, Continue, Cline & other MCP clients
+            </h3>
+            <p className="text-xs text-muted">
+              Add the endpoint URL with <span className="font-mono text-secondary">http</span>{" "}
+              transport to your client's MCP settings. See your client's docs for the exact config
+              format.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="font-display text-sm font-medium text-secondary mb-2">
+              Programmatic access
+            </h3>
+            <p className="text-xs text-muted">
+              The server is a standard JSON-RPC 2.0 endpoint. POST a{" "}
+              <span className="font-mono text-secondary">tools/call</span> request with{" "}
+              <span className="font-mono text-secondary">Content-Type: application/json</span>. No
+              SDK required.{" "}
+              <a
+                href="https://modelcontextprotocol.io/specification/2025-06-18/basic/transports"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent hover:underline"
+              >
+                MCP spec →
+              </a>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Tools */}
+      <div className="relative max-w-2xl mx-auto w-full mb-8">
+        <div className="bg-surface rounded-lg border border-subtle p-6">
+          <h2 className="font-display text-lg font-semibold text-primary mb-4">Available tools</h2>
+          <div className="space-y-4">
+            {TOOLS.map((tool) => (
+              <div key={tool.name} className="border-l-2 border-accent/30 pl-3">
+                <div className="font-mono text-sm text-accent">{tool.name}</div>
+                <div className="text-xs text-muted leading-relaxed">{tool.desc}</div>
+                <div className="text-xs text-secondary italic mt-0.5">"{tool.example}"</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Example prompts */}
+      <div className="relative max-w-2xl mx-auto w-full mb-8">
+        <div className="bg-surface rounded-lg border border-subtle p-6">
+          <h2 className="font-display text-lg font-semibold text-primary mb-3">
+            Things to ask your AI
+          </h2>
+          <ul className="space-y-2 text-sm text-muted">
+            <li className="pl-4 -indent-4">
+              "I'm flying SFO to JAX on April 10 — what's my best shot at Starlink?"
+            </li>
+            <li className="pl-4 -indent-4">
+              "Compare UA4680 vs UA5259 — which is more likely to have Starlink?"
+            </li>
+            <li className="pl-4 -indent-4">
+              "I'd rather fly 7 hours with internet than 5 hours without — find me a routing DEN to
+              ORD"
+            </li>
+            <li className="pl-4 -indent-4">
+              "What percentage of United's express fleet has Starlink now?"
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="relative text-center mb-6">
+        <a href="/" className="text-sm text-accent hover:underline font-display">
+          ← Back to United Starlink Tracker
+        </a>
+      </div>
+
+      <footer className="relative py-6 text-center border-t border-subtle text-muted text-sm">
+        <a
+          href="https://x.com/martinamps"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center text-secondary hover:text-primary transition-colors"
+        >
+          Built with
+          <svg
+            className="w-4 h-4 mx-1 text-red-400"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-label="Heart"
+            role="img"
+          >
+            <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+          </svg>
+          by @martinamps
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -408,18 +408,38 @@ export default function Page({
         </div>
       </header>
 
-      {/* Intro paragraph for SEO */}
+      {/* Intro paragraph + nav links */}
       {isUnited && (
-        <p className="relative text-sm text-secondary text-center max-w-2xl mx-auto mb-6 leading-relaxed">
-          United Airlines is rolling out free Starlink WiFi across its fleet — the fastest internet
-          ever available on a commercial airline. Use this tracker to check if your United flight
-          has Starlink, browse all equipped aircraft, or search by flight number and route. You can
-          also{" "}
-          <a href="/check-flight" className="text-accent hover:underline">
-            check a specific flight number and date
-          </a>
-          .
-        </p>
+        <div className="relative text-center max-w-2xl mx-auto mb-6">
+          <p className="text-sm text-secondary leading-relaxed mb-3">
+            United Airlines is rolling out free Starlink WiFi across its fleet — the fastest
+            internet ever available on a commercial airline. Use this tracker to browse all equipped
+            aircraft, check your flight, or plan a Starlink-maximizing itinerary.
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-2 text-sm font-display">
+            <a
+              href="/check-flight"
+              className="px-3 py-1.5 bg-surface border border-subtle rounded text-secondary hover:text-accent hover:border-accent transition-colors"
+            >
+              Check a Flight
+            </a>
+            <a
+              href="/route-planner"
+              className="px-3 py-1.5 bg-surface border border-subtle rounded text-secondary hover:text-accent hover:border-accent transition-colors inline-flex items-center gap-1.5"
+            >
+              Route Planner
+              <span className="text-[10px] font-mono px-1.5 py-0.5 bg-accent/20 text-accent rounded">
+                NEW
+              </span>
+            </a>
+            <a
+              href="#integrations"
+              className="px-3 py-1.5 bg-surface border border-subtle rounded text-secondary hover:text-accent hover:border-accent transition-colors"
+            >
+              Tools & MCP
+            </a>
+          </div>
+        </div>
       )}
 
       {/* Fleet Stats - Instrument Panel Style */}
@@ -826,80 +846,133 @@ export default function Page({
         </div>
       </div>
 
-      {/* Chrome Extension CTA */}
-      <div className="relative my-8 max-w-xl mx-auto bg-surface rounded-lg border border-subtle p-5">
-        <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-          <div className="text-center sm:text-left">
-            <div className="font-mono text-sm text-primary mb-0.5">
-              Annotate Google Flights automatically
-            </div>
-            <div className="text-xs text-muted">Adds a Starlink badge on equipped flights</div>
-          </div>
-          <a
-            href="https://chromewebstore.google.com/detail/google-flights-starlink-i/jjfljoifenkfdbldliakmmjhdkbhehoi"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-4 py-2 bg-surface-elevated text-xs sm:text-sm text-secondary font-mono rounded border border-subtle hover:border-accent hover:text-accent transition-colors whitespace-nowrap"
+      {/* Tools & Integrations */}
+      <div id="integrations" className="relative my-8 max-w-3xl mx-auto scroll-mt-4">
+        <h2 className="font-display text-lg font-semibold text-primary mb-3 text-center">
+          Tools & Integrations
+        </h2>
+        <div className="grid sm:grid-cols-2 gap-3">
+          {/* Chrome Extension */}
+          <div
+            id="chrome-extension"
+            className="bg-surface rounded-lg border border-subtle p-5 flex flex-col scroll-mt-4"
           >
-            <svg
-              className="w-8 h-8"
-              viewBox="0 0 48 48"
-              xmlns="http://www.w3.org/2000/svg"
-              role="img"
-              aria-label="Chrome"
+            <div className="flex items-start gap-3 mb-3">
+              <svg
+                className="w-8 h-8 flex-shrink-0"
+                viewBox="0 0 48 48"
+                xmlns="http://www.w3.org/2000/svg"
+                role="img"
+                aria-label="Chrome"
+              >
+                <defs>
+                  <linearGradient
+                    id="chrome-a"
+                    x1="3.2173"
+                    y1="15"
+                    x2="44.7812"
+                    y2="15"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0" stopColor="#d93025" />
+                    <stop offset="1" stopColor="#ea4335" />
+                  </linearGradient>
+                  <linearGradient
+                    id="chrome-b"
+                    x1="20.7219"
+                    y1="47.6791"
+                    x2="41.5039"
+                    y2="11.6837"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0" stopColor="#fcc934" />
+                    <stop offset="1" stopColor="#fbbc04" />
+                  </linearGradient>
+                  <linearGradient
+                    id="chrome-c"
+                    x1="26.5981"
+                    y1="46.5015"
+                    x2="5.8161"
+                    y2="10.506"
+                    gradientUnits="userSpaceOnUse"
+                  >
+                    <stop offset="0" stopColor="#1e8e3e" />
+                    <stop offset="1" stopColor="#34a853" />
+                  </linearGradient>
+                </defs>
+                <circle cx="24" cy="23.9947" r="12" fill="#fff" />
+                <path
+                  d="M24,12H44.7812a23.9939,23.9939,0,0,0-41.5639.0029L13.6079,30l.0093-.0024A11.9852,11.9852,0,0,1,24,12Z"
+                  fill="url(#chrome-a)"
+                />
+                <circle cx="24" cy="24" r="9.5" fill="#1a73e8" />
+                <path
+                  d="M34.3913,30.0029,24.0007,48A23.994,23.994,0,0,0,44.78,12.0031H23.9989l-.0025.0093A11.985,11.985,0,0,1,34.3913,30.0029Z"
+                  fill="url(#chrome-b)"
+                />
+                <path
+                  d="M13.6086,30.0031,3.218,12.006A23.994,23.994,0,0,0,24.0025,48L34.3931,30.0029l-.0067-.0068a11.9852,11.9852,0,0,1-20.7778.007Z"
+                  fill="url(#chrome-c)"
+                />
+              </svg>
+              <div>
+                <div className="font-display font-semibold text-primary text-sm">
+                  Chrome Extension
+                </div>
+                <div className="text-xs text-muted">For Google Flights</div>
+              </div>
+            </div>
+            <p className="text-xs text-muted leading-relaxed mb-4 flex-1">
+              See Starlink badges directly on Google Flights search results — no extra steps while
+              you shop for flights.
+            </p>
+            <a
+              href="https://chromewebstore.google.com/detail/google-flights-starlink-i/jjfljoifenkfdbldliakmmjhdkbhehoi"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-accent hover:underline font-mono"
             >
-              <defs>
-                <linearGradient
-                  id="chrome-a"
-                  x1="3.2173"
-                  y1="15"
-                  x2="44.7812"
-                  y2="15"
-                  gradientUnits="userSpaceOnUse"
+              Add to Chrome →
+            </a>
+          </div>
+
+          {/* MCP Server */}
+          <div
+            id="mcp"
+            className="bg-surface rounded-lg border border-subtle p-5 flex flex-col scroll-mt-4"
+          >
+            <div className="flex items-start gap-3 mb-3">
+              <div className="w-8 h-8 flex-shrink-0 rounded bg-accent/20 border border-accent/40 flex items-center justify-center">
+                <svg
+                  className="w-5 h-5 text-accent"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  role="img"
+                  aria-label="AI"
                 >
-                  <stop offset="0" stopColor="#d93025" />
-                  <stop offset="1" stopColor="#ea4335" />
-                </linearGradient>
-                <linearGradient
-                  id="chrome-b"
-                  x1="20.7219"
-                  y1="47.6791"
-                  x2="41.5039"
-                  y2="11.6837"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0" stopColor="#fcc934" />
-                  <stop offset="1" stopColor="#fbbc04" />
-                </linearGradient>
-                <linearGradient
-                  id="chrome-c"
-                  x1="26.5981"
-                  y1="46.5015"
-                  x2="5.8161"
-                  y2="10.506"
-                  gradientUnits="userSpaceOnUse"
-                >
-                  <stop offset="0" stopColor="#1e8e3e" />
-                  <stop offset="1" stopColor="#34a853" />
-                </linearGradient>
-              </defs>
-              <circle cx="24" cy="23.9947" r="12" fill="#fff" />
-              <path
-                d="M24,12H44.7812a23.9939,23.9939,0,0,0-41.5639.0029L13.6079,30l.0093-.0024A11.9852,11.9852,0,0,1,24,12Z"
-                fill="url(#chrome-a)"
-              />
-              <circle cx="24" cy="24" r="9.5" fill="#1a73e8" />
-              <path
-                d="M34.3913,30.0029,24.0007,48A23.994,23.994,0,0,0,44.78,12.0031H23.9989l-.0025.0093A11.985,11.985,0,0,1,34.3913,30.0029Z"
-                fill="url(#chrome-b)"
-              />
-              <path
-                d="M13.6086,30.0031,3.218,12.006A23.994,23.994,0,0,0,24.0025,48L34.3931,30.0029l-.0067-.0068a11.9852,11.9852,0,0,1-20.7778.007Z"
-                fill="url(#chrome-c)"
-              />
-            </svg>
-            Add to Chrome
-          </a>
+                  <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
+                </svg>
+              </div>
+              <div>
+                <div className="font-display font-semibold text-primary text-sm inline-flex items-center gap-1.5">
+                  MCP Server
+                  <span className="text-[10px] font-mono px-1.5 py-0.5 bg-accent/20 text-accent rounded">
+                    NEW
+                  </span>
+                </div>
+                <div className="text-xs text-muted">For Claude, Cursor & AI assistants</div>
+              </div>
+            </div>
+            <p className="text-xs text-muted leading-relaxed mb-4 flex-1">
+              Ask your AI assistant to check flights, predict Starlink probability, or plan routes —
+              live tracker data via the Model Context Protocol.
+            </p>
+            <a href="/mcp" className="text-xs text-accent hover:underline font-mono">
+              Setup instructions →
+            </a>
+          </div>
         </div>
       </div>
 
@@ -1190,8 +1263,13 @@ export default function Page({
               </summary>
               <div className="mt-3 text-sm text-muted leading-relaxed">
                 <p>
-                  Search above by flight number, tail number, or airport code. You can also install
-                  our{" "}
+                  Search above by flight number, tail number, or airport code. For a specific
+                  flight,{" "}
+                  <a href="/check-flight" className="text-accent hover:underline">
+                    check a flight by number and date
+                  </a>{" "}
+                  — if the flight is more than ~2 days out, you'll get a probability estimate based
+                  on 12,000+ historical aircraft assignments. You can also install our{" "}
                   <a
                     href="https://chromewebstore.google.com/detail/google-flights-starlink-i/jjfljoifenkfdbldliakmmjhdkbhehoi"
                     target="_blank"
@@ -1200,11 +1278,90 @@ export default function Page({
                   >
                     Chrome extension
                   </a>{" "}
-                  to see Starlink badges directly on Google Flights, or visit our{" "}
-                  <a href="/check-flight" className="text-accent hover:underline">
-                    check a flight
+                  to see Starlink badges on Google Flights.
+                </p>
+              </div>
+            </details>
+
+            <details className="group py-4">
+              <summary className="cursor-pointer list-none flex items-start justify-between">
+                <div>
+                  <h3 className="font-display text-base font-medium text-secondary group-hover:text-accent transition-colors">
+                    How do I maximize my chances of getting Starlink?
+                  </h3>
+                </div>
+                <div className="ml-4 flex-shrink-0">
+                  <svg
+                    className="w-4 h-4 text-muted group-open:rotate-45 transition-transform"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    role="img"
+                    aria-label="Expand"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                    />
+                  </svg>
+                </div>
+              </summary>
+              <div className="mt-3 text-sm text-muted leading-relaxed">
+                <p className="mb-2">
+                  Use the{" "}
+                  <a href="/route-planner" className="text-accent hover:underline">
+                    Route Planner
                   </a>{" "}
-                  page.
+                  — it finds direct flights and 1-stop connections ranked by Starlink probability.
+                  Express flights (UA3000-6999, regional jets) have ~
+                  {fleetStats?.express.percentage.toFixed(0)}% Starlink coverage vs ~
+                  {fleetStats?.mainline.percentage.toFixed(0)}% for mainline, so a connection
+                  through a hub can beat a direct mainline flight.
+                </p>
+                <p>
+                  For example: DEN→ORD direct is mainline (~2%), but DEN→ASE→ORD is ~90% Starlink on
+                  both legs.
+                </p>
+              </div>
+            </details>
+
+            <details className="group py-4">
+              <summary className="cursor-pointer list-none flex items-start justify-between">
+                <div>
+                  <h3 className="font-display text-base font-medium text-secondary group-hover:text-accent transition-colors">
+                    Can I use this with Claude, ChatGPT, or other AI assistants?
+                  </h3>
+                </div>
+                <div className="ml-4 flex-shrink-0">
+                  <svg
+                    className="w-4 h-4 text-muted group-open:rotate-45 transition-transform"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    role="img"
+                    aria-label="Expand"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                    />
+                  </svg>
+                </div>
+              </summary>
+              <div className="mt-3 text-sm text-muted leading-relaxed">
+                <p>
+                  Yes — there's a free{" "}
+                  <a href="/mcp" className="text-accent hover:underline">
+                    MCP server
+                  </a>{" "}
+                  that works with Claude Desktop, Cursor, and any MCP-compatible client. Once
+                  connected, you can ask your AI assistant things like "does UA4680 next week have
+                  Starlink?" or "find me the best way to fly SFO to JAX with Starlink" and get live
+                  tracker data.
                 </p>
               </div>
             </details>


### PR DESCRIPTION
## Why both a page AND a section

**Dedicated `/mcp` page** for SEO + usability:
- "united starlink mcp server" is a searchable query — a dedicated page with its own title/meta can rank. Anchor links don't get their own search results.
- Setup instructions need room: copy-paste JSON configs, tool descriptions, example prompts. Cramming into a homepage section makes it unusable.
- Linkable: drop `/mcp` in a tweet or GitHub README.

**Homepage section** for discovery:
- Most visitors don't know MCP exists. A card next to Chrome extension surfaces it.

## What changed

### Homepage nav (intro paragraph replaced)
```
[Check a Flight] [Route Planner · NEW] [Tools & MCP]
```
Three nav chips. "Tools & MCP" scrolls to `#integrations`.

### Tools & Integrations (replaces Chrome-only CTA)
Two cards side-by-side:
- **Chrome Extension** (`#chrome-extension`) — same content, now in a card
- **MCP Server** (`#mcp`) — NEW badge, 2-sentence pitch, "Setup instructions →" linking to `/mcp`

### `/mcp` docs page (new)
**Content-negotiated on the SAME endpoint** — no new route:
- `GET` with `Accept: text/html` → docs page (browsers)
- `POST` with `application/json` → JSON-RPC (MCP clients, unchanged)
- `GET` with `Accept: application/json, text/event-stream` → 405 (stateless, unchanged)

Page has: endpoint URL, Claude Desktop JSON config (copy-paste), setup notes for Cursor/Continue/Cline, full tool list with example prompts.

### FAQ updates
| Question | What |
|----------|------|
| How do I maximize my chances of getting Starlink? | **New** — points to Route Planner with DEN→ASE→ORD example |
| Can I use this with Claude, ChatGPT, or other AI assistants? | **New** — points to `/mcp` |
| Does my United flight have Starlink? | Updated to mention probability estimates for flights >2 days out |

All new FAQs also added to FAQPage JSON-LD schema for rich results.

### Refactoring
Extracted `renderSubPage()` — page boilerplate was copy-pasted 3× (~60 LOC each). Now each sub-page is ~15 LOC of metadata.

### Also
- `/mcp` in sitemap (priority 0.6, monthly changefreq)
- llms.txt updated with docs link
- `/check-flight` meta description updated to mention probability estimates

## Testing
```
✓ Homepage renders nav chips + integrations section + new FAQ entries (with united host)
✓ /mcp browser GET → HTML docs page (title, tools, config)
✓ /mcp POST → JSON-RPC still works (ping → {})
✓ /mcp MCP-client GET (Accept: application/json, text/event-stream) → 405
✓ /check-flight, /route-planner still work (use renderSubPage helper)
✓ sitemap includes /mcp
✓ llms.txt updated
✓ TypeScript clean, lint clean (5 pre-existing warnings)
```