### PR TITLE
Match "Wi-Fi Not offered" loosely; prune stale crash log rows

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -5,6 +5,7 @@ import "dotenv/config";
 import { checkNewPlanes, startFlightUpdater } from "./src/api/flight-updater";
 import {
   initializeDatabase,
+  pruneCrashRows,
   reconcileConsensus,
   syncSpreadsheetToFleet,
   updateDatabase,
@@ -139,6 +140,15 @@ if (JOBS_ENABLED) {
       );
     },
     10 * 60 * 1000
+  );
+
+  // Daily prune of subprocess-crash log rows (no observation, just noise).
+  setInterval(
+    () => {
+      const n = pruneCrashRows(db);
+      if (n > 0) info(`Pruned ${n} stale crash rows from verification log`);
+    },
+    24 * 3600 * 1000
   );
 } else {
   info("Background jobs disabled (DISABLE_JOBS=1)");

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1261,6 +1261,25 @@ export function logVerification(
   );
 }
 
+/**
+ * Drop subprocess-crash rows that carry no observation. Aircraft-mismatch
+ * rows are kept — they document tail-on-flight assignments. The 7-day window
+ * stays above needsVerification's max ~96h jitter so retry-storm protection
+ * holds.
+ */
+export function pruneCrashRows(db: Database): number {
+  const cutoff = Math.floor(Date.now() / 1000) - 7 * 86400;
+  const result = db
+    .query(`
+      DELETE FROM starlink_verification_log
+      WHERE has_starlink IS NULL
+        AND error LIKE 'Process exited with code%'
+        AND checked_at < ?
+    `)
+    .run(cutoff);
+  return result.changes;
+}
+
 export function getNextAlaskaVerifyTarget(
   db: Database,
   airline: "AS" | "HA"

--- a/src/scripts/united-starlink-checker.ts
+++ b/src/scripts/united-starlink-checker.ts
@@ -194,9 +194,9 @@ export async function checkStarlinkStatus(
         bodyText.includes("Internet by Thales") || bodyText.includes("by Thales");
       const hasGogoText = bodyText.includes("by Gogo") || bodyText.includes("Gogo Wi-Fi");
 
-      // Check for no WiFi
-      const hasNoWifi =
-        bodyText.includes("Wi-Fi\n\nNot offered") || bodyText.includes("Wi-Fi: Not offered");
+      // Check for no WiFi. Whitespace between the label and value varies
+      // (single vs double newline depending on render timing), so match loosely.
+      const hasNoWifi = /Wi-?Fi[\s:]*Not offered/i.test(bodyText);
 
       // Determine WiFi provider
       let wifiProvider: string | null = null;


### PR DESCRIPTION
Two small verifier hygiene fixes. The exact-string check for the no-WiFi amenity missed pages where label/value whitespace varies — match with a regex so `wifi_provider` gets recorded and we stop saving redundant debug HTMLs. Also adds a daily prune of "Process exited with code 1" verification rows older than 7 days; they carry no observation and accumulate ~120/day. The 7-day window stays above `needsVerification`'s ~96h jitter so retry-storm protection holds.