### PR TITLE
Cache SSR pages briefly; debounce Plausible pageviews

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -102,7 +102,15 @@ function methodNotAllowed(json = false): Response {
 function analyticsSnippet(site: SiteConfig): string {
   const analytics = site.analytics;
   if (!analytics) return "";
-  return `<script defer data-domain="${analytics.dataDomain}" src="${analytics.scriptSrc}"></script>`;
+  // Manual mode + 30s/path debounce: refresh-loop bots and wallboard tabs fire
+  // a pageview on every reload; this dedupes them client-side so the dashboard
+  // tracks visits, not refresh rates.
+  const manualSrc = analytics.scriptSrc.replace(/script\.js$/, "script.manual.js");
+  const debounce =
+    "window.plausible=window.plausible||function(){(window.plausible.q=window.plausible.q||[]).push(arguments)};" +
+    '(function(){try{var k="pv:"+location.pathname,n=Date.now(),t=+sessionStorage.getItem(k)||0;' +
+    'if(n-t<3e4)return;sessionStorage.setItem(k,n)}catch(e){}plausible("pageview")})();';
+  return `<script defer data-domain="${analytics.dataDomain}" src="${manualSrc}"></script><script>${debounce}</script>`;
 }
 
 function jsonLdBlock(payload: unknown): string {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -64,6 +64,9 @@ export const SECURITY_HEADERS = {
     "Content-Security-Policy": `default-src 'self' https://unpkg.com; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;`,
     "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
     "Referrer-Policy": "no-referrer",
+    // Underlying data refreshes hourly; 5min browser / 10min CDN absorbs
+    // refresh-loop bots and wallboard tabs without going stale.
+    "Cache-Control": "public, max-age=300, s-maxage=600",
   },
   notFound: {
     "Content-Type": "text/html",


### PR DESCRIPTION
Adds `Cache-Control: public, max-age=300, s-maxage=600` to SSR HTML responses — the underlying data refreshes hourly, so a short cache lets browsers (and any future CDN) absorb refresh loops instead of re-rendering. Also switches Plausible to manual mode with a 30s/path `sessionStorage` debounce so wallboard tabs and stuck refresh loops register once per window instead of once per reload.