### PR TITLE
Bound routeCache, pin Bun 1.3.13 + --smol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:slim
+FROM oven/bun:1.3.13-slim
 
 WORKDIR /app
 
@@ -44,4 +44,4 @@ ENV DD_VERSION=${SOURCE_COMMIT}
 ENV DD_TRACE_AGENT_HOSTNAME=host.docker.internal
 ENV DD_RUNTIME_METRICS_ENABLED=false
 
-CMD ["bun", "run", "server.ts"]
+CMD ["bun", "--smol", "server.ts"]

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -558,6 +558,14 @@ async function lookupFlightRoutes(
   const cached = routeCache.get(cacheKey);
   if (cached && now - cached.at < ROUTE_CACHE_TTL) return cached.promise;
 
+  // Keyspace is flightNumber × day → unbounded over time. Sweep stale entries
+  // once the cache gets large (matches assignmentCache in flight-verdict.ts).
+  if (routeCache.size > 500) {
+    for (const [k, v] of routeCache) {
+      if (now - v.at >= ROUTE_CACHE_TTL) routeCache.delete(k);
+    }
+  }
+
   const promise = (async (): Promise<RouteEntry[]> => {
     // L1: persistent SQLite cache (builds up over time, survives restarts).
     const sqliteCached = reader.getCachedFlightRoutes(uaFlightNumber, now - 7 * 86400);


### PR DESCRIPTION
## What

- **`src/api/mcp-server.ts:556-562`** — `routeCache` is keyed by `flightNumber × day` (unbounded keyspace) and previously only evicted on empty/error results, so populated entries lived forever. Added a size-triggered TTL sweep (>500 entries) matching the existing pattern in `flight-verdict.ts:27-31`.
- **`Dockerfile`** — pin `oven/bun:1.3.13-slim` (was rolling `:slim`); run `server.ts` directly with `--smol` for lower steady-state RSS on memory-constrained hosts.

## Why "1 GB" wasn't a JS leak

Live cgroup breakdown:
```
anon  193 MB   ← actual process heap
file  907 MB   ← page cache (SQLite I/O on bind-mounted /srv volume)
```
`docker stats` reports the sum. `VmHWM = 403 MB` confirms anon never exceeded ~400 MB. The page cache is kernel-reclaimable under pressure, so this isn't a leak — but it does mean a hard `mem_limit` on this container should account for ~200 MB of unavoidable file cache, or set `PRAGMA cache_size` lower.

Audited all 9 background pollers + module-level state: `assignmentCache`, `ipHits`, `fleetPageCache` already have bounded eviction; `staticResponses`/`modelCache` have fixed keyspaces; pollers themselves hold no module-level Maps. `routeCache` was the only unbounded structure.