### PR TITLE
feat: add expected Starlink hours to itinerary output

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -463,30 +463,50 @@ function toolPlanStarlinkItinerary(
   const fullItins = itineraries.filter((it) => it.coverage === "full");
   const partialItins = itineraries.filter((it) => it.coverage === "partial");
 
+  const fmtHours = (h: number): string => {
+    if (h >= 1) return `${h.toFixed(1)}h`;
+    return `${Math.round(h * 60)}m`;
+  };
+
   const renderLeg = (leg: (typeof itineraries)[number]["legs"][number]): string => {
     if (leg.flight_number === "(any)") {
-      return `position to ${leg.route.split("-")[1]} (mainline, ~2% Starlink)`;
+      return `position to ${leg.route.split("-")[1]} (mainline, ~2% Starlink, duration unknown — likely 3-6h)`;
     }
     const pct = (leg.probability * 100).toFixed(0);
     const fleetTag = inferFleet(leg.flight_number) === "mainline" ? " [Mainline]" : "";
-    return `${leg.flight_number}${fleetTag} (${leg.route}) — ${pct}% ${confidenceTag(leg.n_observations, leg.confidence)}`;
+    const dur = leg.duration_hours !== null ? ` ~${fmtHours(leg.duration_hours)}` : "";
+    return `${leg.flight_number}${fleetTag} (${leg.route}${dur}) — ${pct}% ${confidenceTag(leg.n_observations, leg.confidence)}`;
   };
 
   const renderItin = (it: (typeof itineraries)[number], i: number): string => {
-    // One decimal so displayed ranking matches sort order (avoids "72% below 71%" confusion)
+    // One decimal so displayed ranking matches sort order
     const jointPct = (it.joint_probability * 100).toFixed(1);
-    const atLeastPct = (it.at_least_one_probability * 100).toFixed(0);
     const stops = it.via.length;
     const viaLabel =
       stops === 0 ? "DIRECT" : `via ${it.via.join("→")} (${stops} stop${stops > 1 ? "s" : ""})`;
 
+    // Time-aware summary — this is what users actually care about for tradeoffs
+    let timeSummary: string;
+    if (it.total_flight_hours !== null && it.expected_starlink_hours !== null) {
+      timeSummary = ` · **~${fmtHours(it.expected_starlink_hours)} Starlink** / ~${fmtHours(it.total_flight_hours)} flying`;
+    } else if (it.coverage === "partial") {
+      // Positioning leg has unknown duration — show only the known Starlink leg time
+      const knownStarlink = it.legs.reduce(
+        (s, l) => (l.duration_hours !== null ? s + l.probability * l.duration_hours : s),
+        0
+      );
+      timeSummary = ` · ~${fmtHours(knownStarlink)} Starlink (on final leg only; positioning leg duration unknown)`;
+    } else {
+      timeSummary = "";
+    }
+
     let header: string;
     if (it.coverage === "partial") {
-      header = `${i + 1}. **${viaLabel}** — Starlink on final leg only (~${(it.legs[it.legs.length - 1].probability * 100).toFixed(0)}%)`;
+      header = `${i + 1}. **${viaLabel}**${timeSummary}`;
     } else if (stops === 0) {
-      header = `${i + 1}. **${viaLabel}** — **${jointPct}%** Starlink`;
+      header = `${i + 1}. **${viaLabel}** — ${jointPct}% Starlink${timeSummary}`;
     } else {
-      header = `${i + 1}. **${viaLabel}** — **${jointPct}%** all legs (${atLeastPct}% at least one)`;
+      header = `${i + 1}. **${viaLabel}** — ${jointPct}% joint${timeSummary}`;
     }
 
     const legLines = it.legs.map((l, idx) => `   · Leg ${idx + 1}: ${renderLeg(l)}`).join("\n");
@@ -495,14 +515,14 @@ function toolPlanStarlinkItinerary(
 
   const sections: string[] = [];
   if (fullItins.length > 0) {
-    sections.push(`**Full Starlink coverage** (ranked by joint probability; within 1pp, fewer stops wins):
+    sections.push(`**Full Starlink coverage**:
 
 ${fullItins.map(renderItin).join("\n\n")}`);
   }
   if (partialItins.length > 0) {
     const header =
       fullItins.length === 0
-        ? `**No all-Starlink path found within ${maxStops} stops** — all routes out of ${origin.toUpperCase()} in our Starlink data don't connect to ${destination.toUpperCase()}. Best partial options (position on non-Starlink leg, Starlink on connection):\n`
+        ? `**No all-Starlink path found within ${maxStops} stops.** Partial coverage options (positioning leg likely no Starlink, then Starlink on the connection):\n`
         : "**Partial coverage** (positioning leg needed):\n";
     sections.push(`${header}
 ${partialItins.map((it, i) => renderItin(it, fullItins.length + i)).join("\n\n")}`);
@@ -510,14 +530,14 @@ ${partialItins.map((it, i) => renderItin(it, fullItins.length + i)).join("\n\n")
 
   const hasMultiLeg = itineraries.some((it) => it.legs.length > 1);
   const timingNote = hasMultiLeg
-    ? "\n\n⚠️ Connection timing NOT validated — verify on united.com that the legs connect same-day before booking."
+    ? "\n\n⚠️ Connection timing NOT validated — verify legs actually connect same-day on united.com."
     : "";
 
   const text = `**Starlink routings: ${origin.toUpperCase()} → ${destination.toUpperCase()}**
 
 ${sections.join("\n\n---\n\n")}${timingNote}
 
-_Probabilities from historical aircraft assignments. Not guaranteed — use check_flight 1-2 days before departure for firm answers._`;
+**Key for trade-offs**: "~1.8h Starlink / ~7h flying" = expected Starlink time (Σ leg_prob × leg_duration) over total air time. A "92% leg" means little if that leg is 2h out of a 7h trip — compare expected Starlink hours, not leg percentages.`;
 
   return { content: [{ type: "text", text }] };
 }
@@ -750,13 +770,13 @@ function handleInitialize(
     instructions: `United Starlink tracker. Key facts:
 • Express/regional (UA3000-6999): ~${expressPct}% have Starlink
 • Mainline (UA1-2999, 737/787/etc): only ~${mainlinePct}% — assume NO Starlink on long-haul
-• Probability and confidence are INDEPENDENT: "92% (4 obs · medium)" is less certain than "79% (10 obs · high)", but still higher probability
+• Users want to MAXIMIZE STARLINK HOURS, not leg-level percentages. A "92% Starlink" 2h leg after a 5h no-Starlink leg ≈ 1.8h Starlink out of 7h. Compare expected Starlink hours (plan_starlink_itinerary computes this).
 
 Tool selection:
-• Routing questions ("best way to JAX with Starlink") → plan_starlink_itinerary first. Does multi-stop search (up to 3 stops) automatically.
+• Routing/tradeoff questions → plan_starlink_itinerary (multi-stop search, shows expected Starlink hours)
 • Future flight probability → predict_flight_starlink / predict_route_starlink
 • Firm confirmation (≤2 days out) → check_flight
-• search_starlink_flights = next ~2 days ONLY. Don't use for future dates.`,
+• search_starlink_flights = next ~2 days ONLY`,
   });
 }
 

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -532,7 +532,10 @@ const MIN_LEG_PROBABILITY = 0.3;
 // Minimum probability for the Starlink leg in partial-coverage fallback
 const PARTIAL_FALLBACK_MIN_PROB = 0.5;
 
-export type ItineraryLeg = BasePrediction & { route: string };
+export type ItineraryLeg = BasePrediction & {
+  route: string;
+  duration_hours: number | null; // null when we don't know (positioning legs on routes outside our data)
+};
 
 export interface Itinerary {
   via: string[]; // connection hub(s) in order, empty for direct
@@ -540,17 +543,23 @@ export interface Itinerary {
   joint_probability: number; // P(all legs have Starlink) = product of leg probs
   at_least_one_probability: number; // P(at least one leg has Starlink)
   coverage: "full" | "partial"; // "full"=all legs in Starlink graph, "partial"=positioning leg needed
+  // Time-aware metrics — these are what users actually care about for trade-off decisions.
+  // A "92% Starlink" 2-hour leg after a 5-hour no-Starlink leg is ~1.8h of Starlink out of 7h flying.
+  total_flight_hours: number | null; // null if any leg duration unknown
+  expected_starlink_hours: number | null; // Σ(leg_probability × leg_duration), null if any duration unknown
 }
 
 /**
  * Build the Starlink route adjacency graph: for each airport, the best
  * (highest-probability) flight number to each reachable destination.
- * One SQL query + one prediction per distinct route.
+ * One SQL query + one prediction per distinct route. Includes avg leg duration.
  */
 function buildRouteGraph(db: Database, minLegProb: number): Map<string, Map<string, ItineraryLeg>> {
   const rows = db
     .query(
-      `SELECT flight_number, departure_airport, arrival_airport, COUNT(*) as obs
+      `SELECT flight_number, departure_airport, arrival_airport,
+              COUNT(*) as obs,
+              AVG(arrival_time - departure_time) as avg_duration_sec
        FROM upcoming_flights
        GROUP BY flight_number, departure_airport, arrival_airport`
     )
@@ -559,6 +568,7 @@ function buildRouteGraph(db: Database, minLegProb: number): Map<string, Map<stri
     departure_airport: string;
     arrival_airport: string;
     obs: number;
+    avg_duration_sec: number;
   }>;
 
   // For each directed edge (dep → arr), keep the highest-probability flight
@@ -573,7 +583,11 @@ function buildRouteGraph(db: Database, minLegProb: number): Map<string, Map<stri
     const edges = graph.get(dep)!;
     const existing = edges.get(arr);
     if (!existing || pred.probability > existing.probability) {
-      edges.set(arr, { ...pred, route: `${dep}-${arr}` });
+      edges.set(arr, {
+        ...pred,
+        route: `${dep}-${arr}`,
+        duration_hours: r.avg_duration_sec / 3600,
+      });
     }
   }
   return graph;
@@ -582,14 +596,25 @@ function buildRouteGraph(db: Database, minLegProb: number): Map<string, Map<stri
 function computeItinerary(legs: ItineraryLeg[], coverage: "full" | "partial"): Itinerary {
   const joint = legs.reduce((p, l) => p * l.probability, 1);
   const atLeastOne = 1 - legs.reduce((p, l) => p * (1 - l.probability), 1);
-  // via = all intermediate airports (exclude origin and final dest)
   const via = legs.slice(0, -1).map((l) => l.route.split("-")[1]);
+
+  // Time-aware metrics. Null if any leg has unknown duration (positioning legs).
+  const allDurationsKnown = legs.every((l) => l.duration_hours !== null);
+  const totalHours = allDurationsKnown
+    ? legs.reduce((s, l) => s + (l.duration_hours as number), 0)
+    : null;
+  const expectedStarlinkHours = allDurationsKnown
+    ? legs.reduce((s, l) => s + l.probability * (l.duration_hours as number), 0)
+    : null;
+
   return {
     via,
     legs,
     joint_probability: joint,
     at_least_one_probability: atLeastOne,
     coverage,
+    total_flight_hours: totalHours,
+    expected_starlink_hours: expectedStarlinkHours,
   };
 }
 
@@ -688,21 +713,33 @@ export function planItinerary(
         probability: DEFAULT_CONFIG.mainlineColdPrior,
         confidence: "low",
         n_observations: 0,
+        duration_hours: null, // unknown — mainline route outside our Starlink-tracked data
       };
       itineraries.push(computeItinerary([positioningLeg, finalLeg], "partial"));
     }
   }
 
-  // Rank: full coverage first (by joint prob), then partial (by at-least-one prob)
-  // Within same coverage, prefer fewer stops as tiebreaker
+  // Rank by EXPECTED STARLINK HOURS (what users actually want to maximize).
+  // Full-coverage paths sort above partial. Within coverage: expected Starlink
+  // hours (descending), then fewer legs as tiebreaker. Falls back to joint prob
+  // when duration unknown.
   itineraries.sort((a, b) => {
     if (a.coverage !== b.coverage) return a.coverage === "full" ? -1 : 1;
-    const probDiff =
-      a.coverage === "full"
-        ? b.joint_probability - a.joint_probability
-        : b.at_least_one_probability - a.at_least_one_probability;
+
+    // Primary: expected Starlink hours (higher is better). Unknown sorts last.
+    const aE = a.expected_starlink_hours;
+    const bE = b.expected_starlink_hours;
+    if (aE !== null && bE !== null) {
+      if (Math.abs(bE - aE) > 0.05) return bE - aE;
+    } else if (aE !== null) return -1;
+    else if (bE !== null) return 1;
+
+    // Secondary: joint probability (for when durations tie or are unknown)
+    const probDiff = b.joint_probability - a.joint_probability;
     if (Math.abs(probDiff) > 0.01) return probDiff;
-    return a.legs.length - b.legs.length; // fewer stops wins ties
+
+    // Tertiary: fewer legs (simpler routing)
+    return a.legs.length - b.legs.length;
   });
 
   return itineraries.slice(0, maxItineraries);


### PR DESCRIPTION
## The problem

Real agent test transcript:

> **Agent**: "SFO → EWR → JAX has **92%** Starlink odds!"
> **User**: "that's really confusing when it says 2/9 hours will have starlink. The goal here is to maximize starlink hours and minimize travel hours"

The agent optimized for **leg probability** when the user cared about **Starlink time**. A 92% probability on a 2.7h leg (after a 5.5h no-Starlink positioning leg) = **~2.5h expected Starlink** out of ~8h flying. That's not "great odds" — that's mostly no WiFi.

## The fix

Compute and surface **expected Starlink hours** = Σ(leg_probability × leg_duration):

| Route | Before | After |
|-------|--------|-------|
| 1-stop SFO→EWR→JAX | "92% Starlink" | **~2.5h Starlink** / ~8h+ flying |
| 2-stop SFO→MTY→ORD→JAX | "72.5% joint" | **~8.8h Starlink** / ~9.8h flying |

The agent literally cannot miss this now. Leg durations come from `AVG(arrival_time - departure_time)` in `upcoming_flights`. Positioning legs (mainline routes we don't track) show "duration unknown — likely 3-6h".

### Changed

- `ItineraryLeg` gets `duration_hours: number | null`
- `Itinerary` gets `total_flight_hours` + `expected_starlink_hours`
- **Ranked by expected Starlink hours**, not joint probability — so 8.8h@72% sorts above 7.7h@75%
- MCP output headline: `72.5% joint · **~8.8h Starlink** / ~9.8h flying`
- Footer explains the metric: "A '92% leg' means little if that leg is 2h out of a 7h trip — compare expected Starlink hours, not leg percentages."
- Instructions: "Users want to MAXIMIZE STARLINK HOURS, not leg-level percentages."

### Output diff

```
# Before
1. **via TUS→ORD (2 stops)** — **74.7%** all legs (100% at least one)

# After
1. **via MTY→ORD (2 stops)** — 72.5% joint · **~8.8h Starlink** / ~9.8h flying
```

```
# Before (partial)
1. **via EWR (1 stop)** — Starlink on final leg only (~92%)

# After
1. **via EWR (1 stop)** · ~2.5h Starlink (on final leg only; positioning leg duration unknown)
   · Leg 1: position to EWR (mainline, ~2% Starlink, duration unknown — likely 3-6h)
   · Leg 2: UA3561 (EWR-JAX ~2.7h) — 92% (4 obs · medium confidence)
```

Net: +83/−26.