### PR TITLE
Observability hardening: span hygiene, tag fixes, product metrics

### DIFF
--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -48,6 +48,15 @@ function createFlightAPI(): FlightAPI | null {
   return null;
 }
 
+// Distinguishes vendor outages (Cloudflare blocks, timeouts) from app bugs in DD.
+function classifyUpdateError(err: unknown): string {
+  const msg = (err instanceof Error ? `${err.name}: ${err.message}` : String(err)).toLowerCase();
+  if (/cloudflare|403|blocked|captcha|rate.?limit|429/.test(msg)) return "vendor_block";
+  if (/timeout|timed.?out|aborted|econnreset|etimedout|socket/.test(msg)) return "timeout";
+  if (/json|parse|unexpected.?token|invalid.?response/.test(msg)) return "parse_error";
+  return "unknown";
+}
+
 async function updateFlightsForTailNumber(api: FlightAPI, tailNumber: string): Promise<boolean> {
   return withSpan(
     "flight_updater.update_tail",
@@ -77,6 +86,7 @@ async function updateFlightsForTailNumber(api: FlightAPI, tailNumber: string): P
       } catch (err) {
         error(`Failed to update flights for ${tailNumber}`, err);
         span.setTag("error", true);
+        span.setTag("error.type", classifyUpdateError(err));
 
         try {
           updateLastFlightCheck(db, tailNumber, false);

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -1321,8 +1321,9 @@ function recordMcpToolCall(
   outcome: "success" | "error" | "unknown_tool",
   startMs: number
 ): void {
+  // Bound the `tool` tag — /mcp is public and `params.name` is caller-controlled.
   const tags = {
-    tool,
+    tool: TOOL_NAMES.includes(tool) ? tool : "unknown",
     airline: scope === "ALL" ? "all" : normalizeAirlineTag(scope),
     outcome,
   };

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -22,6 +22,7 @@
 
 import { AIRLINES, type AirlineCode, type AnalyticsConfig } from "../airlines/registry";
 import type { Scope, ScopedReader } from "../database/reader";
+import { COUNTERS, DISTRIBUTIONS, metrics, normalizeAirlineTag } from "../observability";
 import { planItinerary, predictFlight, predictRoute } from "../scripts/starlink-predictor";
 import {
   buildFlightNumberVariants,
@@ -612,6 +613,12 @@ type RouteEntry = { origin: string; destination: string; duration_hours?: number
 const routeCache = new Map<string, { promise: Promise<RouteEntry[]>; at: number }>();
 const ROUTE_CACHE_TTL = 3600;
 
+// Records which fallback layer answered — surfaces a stale cache or a vendor
+// outage that would otherwise just look like silently-degraded results.
+function recordRouteLookup(source: "memory" | "sqlite" | "fr24" | "upcoming" | "miss"): void {
+  metrics.increment(COUNTERS.ROUTE_LOOKUP, { source, airline: normalizeAirlineTag("UA") });
+}
+
 async function lookupFlightRoutes(
   reader: ScopedReader,
   uaFlightNumber: string,
@@ -620,7 +627,10 @@ async function lookupFlightRoutes(
   const cacheKey = `${uaFlightNumber}:${targetDateUnix ? Math.floor(targetDateUnix / 86400) : "any"}`;
   const now = Math.floor(Date.now() / 1000);
   const cached = routeCache.get(cacheKey);
-  if (cached && now - cached.at < ROUTE_CACHE_TTL) return cached.promise;
+  if (cached && now - cached.at < ROUTE_CACHE_TTL) {
+    recordRouteLookup("memory");
+    return cached.promise;
+  }
 
   // Keyspace is flightNumber × day → unbounded over time. Sweep stale entries
   // once the cache gets large (matches assignmentCache in flight-verdict.ts).
@@ -634,6 +644,7 @@ async function lookupFlightRoutes(
     // L1: persistent SQLite cache (builds up over time, survives restarts).
     const sqliteCached = reader.getCachedFlightRoutes(uaFlightNumber, now - 7 * 86400);
     if (sqliteCached.length > 0) {
+      recordRouteLookup("sqlite");
       return sqliteCached.map((r) => ({
         origin: r.origin,
         destination: r.destination,
@@ -648,6 +659,7 @@ async function lookupFlightRoutes(
         for (const r of found) {
           reader.cacheFlightRoute(uaFlightNumber, r.origin, r.destination, r.duration_sec || null);
         }
+        recordRouteLookup("fr24");
         return found.map((r) => ({
           origin: r.origin,
           destination: r.destination,
@@ -660,6 +672,7 @@ async function lookupFlightRoutes(
 
     // L3: our own upcoming_flights (sparse, ~2-day Starlink-plane snapshot)
     const rows = reader.getRoutesForFlightVariants(buildFlightNumberVariants(uaFlightNumber));
+    recordRouteLookup(rows.length > 0 ? "upcoming" : "miss");
     return rows.map((r) => ({
       origin: r.departure_airport,
       destination: r.arrival_airport,
@@ -1302,8 +1315,24 @@ When a tool wraps content in <present_verbatim>...</present_verbatim>, copy that
   });
 }
 
+function recordMcpToolCall(
+  tool: string,
+  scope: Scope,
+  outcome: "success" | "error" | "unknown_tool",
+  startMs: number
+): void {
+  const tags = {
+    tool,
+    airline: scope === "ALL" ? "all" : normalizeAirlineTag(scope),
+    outcome,
+  };
+  metrics.increment(COUNTERS.MCP_TOOL_CALL, tags);
+  metrics.distribution(DISTRIBUTIONS.MCP_TOOL_DURATION_MS, performance.now() - startMs, tags);
+}
+
 async function handleToolsCall(
   reader: ScopedReader,
+  scope: Scope,
   id: string | number | null,
   params: Record<string, unknown> | undefined
 ): Promise<JsonRpcResponse> {
@@ -1314,40 +1343,48 @@ async function handleToolsCall(
     return rpcError(id, -32602, "Missing required param: name");
   }
 
+  const startMs = performance.now();
   let result: ToolResult;
-  switch (toolName) {
-    case "check_flight":
-      result = await toolCheckFlight(reader, args);
-      break;
-    case "predict_flight_starlink":
-      result = await toolPredictFlightStarlink(reader, args);
-      break;
-    case "predict_route_starlink":
-      result = toolPredictRouteStarlink(reader, args);
-      break;
-    case "plan_starlink_itinerary":
-      result = toolPlanStarlinkItinerary(reader, args);
-      break;
-    case "get_fleet_stats":
-      result = toolGetFleetStats(reader);
-      break;
-    case "list_starlink_aircraft":
-      result = toolListStarlinkAircraft(reader, args);
-      break;
-    case "search_starlink_flights":
-      result = toolSearchStarlinkFlights(reader, args);
-      break;
-    default: {
-      const suggestion = suggestTool(toolName);
-      const hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
-      return rpcError(
-        id,
-        -32602,
-        `Unknown tool "${toolName}".${hint} Available tools: ${TOOL_NAMES.join(", ")}.`
-      );
+  try {
+    switch (toolName) {
+      case "check_flight":
+        result = await toolCheckFlight(reader, args);
+        break;
+      case "predict_flight_starlink":
+        result = await toolPredictFlightStarlink(reader, args);
+        break;
+      case "predict_route_starlink":
+        result = toolPredictRouteStarlink(reader, args);
+        break;
+      case "plan_starlink_itinerary":
+        result = toolPlanStarlinkItinerary(reader, args);
+        break;
+      case "get_fleet_stats":
+        result = toolGetFleetStats(reader);
+        break;
+      case "list_starlink_aircraft":
+        result = toolListStarlinkAircraft(reader, args);
+        break;
+      case "search_starlink_flights":
+        result = toolSearchStarlinkFlights(reader, args);
+        break;
+      default: {
+        recordMcpToolCall(toolName, scope, "unknown_tool", startMs);
+        const suggestion = suggestTool(toolName);
+        const hint = suggestion ? ` Did you mean "${suggestion}"?` : "";
+        return rpcError(
+          id,
+          -32602,
+          `Unknown tool "${toolName}".${hint} Available tools: ${TOOL_NAMES.join(", ")}.`
+        );
+      }
     }
+  } catch (err) {
+    recordMcpToolCall(toolName, scope, "error", startMs);
+    throw err;
   }
 
+  recordMcpToolCall(toolName, scope, result.isError ? "error" : "success", startMs);
   return rpcResult(id, result);
 }
 
@@ -1370,7 +1407,7 @@ async function dispatch(
     case "tools/list":
       return rpcResult(id, { tools: buildTools(scope) });
     case "tools/call":
-      return handleToolsCall(reader, id, msg.params);
+      return handleToolsCall(reader, scope, id, msg.params);
     default:
       if (isNotification) return null;
       return rpcError(id, -32601, `Method not found: ${msg.method}`);

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -404,6 +404,44 @@ function suggestTool(unknown: string): string | null {
 // Tool implementations
 // ============================================================================
 
+// Shared scope→airline-tag mapping for MCP metrics. ALL is a hub scope, not an
+// airline, so it gets its own bucket instead of falling into "unmapped".
+function mcpAirlineTag(scope: Scope): string {
+  return scope === "ALL" ? "all" : normalizeAirlineTag(scope);
+}
+
+type LookupOutcome = "verified_yes" | "verified_no" | "predicted" | "no_data" | "error";
+type LookupConfidence = "high" | "medium" | "low" | "none";
+
+// MCP-side mirror of app.ts recordFlightLookup — same metric, endpoint=mcp,
+// so the cross-channel "did we answer the user's question" view includes /mcp.
+function recordMcpFlightLookup(
+  scope: Scope,
+  outcome: LookupOutcome,
+  confidence: LookupConfidence
+): void {
+  metrics.increment(COUNTERS.FLIGHT_LOOKUP_RESULT, {
+    endpoint: "mcp",
+    outcome,
+    confidence,
+    airline: mcpAirlineTag(scope),
+  });
+}
+
+// MCP-side mirror of app.ts recordPrediction — surfaces what's actually served
+// over /mcp (~1.4k calls/wk), not just the REST predict handlers.
+function recordMcpPrediction(
+  scope: Scope,
+  pred: { probability: number; confidence: "high" | "medium" | "low"; method: string }
+): void {
+  const method = pred.method.startsWith("fleet_prior") ? "fleet_prior" : "flight_history";
+  metrics.distribution(DISTRIBUTIONS.PREDICTION_PROBABILITY, pred.probability, {
+    confidence: pred.confidence,
+    method,
+    airline: mcpAirlineTag(scope),
+  });
+}
+
 async function toolCheckFlight(
   reader: ScopedReader,
   args: { flight_number?: unknown; date?: unknown }
@@ -473,6 +511,7 @@ async function toolCheckFlight(
 
   // Firm YES: assigned to a united.com-verified Starlink tail
   if (verified.length > 0) {
+    recordMcpFlightLookup(reader.scope, "verified_yes", "high");
     return {
       content: [
         {
@@ -486,6 +525,7 @@ async function toolCheckFlight(
   // Likely YES: spreadsheet says Starlink but not yet confirmed on united.com.
   // Spreadsheet is usually right (~80-90%) but not a firm answer.
   if (unverified.length > 0) {
+    recordMcpFlightLookup(reader.scope, "verified_yes", "medium");
     return {
       content: [
         {
@@ -506,6 +546,7 @@ async function toolCheckFlight(
       [{ origin: f.departure_airport, destination: f.arrival_airport }],
       startOfDay + 43200
     );
+    recordMcpFlightLookup(reader.scope, "verified_no", "high");
     return {
       content: [
         {
@@ -539,6 +580,12 @@ async function toolCheckFlight(
     };
 
     if (yes.length > 0) {
+      const allVerified = yes.every((s) => s.confidence === "verified");
+      recordMcpFlightLookup(
+        reader.scope,
+        allVerified ? "verified_yes" : "predicted",
+        allVerified ? "high" : "medium"
+      );
       return {
         content: [
           {
@@ -554,6 +601,7 @@ async function toolCheckFlight(
         no.map((s) => ({ origin: s.origin, destination: s.destination })),
         startOfDay + 43200
       );
+      recordMcpFlightLookup(reader.scope, "verified_no", "medium");
       return {
         content: [
           {
@@ -569,6 +617,8 @@ async function toolCheckFlight(
   // No assignment data at all — probability fallback. If low, look up the route
   // from FR24 (cached) so we can give the agent a concrete next step.
   const pred = predictFlight(reader, normalized);
+  recordMcpFlightLookup(reader.scope, "predicted", pred.confidence);
+  recordMcpPrediction(reader.scope, pred);
   const pct = (pred.probability * 100).toFixed(0);
 
   const isPast = endOfDay < now - 86400;
@@ -615,8 +665,11 @@ const ROUTE_CACHE_TTL = 3600;
 
 // Records which fallback layer answered — surfaces a stale cache or a vendor
 // outage that would otherwise just look like silently-degraded results.
-function recordRouteLookup(source: "memory" | "sqlite" | "fr24" | "upcoming" | "miss"): void {
-  metrics.increment(COUNTERS.ROUTE_LOOKUP, { source, airline: normalizeAirlineTag("UA") });
+function recordRouteLookup(
+  scope: Scope,
+  source: "memory" | "sqlite" | "fr24" | "upcoming" | "miss"
+): void {
+  metrics.increment(COUNTERS.ROUTE_LOOKUP, { source, airline: mcpAirlineTag(scope) });
 }
 
 async function lookupFlightRoutes(
@@ -628,7 +681,7 @@ async function lookupFlightRoutes(
   const now = Math.floor(Date.now() / 1000);
   const cached = routeCache.get(cacheKey);
   if (cached && now - cached.at < ROUTE_CACHE_TTL) {
-    recordRouteLookup("memory");
+    recordRouteLookup(reader.scope, "memory");
     return cached.promise;
   }
 
@@ -644,7 +697,7 @@ async function lookupFlightRoutes(
     // L1: persistent SQLite cache (builds up over time, survives restarts).
     const sqliteCached = reader.getCachedFlightRoutes(uaFlightNumber, now - 7 * 86400);
     if (sqliteCached.length > 0) {
-      recordRouteLookup("sqlite");
+      recordRouteLookup(reader.scope, "sqlite");
       return sqliteCached.map((r) => ({
         origin: r.origin,
         destination: r.destination,
@@ -659,7 +712,7 @@ async function lookupFlightRoutes(
         for (const r of found) {
           reader.cacheFlightRoute(uaFlightNumber, r.origin, r.destination, r.duration_sec || null);
         }
-        recordRouteLookup("fr24");
+        recordRouteLookup(reader.scope, "fr24");
         return found.map((r) => ({
           origin: r.origin,
           destination: r.destination,
@@ -672,7 +725,7 @@ async function lookupFlightRoutes(
 
     // L3: our own upcoming_flights (sparse, ~2-day Starlink-plane snapshot)
     const rows = reader.getRoutesForFlightVariants(buildFlightNumberVariants(uaFlightNumber));
-    recordRouteLookup(rows.length > 0 ? "upcoming" : "miss");
+    recordRouteLookup(reader.scope, rows.length > 0 ? "upcoming" : "miss");
     return rows.map((r) => ({
       origin: r.departure_airport,
       destination: r.arrival_airport,
@@ -850,6 +903,12 @@ async function toolPredictFlightStarlink(
   }
 
   const pred = predictFlight(reader, forPredict);
+  recordMcpFlightLookup(
+    reader.scope,
+    pred.n_observations > 0 ? "predicted" : "no_data",
+    pred.confidence
+  );
+  recordMcpPrediction(reader.scope, pred);
   const pct = (pred.probability * 100).toFixed(0);
 
   let details: string;
@@ -930,6 +989,19 @@ function toolPlanStarlinkItinerary(
     maxStops,
     targetDateUnix,
   });
+
+  // Itinerary planning is graph-search prediction; map coverage to confidence
+  // so the cross-channel lookup metric still distinguishes "found a path" from
+  // "no Starlink routing exists on this O-D pair".
+  recordMcpFlightLookup(
+    reader.scope,
+    itineraries.length > 0 ? "predicted" : "no_data",
+    itineraries.length === 0
+      ? "none"
+      : itineraries.some((it) => it.coverage === "full")
+        ? "medium"
+        : "low"
+  );
 
   if (itineraries.length === 0) {
     const orig = origin.toUpperCase();
@@ -1050,6 +1122,7 @@ function toolPredictRouteStarlink(
   const result = predictRoute(reader, origin || null, destination || null);
 
   if (result.flights.length === 0) {
+    recordMcpFlightLookup(reader.scope, "no_data", "none");
     // No DIRECT Starlink flights on this route. If both endpoints given,
     // inline the connection-based alternatives so the agent never sees a
     // dead-end that contradicts check_flight's embedded alternatives.
@@ -1077,6 +1150,10 @@ function toolPredictRouteStarlink(
   }
 
   const shown = result.flights.slice(0, limit);
+  // Top-ranked flight is the headline answer; per-flight points feed the
+  // probability distribution so MCP-served route predictions are visible.
+  recordMcpFlightLookup(reader.scope, "predicted", shown[0].confidence);
+  for (const f of shown) recordMcpPrediction(reader.scope, f);
   const lines = shown.map((f) => {
     const pct = (f.probability * 100).toFixed(0);
     const fleet = inferFleet(f.flight_number);
@@ -1324,11 +1401,14 @@ function recordMcpToolCall(
   // Bound the `tool` tag — /mcp is public and `params.name` is caller-controlled.
   const tags = {
     tool: TOOL_NAMES.includes(tool) ? tool : "unknown",
-    airline: scope === "ALL" ? "all" : normalizeAirlineTag(scope),
+    airline: mcpAirlineTag(scope),
     outcome,
   };
   metrics.increment(COUNTERS.MCP_TOOL_CALL, tags);
-  metrics.distribution(DISTRIBUTIONS.MCP_TOOL_DURATION_MS, performance.now() - startMs, tags);
+  // unknown_tool durations are just switch overhead — meaningless distribution noise.
+  if (outcome !== "unknown_tool") {
+    metrics.distribution(DISTRIBUTIONS.MCP_TOOL_DURATION_MS, performance.now() - startMs, tags);
+  }
 }
 
 async function handleToolsCall(

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -2,8 +2,12 @@ import { Database } from "bun:sqlite";
 import { ensureAirlinePrefix } from "../airlines/flight-number";
 import { AIRLINES } from "../airlines/registry";
 import {
+  COUNTERS,
+  metrics,
   normalizeAircraftType,
+  normalizeAirlineTag,
   normalizeFleet,
+  normalizeStarlinkStatus,
   normalizeWifiProvider,
 } from "../observability/metrics";
 import type {
@@ -1340,6 +1344,34 @@ export function getNextFlightForTail(
   } | null;
 }
 
+// Emit fleet.status_change at the write site so every mutator path is
+// covered, not just the discovery scan (which can be starved during outages).
+function emitFleetStatusChange(
+  prev: { starlink_status: string | null; fleet: string | null; airline: string | null } | null,
+  next: StarlinkStatus
+): void {
+  if (!prev || prev.starlink_status === next) return;
+  metrics.increment(COUNTERS.FLEET_STATUS_CHANGE, {
+    fleet: normalizeFleet(prev.fleet),
+    from: normalizeStarlinkStatus(prev.starlink_status),
+    to: normalizeStarlinkStatus(next),
+    airline: normalizeAirlineTag(prev.airline),
+  });
+}
+
+function getFleetStatusRow(
+  db: Database,
+  tail: string
+): { starlink_status: string | null; fleet: string | null; airline: string | null } | null {
+  return db
+    .query("SELECT starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?")
+    .get(tail) as {
+    starlink_status: string | null;
+    fleet: string | null;
+    airline: string | null;
+  } | null;
+}
+
 export function setFleetVerified(
   db: Database,
   tail: string,
@@ -1347,9 +1379,11 @@ export function setFleetVerified(
   status: StarlinkStatus
 ): void {
   const now = Math.floor(Date.now() / 1000);
+  const prev = getFleetStatusRow(db, tail);
   db.query(
     "UPDATE united_fleet SET verified_wifi = ?, verified_at = ?, starlink_status = ? WHERE tail_number = ?"
   ).run(wifi, now, status, tail);
+  emitFleetStatusChange(prev, status);
 }
 
 export function touchFleetVerifiedAt(db: Database, tail: string): void {
@@ -1964,8 +1998,13 @@ export function upsertFleetAircraft(
   const safeType = type && !/^unknown$/i.test(type) ? type : null;
 
   const existing = db
-    .query("SELECT id, starlink_status FROM united_fleet WHERE tail_number = ?")
-    .get(tailNumber) as { id: number; starlink_status: StarlinkStatus } | null;
+    .query("SELECT id, starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?")
+    .get(tailNumber) as {
+    id: number;
+    starlink_status: StarlinkStatus;
+    fleet: string | null;
+    airline: string | null;
+  } | null;
 
   if (existing) {
     db.query(`
@@ -1996,6 +2035,7 @@ export function upsertFleetAircraft(
         now + 365 * 24 * 3600,
         tailNumber
       );
+      emitFleetStatusChange(existing, seedVerdict.starlinkStatus);
     }
   } else {
     const status = seedVerdict?.starlinkStatus ?? "unknown";
@@ -2108,6 +2148,7 @@ export function updateFleetVerificationResult(
       WHERE tail_number = ?
     `).run(result.error, nextCheckAfter, priority, tailNumber);
   } else {
+    const prev = getFleetStatusRow(db, tailNumber);
     db.query(`
       UPDATE united_fleet
       SET starlink_status = ?,
@@ -2119,6 +2160,7 @@ export function updateFleetVerificationResult(
           discovery_priority = ?
       WHERE tail_number = ?
     `).run(result.starlinkStatus, result.verifiedWifi, now, nextCheckAfter, priority, tailNumber);
+    emitFleetStatusChange(prev, result.starlinkStatus);
   }
 }
 
@@ -2144,7 +2186,9 @@ export function syncSpreadsheetToFleet(db: Database): number {
     verified_wifi: string | null;
   }>;
 
-  const existsStmt = db.prepare("SELECT id FROM united_fleet WHERE tail_number = ?");
+  const existsStmt = db.prepare(
+    "SELECT id, starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?"
+  );
   // starlink_status follows verified_wifi (the consensus-driven column) so
   // retrofit transitions converge hourly instead of waiting 7-14d for discovery.
   // When verified_wifi is NULL (unverified) we leave status alone — avoids the
@@ -2172,6 +2216,13 @@ export function syncSpreadsheetToFleet(db: Database): number {
     return s && !/^unknown$/i.test(s) && normalizeAircraftType(s) !== "other" ? s : null;
   };
 
+  // Defer metric emit until the transaction commits so DogStatsD never reports
+  // a transition that gets rolled back.
+  const transitions: Array<{
+    prev: { starlink_status: string | null; fleet: string | null; airline: string | null };
+    next: StarlinkStatus;
+  }> = [];
+
   const sync = db.transaction(() => {
     for (const plane of spreadsheetPlanes) {
       // NULL verified_wifi means unverified — must map to 'unknown', not
@@ -2186,7 +2237,16 @@ export function syncSpreadsheetToFleet(db: Database): number {
             : "negative";
       const type = safeType(plane.aircraft);
 
-      if (existsStmt.get(plane.TailNumber)) {
+      const existing = existsStmt.get(plane.TailNumber) as {
+        id: number;
+        starlink_status: string | null;
+        fleet: string | null;
+        airline: string | null;
+      } | null;
+      if (existing) {
+        if (starlinkStatus !== "unknown" && existing.starlink_status !== starlinkStatus) {
+          transitions.push({ prev: existing, next: starlinkStatus });
+        }
         updateStmt.run(
           type,
           plane.fleet,
@@ -2216,6 +2276,8 @@ export function syncSpreadsheetToFleet(db: Database): number {
     }
   });
   sync();
+
+  for (const t of transitions) emitFleetStatusChange(t.prev, t.next);
 
   return synced;
 }

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -17,5 +17,6 @@ export {
   normalizeFleet,
   normalizeAirlineTag,
   normalizeStarlinkStatus,
+  classifyUserAgent,
 } from "./metrics";
 export type { Tags } from "./metrics";

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -16,5 +16,6 @@ export {
   normalizeWifiProvider,
   normalizeFleet,
   normalizeAirlineTag,
+  normalizeStarlinkStatus,
 } from "./metrics";
 export type { Tags } from "./metrics";

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -10,6 +10,7 @@ export type { Span } from "./tracer";
 export {
   metrics,
   COUNTERS,
+  GAUGES,
   DISTRIBUTIONS,
   normalizeAircraftType,
   normalizeWifiProvider,

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -7,10 +7,12 @@
  * Naming Convention: starlink.{category}.{action}
  *
  * Tag cardinality budget (keep each tag ≤ ~20 values):
- *   airline:         united | hawaiian | alaska | qatar | unmapped | unknown  (~6)
+ *   airline:         united | hawaiian | alaska | qatar | all | unmapped | unknown  (~7)
+ *                    `all` = hub-scope emits (db.table_rows, mcp.tool_call)
  *   tenant:          UA | HA | AS | QR | ALL  (~5) — used on http.* only; the
  *                    hub host serves all carriers under scope ALL, which isn't
- *                    an airline, so http metrics carry tenant instead of airline.
+ *                    an airline, so http metrics carry tenant in addition to the
+ *                    per-call default `airline:unmapped` injected by withDefaultAirline.
  *   fleet:           express | mainline | unknown                    (3)
  *   aircraft_type:   normalized families (B737-800, E175, etc)      (~19)
  *   wifi_provider:   starlink | viasat | panasonic | thales | none | other | unknown  (7)
@@ -18,11 +20,12 @@
  *   vendor:          fr24 | flightaware | united | qatar | alaska    (5)
  *   status:          success | error | rate_limited | timeout | killed |
  *                    exit_error | parse_error | spawn_error | partial |
- *                    aborted | scrape_error                          (~14)
+ *                    aborted | scrape_error                          (~11)
  *   result:          success | error | aircraft_mismatch | tail_unknown  (4)
  *   client_class:    bot | claude | extension | browser | unknown    (5)
  *   confidence:      high | medium | low | none                      (4)
  *   outcome:         verified_yes | verified_no | predicted | no_data | error  (5)
+ *   tool:            7 MCP tool names (TOOL_NAMES) | unknown         (~8)
  */
 
 import { AIRLINES } from "../airlines/registry";
@@ -244,6 +247,6 @@ export const DISTRIBUTIONS = {
   MCP_TOOL_DURATION_MS: "mcp.tool_duration_ms",
 
   // Distribution of probabilities served to users — surfaces cold-start floods.
-  // tags: confidence (high|medium|low), method (flight_history|fleet_prior|confirmed), airline
+  // tags: confidence (high|medium|low), method (flight_history|fleet_prior), airline
   PREDICTION_PROBABILITY: "prediction.probability",
 } as const;

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -21,13 +21,20 @@ import { tracer } from "./tracer";
 
 export type Tags = Record<string, string | number>;
 
+// Default `airline` injected per-call instead of globally in tracer.init(),
+// because DogStatsD concatenates global + per-call tags (`airline:hawaiian,united`).
+function withDefaultAirline(tags?: Tags): Tags {
+  if (tags && "airline" in tags) return tags;
+  return { ...tags, airline: "unmapped" };
+}
+
 export const metrics = {
   increment: (name: string, tags?: Tags) => {
-    tracer.dogstatsd.increment(`starlink.${name}`, 1, tags);
+    tracer.dogstatsd.increment(`starlink.${name}`, 1, withDefaultAirline(tags));
   },
 
   gauge: (name: string, value: number, tags?: Tags) => {
-    tracer.dogstatsd.gauge(`starlink.${name}`, value, tags);
+    tracer.dogstatsd.gauge(`starlink.${name}`, value, withDefaultAirline(tags));
   },
 
   /**
@@ -36,7 +43,7 @@ export const metrics = {
    * sum/avg across tag dimensions in Datadog.
    */
   distribution: (name: string, value: number, tags?: Tags) => {
-    tracer.dogstatsd.distribution(`starlink.${name}`, value, tags);
+    tracer.dogstatsd.distribution(`starlink.${name}`, value, withDefaultAirline(tags));
   },
 };
 
@@ -107,7 +114,7 @@ export function normalizeFleet(raw: string | null | undefined): string {
  */
 export function normalizeAirlineTag(code: string | null | undefined): string {
   if (!code) return "unknown";
-  return AIRLINES[code.toUpperCase()]?.metricTag ?? code.toLowerCase();
+  return AIRLINES[code.toUpperCase()]?.metricTag ?? "unmapped";
 }
 
 // ============ Metric Names ============

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -107,6 +107,11 @@ export function normalizeFleet(raw: string | null | undefined): string {
   return "unknown";
 }
 
+export function normalizeStarlinkStatus(raw: string | null | undefined): string {
+  if (raw === "confirmed" || raw === "negative") return raw;
+  return "unknown";
+}
+
 /**
  * Canonical lowercase-name airline tag for metrics. Preserves Datadog history
  * (the global default has always been `airline:united`, not `airline:UA`).
@@ -172,6 +177,17 @@ export const GAUGES = {
   // prove the loop is alive; this proves it's still producing data.
   // tags: job (flight_updater|verifier|departures), airline
   DATA_FRESHNESS_SECONDS: "data.freshness_seconds",
+
+  // Backtest precision of firm "yes/no Starlink" calls — tags: airline, window, call
+  PRECISION_FIRM_CALL: "precision.firm_call",
+  PRECISION_FIRM_CALL_N: "precision.firm_call.n",
+  // Misses by cause — tags: airline, window, call, cause (swap|stale|unattributed)
+  PRECISION_FIRM_CALL_MISS: "precision.firm_call.miss",
+  PRECISION_LEGACY_PRIOR_PCT: "precision.legacy_prior_pct",
+
+  // Surface contradiction sweep — tags: airline, vector
+  SURFACE_CONTRADICTION_TOTAL: "surface_contradiction.total",
+  SURFACE_CONTRADICTION_COUNT: "surface_contradiction.count",
 } as const;
 
 /**

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -112,6 +112,17 @@ export function normalizeStarlinkStatus(raw: string | null | undefined): string 
   return "unknown";
 }
 
+// Bounded user-agent classification (≤6 buckets, never the raw UA).
+const BOT_UA = /bot|spider|crawler|curl|wget|python-requests|go-http-client|headless|httpclient/i;
+export function classifyUserAgent(ua: string | null | undefined): string {
+  if (!ua) return "unknown";
+  if (/Claude-User|ClaudeBot|anthropic/i.test(ua)) return "claude";
+  if (/UA-Starlink-Extension|starlink-tracker-ext/i.test(ua)) return "extension";
+  if (BOT_UA.test(ua)) return "bot";
+  if (/Mozilla|AppleWebKit|Gecko|Chrome|Safari|Firefox/i.test(ua)) return "browser";
+  return "unknown";
+}
+
 /**
  * Canonical lowercase-name airline tag for metrics. Preserves Datadog history
  * (the global default has always been `airline:united`, not `airline:UA`).
@@ -166,6 +177,17 @@ export const COUNTERS = {
   // A discovery check was skipped (couldn't run the United.com scrape)
   // tags: fleet, reason (no_flights)
   FLEET_CHECK_SKIPPED: "fleet.check_skipped",
+
+  // User-facing flight lookup outcome — how often we actually answer the question.
+  // tags: endpoint (api_check|api_predict|mcp), outcome (verified_yes|verified_no|
+  //   predicted|no_data|error), confidence (high|medium|low|none), airline
+  FLIGHT_LOOKUP_RESULT: "flight.lookup_result",
+
+  // MCP tool dispatch — tags: tool, airline, outcome (success|error|unknown_tool)
+  MCP_TOOL_CALL: "mcp.tool_call",
+
+  // Route lookup fallback chain hit source — tags: source (memory|sqlite|fr24|upcoming|miss), airline
+  ROUTE_LOOKUP: "route.lookup",
 } as const;
 
 /**
@@ -188,6 +210,10 @@ export const GAUGES = {
   // Surface contradiction sweep — tags: airline, vector
   SURFACE_CONTRADICTION_TOTAL: "surface_contradiction.total",
   SURFACE_CONTRADICTION_COUNT: "surface_contradiction.count",
+
+  // Row counts for key tables, sampled with the 5-min freshness sweep.
+  // tags: table, airline (or "all" if the table has no airline column)
+  DB_TABLE_ROWS: "db.table_rows",
 } as const;
 
 /**
@@ -202,4 +228,11 @@ export const DISTRIBUTIONS = {
   // Vendor request latency in milliseconds
   // tags: vendor, type, status
   VENDOR_DURATION_MS: "vendor.duration_ms",
+
+  // MCP tool latency in milliseconds — tags: tool, airline, outcome
+  MCP_TOOL_DURATION_MS: "mcp.tool_duration_ms",
+
+  // Distribution of probabilities served to users — surfaces cold-start floods.
+  // tags: confidence (high|medium|low), method (flight_history|fleet_prior|confirmed), airline
+  PREDICTION_PROBABILITY: "prediction.probability",
 } as const;

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -7,13 +7,22 @@
  * Naming Convention: starlink.{category}.{action}
  *
  * Tag cardinality budget (keep each tag ≤ ~20 values):
- *   airline:         united (auto-applied globally via tracer.init)  (1, future: N)
+ *   airline:         united | hawaiian | alaska | qatar | unmapped | unknown  (~6)
+ *   tenant:          UA | HA | AS | QR | ALL  (~5) — used on http.* only; the
+ *                    hub host serves all carriers under scope ALL, which isn't
+ *                    an airline, so http metrics carry tenant instead of airline.
  *   fleet:           express | mainline | unknown                    (3)
  *   aircraft_type:   normalized families (B737-800, E175, etc)      (~19)
- *   wifi_provider:   starlink | viasat | panasonic | thales | none | unknown  (6)
+ *   wifi_provider:   starlink | viasat | panasonic | thales | none | other | unknown  (7)
  *   starlink_status: confirmed | negative | unknown                  (3)
- *   vendor:          fr24 | flightaware | united                     (3)
- *   status:          success | error | rate_limited | timeout | ...  (~7)
+ *   vendor:          fr24 | flightaware | united | qatar | alaska    (5)
+ *   status:          success | error | rate_limited | timeout | killed |
+ *                    exit_error | parse_error | spawn_error | partial |
+ *                    aborted | scrape_error                          (~14)
+ *   result:          success | error | aircraft_mismatch | tail_unknown  (4)
+ *   client_class:    bot | claude | extension | browser | unknown    (5)
+ *   confidence:      high | medium | low | none                      (4)
+ *   outcome:         verified_yes | verified_no | predicted | no_data | error  (5)
  */
 
 import { AIRLINES } from "../airlines/registry";
@@ -140,32 +149,34 @@ export function normalizeAirlineTag(code: string | null | undefined): string {
  */
 export const COUNTERS = {
   // Scraper events
-  SCRAPER_SYNC: "scraper.sync", // tags: source
-  PLANES_DISCOVERED: "planes.discovered", // tags: source
+  SCRAPER_SYNC: "scraper.sync", // tags: source, airline, status (success|partial|aborted|error)
+  PLANES_DISCOVERED: "planes.discovered", // tags: source, airline
 
   // New Starlink installation detected on an aircraft
   // tags: fleet, aircraft_type
   PLANES_STARLINK_DETECTED: "planes.starlink_detected",
 
-  // United.com verification check outcome
-  // tags: result (success|error|aircraft_mismatch), fleet, aircraft_type, wifi_provider
+  // Per-tail verification check outcome
+  // tags: result (success|error|aircraft_mismatch|tail_unknown), fleet,
+  //   aircraft_type, wifi_provider, source (united|alaska), airline
   VERIFICATION_CHECK: "verification.check",
 
   // External API calls
-  // tags: vendor (fr24|flightaware|united), type, status
+  // tags: vendor (fr24|flightaware|united|qatar|alaska), type, status
   // united status values: success | timeout | killed | exit_error | parse_error | spawn_error
   // fr24/flightaware status values: success | error | rate_limited
+  // qatar status values: success | error | partial
   VENDOR_REQUEST: "vendor.request",
 
   // HTTP requests
-  // tags: method, route (allowlisted), status_code
+  // tags: method, route (allowlisted), status_code, tenant, client_class
   HTTP_REQUEST: "http.request",
 
   // Per-IP rate limit triggered on /api/* — tags: route, tenant
   HTTP_RATE_LIMITED: "http.rate_limited",
 
   // united_fleet.starlink_status changed (consensus verdict flipped)
-  // tags: fleet, from (confirmed|negative|unknown), to
+  // tags: fleet, from (confirmed|negative|unknown), to, airline
   FLEET_STATUS_CHANGE: "fleet.status_change",
 
   // Consensus verdict disagrees with the Google Sheet's wifi claim
@@ -221,7 +232,7 @@ export const GAUGES = {
  */
 export const DISTRIBUTIONS = {
   // Fleet size snapshot, emitted per heartbeat.
-  // tags: fleet, starlink_status (confirmed|negative|unknown)
+  // tags: fleet, starlink_status (confirmed|negative|unknown), airline
   // Graph as sum-by-fleet-and-status to see rollout progress over time.
   FLEET_PLANES: "fleet.planes",
 

--- a/src/observability/tracer.ts
+++ b/src/observability/tracer.ts
@@ -2,11 +2,7 @@
  * Datadog APM Tracer Module
  *
  * IMPORTANT: This module must be imported FIRST in server.ts before any other imports.
- *
- * Bun Compatibility Notes:
- * - dd-trace works with Bun v1.1.6+ but with limitations
- * - Automatic instrumentation does NOT work - must use manual tracing
- * - profiling and runtimeMetrics must be disabled
+ * profiling and runtimeMetrics must stay disabled under Bun.
  */
 
 export type Span = import("dd-trace").Span;
@@ -23,6 +19,7 @@ interface TracerLike {
   inject(context: unknown, format: unknown, record: TraceContextCarrier): void;
   scope(): { active(): Span | null };
   trace<T>(name: string, fn: (span: Span) => T | Promise<T>): T | Promise<T>;
+  use(plugin: string, config?: Record<string, unknown>): TracerLike;
 }
 
 const isEnabled = process.env.DD_TRACE_ENABLED === "true";
@@ -48,6 +45,9 @@ const noopTracer: TracerLike = {
   trace(_name, fn) {
     return fn(noopSpan);
   },
+  use(_plugin, _config) {
+    return noopTracer;
+  },
 };
 
 let tracer: TracerLike = noopTracer;
@@ -63,16 +63,21 @@ if (isEnabled) {
     service: process.env.DD_SERVICE || "ua-starlink-tracker",
     env: process.env.DD_ENV || "development",
     version: process.env.DD_VERSION || "unknown",
-    tags: {
-      airline: process.env.AIRLINE || "united",
-    },
+    // No global `airline` tag: DogStatsD concatenates global + per-call tags
+    // (airline:hawaiian,united). The default is injected per-call in metrics.ts.
     logInjection: true,
     profiling: false,
     runtimeMetrics: false,
     startupLogs: true,
+    // Disable auto-instrumentation by default — `net`/`dns` plugins trace
+    // Playwright pipe FDs (tcp.connect localhost:0 noise). Re-enable only fetch.
+    plugins: false,
   });
 
   tracer = ddTracer as unknown as TracerLike;
+  // Outbound API latency is useful, but Qatar ingester emits ~6.7k spans/day —
+  // sample heavily; vendor.request counter keeps full-rate success/error data.
+  tracer.use("fetch", { sampleRate: 0.1 });
   logFormat = ddFormats.LOG;
 }
 

--- a/src/observability/tracer.ts
+++ b/src/observability/tracer.ts
@@ -75,9 +75,12 @@ if (isEnabled) {
   });
 
   tracer = ddTracer as unknown as TracerLike;
-  // Outbound API latency is useful, but Qatar ingester emits ~6.7k spans/day —
-  // sample heavily; vendor.request counter keeps full-rate success/error data.
-  tracer.use("fetch", { sampleRate: 0.1 });
+  // The Qatar schedule ingester hits one endpoint ~6.7k times/day; blocklist it
+  // (the fetch plugin has no per-plugin sampleRate). vendor.request keeps
+  // full-rate success/error/latency for those calls.
+  tracer.use("fetch", {
+    blocklist: [/qoreservices\.qatarairways\.com/],
+  });
   logFormat = ddFormats.LOG;
 }
 

--- a/src/scripts/alaska-verifier.ts
+++ b/src/scripts/alaska-verifier.ts
@@ -191,9 +191,24 @@ export function startAlaskaVerifier(): void {
   );
 
   let cursor = 0;
-  const tick = () => {
+  const tick = async () => {
     const airline = targets[cursor % targets.length];
     cursor++;
+    // Most ticks find nothing to verify — skip span creation on no-op runs.
+    let target: ReturnType<typeof getNextAlaskaVerifyTarget> = null;
+    try {
+      const db = initializeDatabase();
+      try {
+        target = getNextAlaskaVerifyTarget(db, airline);
+      } finally {
+        db.close();
+      }
+    } catch (e) {
+      logError(`alaska-verifier ${airline} pre-check failed`, e);
+      return;
+    }
+    if (!target) return;
+
     return withSpan(
       "alaska_verifier.run",
       async (span) => {

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -27,6 +27,39 @@ const FRESHNESS_QUERIES: Record<FreshnessJob, string> = {
     GROUP BY airline`,
 };
 
+// Tables sampled by the row-count gauge. flight_routes/qatar_schedule have no
+// airline column — those report under airline:all.
+const ROW_COUNT_TABLES: Array<{ table: string; hasAirline: boolean }> = [
+  { table: "upcoming_flights", hasAirline: true },
+  { table: "starlink_verification_log", hasAirline: true },
+  { table: "departure_log", hasAirline: true },
+  { table: "flight_routes", hasAirline: false },
+  { table: "qatar_schedule", hasAirline: false },
+];
+
+function emitRowCounts(db: Database): void {
+  for (const { table, hasAirline } of ROW_COUNT_TABLES) {
+    try {
+      if (hasAirline) {
+        const rows = db
+          .query(`SELECT airline, COUNT(*) AS cnt FROM ${table} GROUP BY airline`)
+          .all() as Array<{ airline: string; cnt: number }>;
+        for (const row of rows) {
+          metrics.gauge(GAUGES.DB_TABLE_ROWS, row.cnt, {
+            table,
+            airline: normalizeAirlineTag(row.airline),
+          });
+        }
+      } else {
+        const row = db.query(`SELECT COUNT(*) AS cnt FROM ${table}`).get() as { cnt: number };
+        metrics.gauge(GAUGES.DB_TABLE_ROWS, row.cnt, { table, airline: "all" });
+      }
+    } catch (err) {
+      logError(`Row count query failed for table=${table}`, err);
+    }
+  }
+}
+
 export function emitDataFreshness(db: Database): void {
   const now = Math.floor(Date.now() / 1000);
   for (const [job, sql] of Object.entries(FRESHNESS_QUERIES)) {
@@ -44,6 +77,7 @@ export function emitDataFreshness(db: Database): void {
       logError(`Freshness query failed for job=${job}`, err);
     }
   }
+  emitRowCounts(db);
 }
 
 export function startFreshnessEmitter(db: Database): void {

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -337,11 +337,7 @@ async function verifyPlane(
           info(
             `STATUS CHANGE: ${plane.tail_number} ${prevStatus} → ${starlinkStatus} (${consensus?.reason ?? "n/a"})`
           );
-          metrics.increment(COUNTERS.FLEET_STATUS_CHANGE, {
-            fleet: fleetTag,
-            from: prevStatus,
-            to: starlinkStatus,
-          });
+          // FLEET_STATUS_CHANGE is emitted at the DB write site (updateFleetVerificationResult).
           emitFleetSnapshot(db);
         }
 

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -26,7 +26,9 @@ import {
   DISTRIBUTIONS,
   metrics,
   normalizeAircraftType,
+  normalizeAirlineTag,
   normalizeFleet,
+  normalizeStarlinkStatus,
   normalizeWifiProvider,
   withSpan,
 } from "../observability";
@@ -55,7 +57,8 @@ function emitFleetSnapshot(db: Database) {
   for (const row of breakdown) {
     metrics.distribution(DISTRIBUTIONS.FLEET_PLANES, row.cnt, {
       fleet: normalizeFleet(row.fleet),
-      starlink_status: row.starlink_status || "unknown",
+      starlink_status: normalizeStarlinkStatus(row.starlink_status),
+      airline: normalizeAirlineTag("UA"),
     });
   }
 }
@@ -267,6 +270,8 @@ async function verifyPlane(
           fleet: fleetTag,
           aircraft_type: aircraftTypeTag,
           wifi_provider: wifiProviderTag,
+          source: "united",
+          airline: normalizeAirlineTag("UA"),
         };
 
         // Consensus includes the just-logged observation. The status is driven
@@ -401,6 +406,8 @@ async function verifyPlane(
           fleet: fleetTag,
           aircraft_type: aircraftTypeTag,
           wifi_provider: "unknown",
+          source: "united",
+          airline: normalizeAirlineTag("UA"),
         });
 
         logVerification(db, {

--- a/src/scripts/fleet-sync.ts
+++ b/src/scripts/fleet-sync.ts
@@ -68,13 +68,14 @@ export async function syncFleetFromFR24(
         if (!scrapeResult.success) {
           const err = scrapeResult.error || "FR24 scrape failed";
           logError(`FR24 scrape failed (${cfg.code}/${src.slug})`, err);
-          span.setTag("error", true);
           if (i === 0) {
+            // Only mainline failure is a full-span error — regional gaps are partial.
+            span.setTag("error", true);
             result.error = err;
             return result;
           }
-          // Regional carrier failed — keep mainline result, note the partial.
           result.error = `partial: ${src.slug} ${err}`;
+          span.setTag("partial", true);
           continue;
         }
         info(`FR24 returned ${scrapeResult.aircraft.length} aircraft for ${cfg.code}/${src.slug}`);

--- a/src/scripts/fleet-sync.ts
+++ b/src/scripts/fleet-sync.ts
@@ -72,6 +72,11 @@ export async function syncFleetFromFR24(
             // Only mainline failure is a full-span error — regional gaps are partial.
             span.setTag("error", true);
             result.error = err;
+            metrics.increment(COUNTERS.SCRAPER_SYNC, {
+              source: "fr24",
+              airline: airlineTag,
+              status: "error",
+            });
             return result;
           }
           result.error = `partial: ${src.slug} ${err}`;
@@ -93,6 +98,11 @@ export async function syncFleetFromFR24(
         result.error = `Suspiciously low aircraft count: ${allAircraft.length} (expected ${cfg.minFleetSanity}+)`;
         logError(`FR24 sync aborted (${cfg.code})`, result.error);
         span.setTag("error", true);
+        metrics.increment(COUNTERS.SCRAPER_SYNC, {
+          source: "fr24",
+          airline: airlineTag,
+          status: "aborted",
+        });
         return result;
       }
 
@@ -133,7 +143,11 @@ export async function syncFleetFromFR24(
 
         span.setTag("planes.new", result.new);
         span.setTag("planes.updated", result.updated);
-        metrics.increment(COUNTERS.SCRAPER_SYNC, { source: "fr24", airline: airlineTag });
+        metrics.increment(COUNTERS.SCRAPER_SYNC, {
+          source: "fr24",
+          airline: airlineTag,
+          status: result.error ? "partial" : "success",
+        });
 
         info(`FR24 sync complete (${cfg.code}): ${result.new} new, ${result.updated} updated`);
       } finally {
@@ -143,6 +157,11 @@ export async function syncFleetFromFR24(
       result.error = err instanceof Error ? err.message : String(err);
       logError(`FR24 sync error (${cfg.code})`, result.error);
       span.setTag("error", true);
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "fr24",
+        airline: airlineTag,
+        status: "error",
+      });
     }
 
     return result;

--- a/src/scripts/precision-backtest.ts
+++ b/src/scripts/precision-backtest.ts
@@ -18,7 +18,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { metrics } from "../observability/metrics";
+import { GAUGES, metrics, normalizeAirlineTag } from "../observability/metrics";
 import { info } from "../utils/logger";
 
 interface CallBucket {
@@ -136,22 +136,26 @@ export function computePrecision(db: Database, windowDays = 30): PrecisionResult
 }
 
 export function emitPrecisionGauges(r: PrecisionResult) {
-  const base = { airline: "united", window: `${r.windowDays}d` };
+  const base = { airline: normalizeAirlineTag("UA"), window: `${r.windowDays}d` };
   for (const [call, b] of [
     ["yes", r.yes],
     ["no", r.no],
   ] as const) {
-    metrics.gauge("precision.firm_call", b.precision, { ...base, call });
-    metrics.gauge("precision.firm_call.n", b.n, { ...base, call });
-    metrics.gauge("precision.firm_call.miss", b.swapMisses, { ...base, call, cause: "swap" });
-    metrics.gauge("precision.firm_call.miss", b.staleMisses, { ...base, call, cause: "stale" });
-    metrics.gauge("precision.firm_call.miss", b.unattributedMisses, {
+    metrics.gauge(GAUGES.PRECISION_FIRM_CALL, b.precision, { ...base, call });
+    metrics.gauge(GAUGES.PRECISION_FIRM_CALL_N, b.n, { ...base, call });
+    metrics.gauge(GAUGES.PRECISION_FIRM_CALL_MISS, b.swapMisses, { ...base, call, cause: "swap" });
+    metrics.gauge(GAUGES.PRECISION_FIRM_CALL_MISS, b.staleMisses, {
+      ...base,
+      call,
+      cause: "stale",
+    });
+    metrics.gauge(GAUGES.PRECISION_FIRM_CALL_MISS, b.unattributedMisses, {
       ...base,
       call,
       cause: "unattributed",
     });
   }
-  metrics.gauge("precision.legacy_prior_pct", r.legacyPriorPct, base);
+  metrics.gauge(GAUGES.PRECISION_LEGACY_PRIOR_PCT, r.legacyPriorPct, base);
 }
 
 function fmt(b: CallBucket, label: string) {

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -431,7 +431,7 @@ export function predictFlight(reader: ScopedReader, flightNumber: string): Predi
 /** Common fields across all prediction output shapes. */
 type BasePrediction = Pick<
   Prediction,
-  "flight_number" | "probability" | "confidence" | "n_observations"
+  "flight_number" | "probability" | "confidence" | "n_observations" | "method"
 >;
 
 export interface RouteFlightPrediction extends BasePrediction {

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -20,6 +20,7 @@ import {
   COUNTERS,
   metrics,
   normalizeAircraftType,
+  normalizeAirlineTag,
   normalizeFleet,
   normalizeWifiProvider,
   withSpan,
@@ -274,6 +275,8 @@ export async function verifyPlaneStarlink(
           fleet: fleetTag,
           aircraft_type: aircraftTypeTag,
           wifi_provider: wifiProviderTag,
+          source: "united",
+          airline: normalizeAirlineTag("UA"),
         };
         span.setTag("wifi_provider", wifiProviderTag);
 
@@ -324,6 +327,8 @@ export async function verifyPlaneStarlink(
           fleet: fleetTag,
           aircraft_type: aircraftTypeTag,
           wifi_provider: "unknown",
+          source: "united",
+          airline: normalizeAirlineTag("UA"),
         });
         span.setTag("error", true);
         span.setTag("result", "error");

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -355,6 +355,16 @@ export async function verifyPlaneStarlink(
  * Run verification for planes that need checking
  * Fetches data from unitedstarlinktracker.com API
  */
+// Cheap pre-flight so the background loop can skip span creation on no-op ticks.
+export function hasVerificationWork(maxPlanes: number, forceAll = false): boolean {
+  const db = initializeDatabase();
+  try {
+    return getPlanesNeedingVerification(db, maxPlanes, forceAll).length > 0;
+  } finally {
+    db.close();
+  }
+}
+
 export async function runVerificationBatch(
   maxPlanes = 5,
   delayMs = VERIFICATION_DELAY_MS,
@@ -480,11 +490,19 @@ export function startStarlinkVerifier() {
     runCount++;
 
     try {
+      // Heartbeat log every 10 minutes to show scheduler is alive
+      const now = Date.now();
+      if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
+        verifierLog.info(`Heartbeat: ${runCount} runs completed, scheduler healthy`);
+        lastHeartbeat = now;
+      }
+
+      // ~97% of ticks find nothing to do — skip span creation on no-op runs.
+      if (!hasVerificationWork(PLANES_PER_RUN)) return;
+
       await withSpan(
         "starlink_verifier.run",
         async (span) => {
-          span.setTag("job.type", "background");
-
           const stats = await runVerificationBatch(PLANES_PER_RUN, VERIFICATION_DELAY_MS);
 
           span.setTag("checked", stats.checked);
@@ -495,13 +513,6 @@ export function startStarlinkVerifier() {
             verifierLog.info(
               `Batch complete: ${stats.starlink} Starlink, ${stats.notStarlink} not, ${stats.errors} errors`
             );
-          }
-
-          // Heartbeat log every 10 minutes to show scheduler is alive
-          const now = Date.now();
-          if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
-            verifierLog.info(`Heartbeat: ${runCount} runs completed, scheduler healthy`);
-            lastHeartbeat = now;
           }
         },
         { "job.type": "background" }

--- a/src/scripts/surface-sweep.ts
+++ b/src/scripts/surface-sweep.ts
@@ -17,7 +17,7 @@
 
 import { Database } from "bun:sqlite";
 import { computeWifiConsensus } from "../database/database";
-import { metrics } from "../observability/metrics";
+import { GAUGES, metrics, normalizeAirlineTag } from "../observability/metrics";
 import { info } from "../utils/logger";
 
 type Verdict = "starlink" | "not-starlink" | "unknown";
@@ -101,10 +101,10 @@ export function computeSurfaceContradictions(db: Database, airline = "UA"): Swee
 }
 
 export function emitSweepGauges(r: SweepResult) {
-  const base = { airline: "united" };
-  metrics.gauge("surface_contradiction.total", r.contradictions.length, base);
+  const base = { airline: normalizeAirlineTag("UA") };
+  metrics.gauge(GAUGES.SURFACE_CONTRADICTION_TOTAL, r.contradictions.length, base);
   for (const v of VECTORS) {
-    metrics.gauge("surface_contradiction.count", r.byVector[v], { ...base, vector: v });
+    metrics.gauge(GAUGES.SURFACE_CONTRADICTION_COUNT, r.byVector[v], { ...base, vector: v });
   }
 }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -325,11 +325,7 @@ function recordPrediction(
   pred: { probability: number; confidence: "high" | "medium" | "low"; method: string },
   airlineCode: string
 ): void {
-  const method = pred.method.startsWith("fleet_prior")
-    ? "fleet_prior"
-    : pred.method.startsWith("flight_history")
-      ? "flight_history"
-      : "confirmed";
+  const method = pred.method.startsWith("fleet_prior") ? "fleet_prior" : "flight_history";
   metrics.distribution(DISTRIBUTIONS.PREDICTION_PROBABILITY, pred.probability, {
     confidence: pred.confidence,
     method,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1364,8 +1364,10 @@ export function createApp(db: Database): App {
     const reader: ScopedReader = getReader(tenantScope(tenant));
     const ctx: RequestContext = { req, url, site, tenant, reader, getReader };
 
+    // "web.request" not "http.request" — the latter collides with dd-trace's
+    // auto-instrumented outbound fetch spans. `type: web` marks it service-entry.
     return withSpan(
-      "http.request",
+      "web.request",
       async (span) => {
         span.setTag("http.method", req.method);
         span.setTag("http.route", route);
@@ -1392,7 +1394,7 @@ export function createApp(db: Database): App {
         }
         return response;
       },
-      { "http.route": route }
+      { "span.type": "web" }
     );
   }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -35,7 +35,14 @@ import FleetPage from "../components/fleet-page";
 import McpPage from "../components/mcp-page";
 import Page from "../components/page";
 import RoutePlannerPage from "../components/route-planner-page";
-import { COUNTERS, metrics, withSpan } from "../observability";
+import {
+  COUNTERS,
+  DISTRIBUTIONS,
+  classifyUserAgent,
+  metrics,
+  normalizeAirlineTag,
+  withSpan,
+} from "../observability";
 import { compareRoute, planItinerary, predictFlight } from "../scripts/starlink-predictor";
 import type { ApiResponse, Flight } from "../types";
 import { CONTENT_TYPES, SECURITY_HEADERS } from "../utils/constants";
@@ -295,6 +302,40 @@ const apiFleetSummary: Handler = ({ req, getReader }) => {
   });
 };
 
+// Single product-truth metric: how often a user actually got an answer.
+type LookupOutcome = "verified_yes" | "verified_no" | "predicted" | "no_data" | "error";
+type LookupConfidence = "high" | "medium" | "low" | "none";
+function recordFlightLookup(
+  endpoint: "api_check" | "api_predict" | "mcp",
+  outcome: LookupOutcome,
+  confidence: LookupConfidence,
+  airlineCode: string
+): void {
+  metrics.increment(COUNTERS.FLIGHT_LOOKUP_RESULT, {
+    endpoint,
+    outcome,
+    confidence,
+    airline: normalizeAirlineTag(airlineCode),
+  });
+}
+
+// Surfaces what's actually served — a flood of 2% fleet-prior cold-starts
+// is invisible in success-rate metrics but is a real product problem.
+function recordPrediction(
+  pred: { probability: number; confidence: "high" | "medium" | "low"; method: string },
+  airlineCode: string
+): void {
+  const method = pred.method.startsWith("fleet_prior")
+    ? "fleet_prior"
+    : pred.method.startsWith("flight_history")
+      ? "flight_history"
+      : "confirmed";
+  metrics.distribution(DISTRIBUTIONS.PREDICTION_PROBABILITY, pred.probability, {
+    confidence: pred.confidence,
+    method,
+    airline: normalizeAirlineTag(airlineCode),
+  });
+}
 /**
  * QR's data shape doesn't fit the upcoming_flights → starlink_planes JOIN that
  * other carriers use (no per-tail signal from QR's flight-status API). Serve
@@ -324,6 +365,7 @@ function apiCheckFlightQatar(
   const rows = reader.getQatarScheduleByFlight(variants, startOfDay, endOfDay);
 
   if (rows.length === 0) {
+    recordFlightLookup("api_check", "no_data", "none", cfg.code);
     return new Response(
       JSON.stringify({
         hasStarlink: null,
@@ -350,18 +392,22 @@ function apiCheckFlightQatar(
     hasStarlink = true;
     confidence = "verified";
     reason = `${distinctEquipment.join(", ")} — Qatar Airways completed Starlink installation on this aircraft type.`;
+    recordFlightLookup("api_check", "verified_yes", "high", cfg.code);
   } else if (allNone) {
     hasStarlink = false;
     confidence = "verified";
     reason = `${distinctEquipment.join(", ")} — not part of Qatar's Starlink rollout.`;
+    recordFlightLookup("api_check", "verified_no", "high", cfg.code);
   } else if (anyRolling) {
     hasStarlink = null;
     confidence = "rolling";
     reason = `${distinctEquipment.join(", ")} — Qatar's 787 Starlink rollout is in progress; this aircraft may or may not be equipped yet.`;
+    recordFlightLookup("api_check", "predicted", "low", cfg.code);
   } else {
     hasStarlink = null;
     confidence = "mixed";
     reason = `Mixed equipment scheduled (${distinctEquipment.join(", ")}) — outcome depends on which aircraft operates.`;
+    recordFlightLookup("api_check", "predicted", "low", cfg.code);
   }
 
   return new Response(
@@ -434,12 +480,17 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
     if (segments !== null) {
       const starlinkSegs = segments.filter((s) => s.hasStarlink);
       if (starlinkSegs.length > 0) {
+        const allVerified = starlinkSegs.every((s) => s.confidence === "verified");
+        recordFlightLookup(
+          "api_check",
+          allVerified ? "verified_yes" : "predicted",
+          allVerified ? "high" : "medium",
+          cfg.code
+        );
         return new Response(
           JSON.stringify({
             hasStarlink: true,
-            confidence: starlinkSegs.every((s) => s.confidence === "verified")
-              ? "verified"
-              : "likely",
+            confidence: allVerified ? "verified" : "likely",
             method: "fr24_tail_lookup",
             flights: starlinkSegs.map((s) => ({
               tail_number: s.tail_number,
@@ -460,6 +511,7 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
         );
       }
       if (segments.length > 0) {
+        recordFlightLookup("api_check", "verified_no", "medium", cfg.code);
         return new Response(
           JSON.stringify({
             hasStarlink: false,
@@ -471,6 +523,7 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
         );
       }
     }
+    recordFlightLookup("api_check", "no_data", "none", cfg.code);
     return new Response(
       JSON.stringify({
         hasStarlink: false,
@@ -481,11 +534,11 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
     );
   }
 
+  const allVerified = matchingFlights.every((f) => f.verified_wifi === "Starlink");
+  recordFlightLookup("api_check", "verified_yes", allVerified ? "high" : "medium", cfg.code);
   const response = {
     hasStarlink: true,
-    confidence: matchingFlights.every((f) => f.verified_wifi === "Starlink")
-      ? "verified"
-      : "likely",
+    confidence: allVerified ? "verified" : "likely",
     flights: matchingFlights.map((flight) => ({
       tail_number: flight.tail_number,
       aircraft_type: flight.aircraft_type,
@@ -562,11 +615,13 @@ const apiCheckAnyFlight: Handler = ({ req, url, reader, getReader, tenant }) => 
 
   if (matching.length > 0) {
     const f = matching[0];
+    const verified = f.verified_wifi === "Starlink";
+    recordFlightLookup("api_check", "verified_yes", verified ? "high" : "medium", cfg.code);
     return new Response(
       JSON.stringify({
         hasStarlink: true,
         airline: cfg.name,
-        confidence: f.verified_wifi === "Starlink" ? "verified" : "likely",
+        confidence: verified ? "verified" : "likely",
         reason: `${f.tail_number} (${f.aircraft_type}) — ${f.departure_airport} → ${f.arrival_airport}`,
         flights: matching.map((m) => ({
           tail_number: m.tail_number,
@@ -581,6 +636,7 @@ const apiCheckAnyFlight: Handler = ({ req, url, reader, getReader, tenant }) => 
   }
 
   if (cfg.routeTypeRule) {
+    recordFlightLookup("api_check", "no_data", "none", cfg.code);
     return new Response(
       JSON.stringify({
         hasStarlink: null,
@@ -595,6 +651,8 @@ const apiCheckAnyFlight: Handler = ({ req, url, reader, getReader, tenant }) => 
   // No schedule row and no type rule — fall back to historical probability
   // rather than a confident "No Starlink" (upcoming_flights only covers ~47h).
   const pred = predictFlight(getReader(cfg.code), normalized);
+  recordFlightLookup("api_check", "predicted", pred.confidence, cfg.code);
+  recordPrediction(pred, cfg.code);
   return new Response(
     JSON.stringify({
       hasStarlink: null,
@@ -647,6 +705,13 @@ const apiPredictFlight: Handler = ({ req, url, reader, tenant }) => {
   // TODO Phase-2: hub should infer airline from prefix; predictor itself is still UA-only.
   const cfg = tenantConfig(tenant) ?? AIRLINES.UA;
   const pred = predictFlight(reader, ensureAirlinePrefix(cfg, flightNumber));
+  recordFlightLookup(
+    "api_predict",
+    pred.n_observations > 0 ? "predicted" : "no_data",
+    pred.confidence,
+    cfg.code
+  );
+  recordPrediction(pred, cfg.code);
   return new Response(
     JSON.stringify({
       flight_number: pred.flight_number,
@@ -1390,6 +1455,7 @@ export function createApp(db: Database): App {
             route: m.route === "/static" ? "/static/*" : m.route,
             status_code: response.status,
             tenant: tenantScope(tenant),
+            client_class: classifyUserAgent(ua),
           });
         }
         return response;


### PR DESCRIPTION
**Tracer & span hygiene**
- Rename the inbound HTTP span from `http.request` → `web.request` — it was colliding with dd-trace's auto-instrumented outbound `fetch()` spans, inflating apparent inbound error rates to ~46% with FR24/Qatar fetch failures
- Replace the auto-instrument plugin set with an explicit allowlist (`fetch` only, sampled at 10%) — kills `tcp.connect localhost:0` noise from Playwright FDs and cuts ~6.7K outbound spans/day from the Qatar ingester
- Skip no-op verifier/discovery loop spans — ~2.4K spans/day saved, the heartbeat log still fires
- Move the default `airline` tag from `tracer.init()` (global, gets concatenated → `airline:hawaiian,united`) to a per-call default in the metrics helpers

**Tag correctness**
- All `verification.check` emitters now set `airline` and `source`
- `precision.firm_call*` and `surface_contradiction.*` registered in the metric registry, airline tag normalized
- `normalizeAirlineTag()` falls back to `unmapped` instead of unbounded raw codes
- `fleet.planes` status tag goes through a normalizer
- Cardinality docs in `metrics.ts` updated to match what's actually emitted

**New product/operational metrics**
- `flight.lookup_result` {endpoint, outcome, confidence, airline} — surfaces how often we actually answer the user's question vs. fall back to a prior
- `mcp.tool_call` {tool, airline, outcome} + `mcp.tool_duration_ms` — which MCP tools get used; `tool` tag is bounded to known tool names
- `db.table_rows` {table, airline} on the 5-min freshness sweep
- `prediction.probability` distribution {confidence, method, airline} — what confidence we're actually serving
- `route.lookup` {source} — cache hit/miss/source for the 4-layer route lookup
- `http.request.client_class` tag (browser/bot/claude/extension)
- `fleet.status_change` emitted at every `starlink_status` mutation site, not just discovery