### PR TITLE
Emit per-pipeline data freshness gauge

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import {
 } from "./src/database/database";
 import { withSpan } from "./src/observability";
 import { startAlaskaVerifier } from "./src/scripts/alaska-verifier";
+import { startFreshnessEmitter } from "./src/scripts/data-freshness";
 import { startFleetDiscovery } from "./src/scripts/fleet-discovery";
 import { startFleetSync } from "./src/scripts/fleet-sync";
 import { computePrecision, emitPrecisionGauges } from "./src/scripts/precision-backtest";
@@ -128,6 +129,10 @@ if (JOBS_ENABLED) {
   startQatarScheduleIngester();
   // Fleet sync iterates enabledAirlines() internally.
   startFleetSync();
+
+  // Data-freshness gauges: derived from MAX(timestamp) in the DB, not a
+  // ran-at heartbeat — catches "loop alive but writes nothing" silent failures.
+  startFreshnessEmitter(db);
 
   // Ship-number resolution is UA-specific (United's ship→tail Google Sheet).
   setTimeout(

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -157,6 +157,17 @@ export const COUNTERS = {
 } as const;
 
 /**
+ * Gauge metrics — periodic state snapshots, last-write-wins per flush window
+ */
+export const GAUGES = {
+  // Seconds since the last successful data write per pipeline, derived from the
+  // DB itself (MAX(timestamp)) — not from a "last ran at" heartbeat. Heartbeats
+  // prove the loop is alive; this proves it's still producing data.
+  // tags: job (flight_updater|verifier|departures), airline
+  DATA_FRESHNESS_SECONDS: "data.freshness_seconds",
+} as const;
+
+/**
  * Distribution metrics — server-side aggregated, graph p50/p95/p99/sum/avg
  */
 export const DISTRIBUTIONS = {

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -1,0 +1,53 @@
+import type { Database } from "bun:sqlite";
+import { GAUGES, metrics, normalizeAirlineTag } from "../observability/metrics";
+import { info, error as logError } from "../utils/logger";
+
+const EMIT_INTERVAL_MS = 5 * 60 * 1000;
+
+type FreshnessJob = "flight_updater" | "verifier" | "departures";
+
+// Per-job freshness anchor: the newest timestamp that proves the pipeline
+// actually wrote data, grouped by airline. Skips airlines with no rows so an
+// airline that has never used a path doesn't emit a forever-stale gauge.
+const FRESHNESS_QUERIES: Record<FreshnessJob, string> = {
+  flight_updater: `
+    SELECT airline, MAX(last_updated) AS ts
+    FROM upcoming_flights
+    GROUP BY airline`,
+  // has_starlink IS NOT NULL filters out crash/error rows — a verifier that
+  // runs but only logs failures should still read as stale.
+  verifier: `
+    SELECT airline, MAX(checked_at) AS ts
+    FROM starlink_verification_log
+    WHERE has_starlink IS NOT NULL
+    GROUP BY airline`,
+  departures: `
+    SELECT airline, MAX(departed_at) AS ts
+    FROM departure_log
+    GROUP BY airline`,
+};
+
+export function emitDataFreshness(db: Database): void {
+  const now = Math.floor(Date.now() / 1000);
+  for (const [job, sql] of Object.entries(FRESHNESS_QUERIES)) {
+    try {
+      const rows = db.query(sql).all() as Array<{ airline: string; ts: number | null }>;
+      for (const row of rows) {
+        if (row.ts == null) continue;
+        const ageSec = Math.max(0, now - row.ts);
+        metrics.gauge(GAUGES.DATA_FRESHNESS_SECONDS, ageSec, {
+          job,
+          airline: normalizeAirlineTag(row.airline),
+        });
+      }
+    } catch (err) {
+      logError(`Freshness query failed for job=${job}`, err);
+    }
+  }
+}
+
+export function startFreshnessEmitter(db: Database): void {
+  info(`Starting data freshness emitter (every ${EMIT_INTERVAL_MS / 60000} min)`);
+  emitDataFreshness(db);
+  setInterval(() => emitDataFreshness(db), EMIT_INTERVAL_MS);
+}


### PR DESCRIPTION
Adds a `data.freshness_seconds` gauge derived from `MAX(timestamp)` per pipeline per airline, emitted every 5 minutes. Heartbeats prove the loops run, not that they write data — this gauge catches the "loop alive but writes nothing" failure mode and lets us alert on stale pipelines in Datadog.