### PR TITLE
Redesign hub landing page: per-segment framing, dense comparison

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,62 @@
       .text-accent { color: var(--color-accent); }
       .text-white { color: #ffffff; }
 
+      /* Tooltip — CSS-only, works on hover and tap-to-focus. Trigger gets a
+         dotted underline as the affordance; content comes from data-tip. */
+      .tip {
+        position: relative;
+        text-decoration: underline dotted;
+        text-decoration-color: var(--color-text-muted);
+        text-underline-offset: 3px;
+        cursor: help;
+      }
+      .tip::after {
+        content: attr(data-tip);
+        position: absolute;
+        bottom: calc(100% + 8px);
+        left: 50%;
+        transform: translateX(-50%);
+        background: var(--color-surface-elevated);
+        color: var(--color-text-primary);
+        border: 1px solid var(--color-border);
+        border-radius: 6px;
+        padding: 6px 9px;
+        font-family: var(--font-mono);
+        font-size: 11px;
+        line-height: 1.4;
+        white-space: normal;
+        width: max-content;
+        max-width: 260px;
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.5);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 120ms ease, visibility 120ms;
+        pointer-events: none;
+        z-index: 50;
+      }
+      .tip::before {
+        content: '';
+        position: absolute;
+        bottom: calc(100% + 3px);
+        left: 50%;
+        transform: translateX(-50%);
+        border: 5px solid transparent;
+        border-top-color: var(--color-border);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 120ms ease, visibility 120ms;
+        z-index: 50;
+      }
+      .tip:hover::after, .tip:hover::before,
+      .tip:focus::after, .tip:focus::before,
+      .tip:focus-within::after, .tip:focus-within::before {
+        opacity: 1;
+        visibility: visible;
+      }
+      /* Right-aligned variant — tooltip flows leftward to stay in viewport. */
+      .tip-l::after { left: auto; right: 0; transform: none; }
+      .tip-l::before { left: auto; right: 12px; transform: none; }
+
       /* Glow effects */
       .glow-accent {
         box-shadow: 0 0 20px rgba(14, 165, 233, 0.15);

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -31,8 +31,23 @@ INSERT OR IGNORE INTO starlink_planes (aircraft, wifi, sheet_gid, sheet_type, Da
 
 INSERT OR IGNORE INTO upcoming_flights (tail_number, flight_number, departure_airport, arrival_airport, departure_time, arrival_time, last_updated, airline)
   VALUES ('N999HA', 'HA9999', 'HNL', 'LAX', 1774200000, 1774220000, 1774190000, 'HA'),
+         -- Establish HA's network footprint so airlineServesAirports() gates the
+         -- routeTypeRule correctly (compare-route tests need SFO + interisland).
+         ('N999HA', 'HA0011', 'HNL', 'SFO', 1774200000, 1774220000, 1774190000, 'HA'),
+         ('N999HA', 'HA0012', 'HNL', 'OGG', 1774200000, 1774206000, 1774190000, 'HA'),
+         ('N999HA', 'HA0013', 'HNL', 'KOA', 1774200000, 1774206000, 1774190000, 'HA'),
          ('N644AS', 'AS118',  'SEA', 'SAN', 1774200000, 1774215000, 1774190000, 'AS'),
-         ('A7-TST', 'QR9999', 'DOH', 'LHR', 1774200000, 1774230000, 1774190000, 'QR');
+         ('A7-TST', 'QR9999', 'DOH', 'LHR', 1774200000, 1774230000, 1774190000, 'QR'),
+         -- compareRoute fixtures: UA must touch SEA + AUS (no direct SFO-AUS so
+         -- inferred_absent fires); SEA-SFO needs both mainline and express flight
+         -- numbers; ORD-LAX needs mainline only. AS needs SFO + AUS reach.
+         ('N12345', 'UA499',  'SEA', 'SFO', 1774200000, 1774206000, 1774190000, 'UA'),
+         ('N12345', 'UA5301', 'SEA', 'SFO', 1774200000, 1774206000, 1774190000, 'UA'),
+         ('N12345', 'UA1967', 'ORD', 'LAX', 1774200000, 1774215000, 1774190000, 'UA'),
+         ('N12345', 'UA353',  'ORD', 'LAX', 1774200000, 1774215000, 1774190000, 'UA'),
+         ('N12345', 'UA4422', 'IAH', 'AUS', 1774200000, 1774203000, 1774190000, 'UA'),
+         ('N654QX', 'QX2402', 'PDX', 'SFO', 1774200000, 1774206000, 1774190000, 'AS'),
+         ('N654QX', 'QX2403', 'SAN', 'AUS', 1774200000, 1774208000, 1774190000, 'AS');
 
 -- Real HA fleet sample (subset of seed-hawaiian output) — hermetic stand-in for
 -- the live FR24 scrape so isolation tests exercise real tails without network.

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -69,6 +69,10 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
             function fleetTip(a, b){
               return esc(b.total)+' '+esc(shorten(b.label))+' aircraft in '+esc(a.shortName||a.name)+'\\u2019s fleet \\u2014 '+esc(b.equipped)+' have Starlink';
             }
+            function tip(cls, tipText, inner){
+              if (!tipText) return '<span class="'+cls+'">'+inner+'</span>';
+              return '<span class="'+cls+' tip" tabindex="0" data-tip="'+tipText+'">'+inner+'</span>';
+            }
             function renderResult(a, O, D) {
               var color = a.accentColor || '#0ea5e9';
               var inferred = a.kind === 'inferred_absent';
@@ -83,10 +87,10 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
                 var rows = (a.breakdown||[]).map(function(b,i){
                   var br = Math.round(b.pct*100);
                   var lblTip = b.hint ? 'Flight numbers '+esc(b.hint) : '';
-                  var best = i===0 && br>=50 ? ' <span class="text-[8px] px-1 py-px rounded" title="Pick a flight in this group for the best Starlink odds" style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+'">best bet</span>' : '';
+                  var best = i===0 && br>=50 ? ' '+tip('text-[8px] px-1 py-px rounded no-underline','Pick a flight in this group for the best Starlink odds','<span style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+';padding:1px 4px;border-radius:3px">best bet</span>') : '';
                   return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]">'
-                       + '<span class="text-secondary" title="'+lblTip+'">'+esc(shorten(b.label))+best+'</span>'
-                       + '<span class="text-accent" title="'+fleetTip(a,b)+'">'+esc(b.equipped)+'/'+esc(b.total)+' aircraft \\u00b7 '+br+'%</span></div>'+bar(br,color,false)+'</div>';
+                       + '<span>'+tip('text-secondary',lblTip,esc(shorten(b.label)))+best+'</span>'
+                       + tip('text-accent tip-l',fleetTip(a,b),esc(b.equipped)+'/'+esc(b.total)+' aircraft \\u00b7 '+br+'%')+'</div>'+bar(br,color,false)+'</div>';
                 }).join('');
                 return '<div class="mb-3">'+head+rows+'</div>';
               }
@@ -95,7 +99,7 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
               var pctTip = (bd0.equipped!=null) ? fleetTip(a,bd0) : '';
               var chipL = (pct < 50 && a.kind !== 'type_rule' && rp) ? pill(rp, 'try a connection', color) : '';
               return '<div class="mb-3"><div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipL+'</span>'
-                   + '<span class="text-accent" title="'+pctTip+'">'+pct+'%</span></div>'
+                   + tip('text-accent tip-l',pctTip,pct+'%')+'</div>'
                    + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar(pct,color,inferred)+'</div>';
             }
             function doCompare(origin, dest) {

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -65,24 +65,32 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
             function pill(href, txt, color) {
               return '<a href="'+esc(href)+'" class="ml-2 font-mono text-[9px] px-1.5 py-0.5 rounded-full whitespace-nowrap hover:underline" style="color:'+esc(color)+';background:color-mix(in srgb,'+esc(color)+' 14%,transparent);border:1px solid color-mix(in srgb,'+esc(color)+' 40%,transparent)">'+esc(txt)+' \\u2192</a>';
             }
+            function shorten(label){return String(label||'').replace(/\\s*Fleet$/i,'').trim();}
             function renderResult(a, O, D) {
               var color = a.accentColor || '#0ea5e9';
               var inferred = a.kind === 'inferred_absent';
               var rpHref = '/route-planner?from='+O+'&to='+D;
               if (a.kind === 'observed_mixed') {
-                var bp = a.bestPick;
-                var chipM = bp && bp.hint ? pill(rpHref, 'book '+bp.hint+' \\u2248 '+Math.round(bp.pct*100)+'%', color) : '';
-                var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipM+'</span><span class="text-accent">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
+                var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span>'
+                         + '<span class="text-accent" title="Depends on which aircraft type operates your flight">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
                          + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>';
-                var rows = (a.breakdown||[]).map(function(b){
+                var rows = (a.breakdown||[]).map(function(b,i){
                   var br = Math.round(b.pct*100);
-                  return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]"><span class="text-secondary">'+esc(b.hint||'')+'</span><span class="text-accent">'+br+'% \\u00b7 '+b.equipped+'/'+b.total+'</span></div>'+bar(br,color,false)+'</div>';
+                  var lblTip = b.hint ? esc(shorten(b.label))+' \\u2014 flight numbers '+esc(b.hint) : esc(shorten(b.label));
+                  var numTip = esc(b.equipped)+' of '+esc(b.total)+' aircraft in this group have Starlink';
+                  var best = i===0 && br>=50 ? ' <span class="text-[8px] px-1 py-px rounded" style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+'">best bet</span>' : '';
+                  return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]">'
+                       + '<span class="text-secondary cursor-help" title="'+lblTip+'">'+esc(shorten(b.label))+best+'</span>'
+                       + '<span class="text-accent cursor-help" title="'+numTip+'">'+br+'% \\u00b7 '+esc(b.equipped)+'/'+esc(b.total)+'</span></div>'+bar(br,color,false)+'</div>';
                 }).join('');
                 return '<div class="mb-3">'+head+rows+'</div>';
               }
               var pct = Math.round(a.probability*100);
+              var bd0 = (a.breakdown||[])[0]||{};
+              var pctTip = (bd0.equipped!=null) ? esc(bd0.equipped)+' of '+esc(bd0.total)+' '+esc(shorten(bd0.label||'aircraft'))+' aircraft have Starlink' : '';
               var chipL = (pct < 50 && a.kind !== 'type_rule') ? pill(rpHref, 'try a connection', color) : '';
-              return '<div class="mb-3"><div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipL+'</span><span class="text-accent">'+pct+'%</span></div>'
+              return '<div class="mb-3"><div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipL+'</span>'
+                   + '<span class="text-accent cursor-help" title="'+pctTip+'">'+pct+'%</span></div>'
                    + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar(pct,color,inferred)+'</div>';
             }
             function doCompare(origin, dest) {

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -70,6 +70,10 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
               var color = a.accentColor || '#0ea5e9';
               var inferred = a.kind === 'inferred_absent';
               var rpHref = '/route-planner?from='+O+'&to='+D;
+              if (a.kind === 'no_data') {
+                return '<div class="mb-3 opacity-60"><div class="flex justify-between items-center font-mono text-xs"><span class="text-muted">'+esc(a.name)+pill(rpHref,'check route planner',color)+'</span><span class="text-muted">\\u2014</span></div>'
+                     + '<div class="font-mono text-[10px] text-muted">No route data yet</div></div>';
+              }
               if (a.kind === 'observed_mixed') {
                 var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span>'
                          + '<span class="text-accent" title="Depends on which aircraft type operates your flight">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
@@ -81,7 +85,7 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
                   var best = i===0 && br>=50 ? ' <span class="text-[8px] px-1 py-px rounded" style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+'">best bet</span>' : '';
                   return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]">'
                        + '<span class="text-secondary cursor-help" title="'+lblTip+'">'+esc(shorten(b.label))+best+'</span>'
-                       + '<span class="text-accent cursor-help" title="'+numTip+'">'+br+'% \\u00b7 '+esc(b.equipped)+'/'+esc(b.total)+'</span></div>'+bar(br,color,false)+'</div>';
+                       + '<span class="text-accent" title="'+numTip+'">'+esc(b.equipped)+'/'+esc(b.total)+' aircraft \\u00b7 '+br+'%</span></div>'+bar(br,color,false)+'</div>';
                 }).join('');
                 return '<div class="mb-3">'+head+rows+'</div>';
               }

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -66,35 +66,36 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
               return '<a href="'+esc(href)+'" class="ml-2 font-mono text-[9px] px-1.5 py-0.5 rounded-full whitespace-nowrap hover:underline" style="color:'+esc(color)+';background:color-mix(in srgb,'+esc(color)+' 14%,transparent);border:1px solid color-mix(in srgb,'+esc(color)+' 40%,transparent)">'+esc(txt)+' \\u2192</a>';
             }
             function shorten(label){return String(label||'').replace(/\\s*Fleet$/i,'').trim();}
+            function fleetTip(a, b){
+              return esc(b.total)+' '+esc(shorten(b.label))+' aircraft in '+esc(a.shortName||a.name)+'\\u2019s fleet \\u2014 '+esc(b.equipped)+' have Starlink';
+            }
             function renderResult(a, O, D) {
               var color = a.accentColor || '#0ea5e9';
               var inferred = a.kind === 'inferred_absent';
-              var rpHref = '/route-planner?from='+O+'&to='+D;
+              var rp = a.routePlannerBase ? a.routePlannerBase+'/'+O+'/'+D : null;
               if (a.kind === 'no_data') {
-                return '<div class="mb-3 opacity-60"><div class="flex justify-between items-center font-mono text-xs"><span class="text-muted">'+esc(a.name)+pill(rpHref,'check route planner',color)+'</span><span class="text-muted">\\u2014</span></div>'
+                return '<div class="mb-3 opacity-60"><div class="flex justify-between items-center font-mono text-xs"><span class="text-muted">'+esc(a.name)+(rp?pill(rp,'check route planner',color):'')+'</span><span class="text-muted">\\u2014</span></div>'
                      + '<div class="font-mono text-[10px] text-muted">No route data yet</div></div>';
               }
               if (a.kind === 'observed_mixed') {
-                var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span>'
-                         + '<span class="text-accent" title="Depends on which aircraft type operates your flight">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
+                var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span></div>'
                          + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>';
                 var rows = (a.breakdown||[]).map(function(b,i){
                   var br = Math.round(b.pct*100);
-                  var lblTip = b.hint ? esc(shorten(b.label))+' \\u2014 flight numbers '+esc(b.hint) : esc(shorten(b.label));
-                  var numTip = esc(b.equipped)+' of '+esc(b.total)+' aircraft in this group have Starlink';
-                  var best = i===0 && br>=50 ? ' <span class="text-[8px] px-1 py-px rounded" style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+'">best bet</span>' : '';
+                  var lblTip = b.hint ? 'Flight numbers '+esc(b.hint) : '';
+                  var best = i===0 && br>=50 ? ' <span class="text-[8px] px-1 py-px rounded" title="Pick a flight in this group for the best Starlink odds" style="background:color-mix(in srgb,'+esc(color)+' 18%,transparent);color:'+esc(color)+'">best bet</span>' : '';
                   return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]">'
-                       + '<span class="text-secondary cursor-help" title="'+lblTip+'">'+esc(shorten(b.label))+best+'</span>'
-                       + '<span class="text-accent" title="'+numTip+'">'+esc(b.equipped)+'/'+esc(b.total)+' aircraft \\u00b7 '+br+'%</span></div>'+bar(br,color,false)+'</div>';
+                       + '<span class="text-secondary" title="'+lblTip+'">'+esc(shorten(b.label))+best+'</span>'
+                       + '<span class="text-accent" title="'+fleetTip(a,b)+'">'+esc(b.equipped)+'/'+esc(b.total)+' aircraft \\u00b7 '+br+'%</span></div>'+bar(br,color,false)+'</div>';
                 }).join('');
                 return '<div class="mb-3">'+head+rows+'</div>';
               }
               var pct = Math.round(a.probability*100);
               var bd0 = (a.breakdown||[])[0]||{};
-              var pctTip = (bd0.equipped!=null) ? esc(bd0.equipped)+' of '+esc(bd0.total)+' '+esc(shorten(bd0.label||'aircraft'))+' aircraft have Starlink' : '';
-              var chipL = (pct < 50 && a.kind !== 'type_rule') ? pill(rpHref, 'try a connection', color) : '';
+              var pctTip = (bd0.equipped!=null) ? fleetTip(a,bd0) : '';
+              var chipL = (pct < 50 && a.kind !== 'type_rule' && rp) ? pill(rp, 'try a connection', color) : '';
               return '<div class="mb-3"><div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipL+'</span>'
-                   + '<span class="text-accent cursor-help" title="'+pctTip+'">'+pct+'%</span></div>'
+                   + '<span class="text-accent" title="'+pctTip+'">'+pct+'%</span></div>'
                    + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar(pct,color,inferred)+'</div>';
             }
             function doCompare(origin, dest) {
@@ -108,7 +109,10 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
                   var html = (d.results||[]).map(function(r){return renderResult(r,O,D)}).join('');
                   rr.innerHTML = html || '<span class="font-mono text-xs text-muted">No tracked airline shows a Starlink-equipped nonstop on '+O+' \\u21c4 '+D+' yet.</span>';
                   if (rfoot) rfoot.classList.remove('hidden');
-                  if (rplnk) rplnk.href = '/route-planner?from='+O+'&to='+D;
+                  // Hub has no route planner; the per-row chip links to whichever
+                  // airline's planner exists. Footer link goes to UA's (the only
+                  // tenant with a planner page) until the hub grows its own.
+                  if (rplnk) rplnk.href = 'https://unitedstarlinktracker.com/route-planner/'+O+'/'+D;
                 })
                 .catch(function(){ rr.textContent = 'Lookup failed.'; });
             }

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -32,7 +32,7 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
         dangerouslySetInnerHTML={{
           __html: `
           document.addEventListener('DOMContentLoaded', function() {
-            function esc(s){var d=document.createElement('div');d.textContent=String(s==null?'':s);return d.innerHTML;}
+            function esc(s){var d=document.createElement('div');d.textContent=String(s==null?'':s);return d.innerHTML.replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
             var cf = document.getElementById('hub-check-flight');
             var cr = document.getElementById('hub-check-result');
             if (cf) cf.addEventListener('submit', function(e) {
@@ -62,21 +62,27 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
               if (dotted) style = 'width:'+pct+'%;border-top:2px dotted '+esc(color)+';background:transparent';
               return '<div class="h-1.5 bg-surface-elevated rounded overflow-hidden mt-1"><div class="h-full" style="'+style+'"></div></div>';
             }
-            function renderResult(a) {
+            function pill(href, txt, color) {
+              return '<a href="'+esc(href)+'" class="ml-2 font-mono text-[9px] px-1.5 py-0.5 rounded-full whitespace-nowrap hover:underline" style="color:'+esc(color)+';background:color-mix(in srgb,'+esc(color)+' 14%,transparent);border:1px solid color-mix(in srgb,'+esc(color)+' 40%,transparent)">'+esc(txt)+' \\u2192</a>';
+            }
+            function renderResult(a, O, D) {
               var color = a.accentColor || '#0ea5e9';
               var inferred = a.kind === 'inferred_absent';
-              var chip = inferred ? ' <span class="text-[9px] px-1 py-0.5 bg-surface-elevated border border-subtle rounded text-muted">inferred</span>' : '';
+              var rpHref = '/route-planner?from='+O+'&to='+D;
               if (a.kind === 'observed_mixed') {
-                var head = '<div class="flex justify-between font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span><span class="text-accent">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
+                var bp = a.bestPick;
+                var chipM = bp && bp.hint ? pill(rpHref, 'book '+bp.hint+' \\u2248 '+Math.round(bp.pct*100)+'%', color) : '';
+                var head = '<div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipM+'</span><span class="text-accent">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
                          + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>';
                 var rows = (a.breakdown||[]).map(function(b){
-                  var bp = Math.round(b.pct*100);
-                  return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]"><span class="text-secondary">'+esc(b.hint||'')+': '+esc(b.label)+'</span><span class="text-accent">'+bp+'% ('+b.equipped+'/'+b.total+')</span></div>'+bar(bp,color,false)+'</div>';
+                  var br = Math.round(b.pct*100);
+                  return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]"><span class="text-secondary">'+esc(b.hint||'')+'</span><span class="text-accent">'+br+'% \\u00b7 '+b.equipped+'/'+b.total+'</span></div>'+bar(br,color,false)+'</div>';
                 }).join('');
                 return '<div class="mb-3">'+head+rows+'</div>';
               }
               var pct = Math.round(a.probability*100);
-              return '<div class="mb-3"><div class="flex justify-between font-mono text-xs"><span class="text-primary">'+esc(a.name)+chip+'</span><span class="text-accent">'+pct+'%</span></div>'
+              var chipL = (pct < 50 && a.kind !== 'type_rule') ? pill(rpHref, 'try a connection', color) : '';
+              return '<div class="mb-3"><div class="flex justify-between items-center font-mono text-xs"><span class="text-primary">'+esc(a.name)+chipL+'</span><span class="text-accent">'+pct+'%</span></div>'
                    + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar(pct,color,inferred)+'</div>';
             }
             function doCompare(origin, dest) {
@@ -87,7 +93,7 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
                 .then(function(d){
                   if (d.error) { rr.innerHTML = '<span class="text-amber-400 font-mono text-xs">' + esc(d.error) + '</span>'; return; }
                   var O = esc((d.origin||'').toUpperCase()), D = esc((d.destination||'').toUpperCase());
-                  var html = (d.results||[]).map(renderResult).join('');
+                  var html = (d.results||[]).map(function(r){return renderResult(r,O,D)}).join('');
                   rr.innerHTML = html || '<span class="font-mono text-xs text-muted">No tracked airline shows a Starlink-equipped nonstop on '+O+' \\u21c4 '+D+' yet.</span>';
                   if (rfoot) rfoot.classList.remove('hidden');
                   if (rplnk) rplnk.href = '/route-planner?from='+O+'&to='+D;

--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import {
+  AirlineStatusCards,
   FlightCheckInput,
   RecentInstallsFeed,
-  RolloutLeaderboard,
   RouteComparePanel,
 } from "../../components/atoms";
 import { publicAirlines } from "../registry";
@@ -15,26 +15,18 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
       <div className="text-center">
         <div className="font-mono text-sm text-secondary">
           Tracking <span className="text-accent font-semibold">{starlinkCount}</span> Starlink
-          aircraft across{" "}
+          aircraft across <span className="text-muted">{totalCount}</span> planes over{" "}
           <span className="text-accent font-semibold">{perAirlineStats.length}</span> airline
-          {perAirlineStats.length === 1 ? "" : "s"} ·{" "}
-          <span className="text-muted">{totalCount} total fleet</span>
+          {perAirlineStats.length === 1 ? "" : "s"}
         </div>
       </div>
 
-      <div className="grid lg:grid-cols-2 gap-4">
-        <FlightCheckInput />
-        <RouteComparePanel />
-      </div>
+      <AirlineStatusCards stats={perAirlineStats} />
+      <RouteComparePanel />
+      <FlightCheckInput />
+      <RecentInstallsFeed items={recentInstalls} airlines={perAirlineStats} />
 
-      <div className="grid lg:grid-cols-3 gap-4">
-        <div className="lg:col-span-2">
-          <RolloutLeaderboard stats={perAirlineStats} />
-        </div>
-        <RecentInstallsFeed items={recentInstalls} airlines={perAirlineStats} />
-      </div>
-
-      {/* Client-side wiring for flight-check + route-compare forms */}
+      {/* Client-side wiring for flight-check + route-compare forms + preset chips */}
       <script
         // biome-ignore lint/security/noDangerouslySetInnerHtml: SSR client wiring, no user input
         dangerouslySetInnerHTML={{
@@ -63,22 +55,58 @@ const HubHero = ({ stats, perAirlineStats = [], recentInstalls = [] }: HeroProps
             });
             var rf = document.getElementById('hub-compare-route');
             var rr = document.getElementById('hub-compare-result');
-            if (rf) rf.addEventListener('submit', function(e) {
-              e.preventDefault();
-              var fd = new FormData(rf);
+            var rfoot = document.getElementById('hub-compare-footer');
+            var rplnk = document.getElementById('hub-compare-rp');
+            function bar(pct, color, dotted) {
+              var style = 'width:'+pct+'%;background:'+esc(color);
+              if (dotted) style = 'width:'+pct+'%;border-top:2px dotted '+esc(color)+';background:transparent';
+              return '<div class="h-1.5 bg-surface-elevated rounded overflow-hidden mt-1"><div class="h-full" style="'+style+'"></div></div>';
+            }
+            function renderResult(a) {
+              var color = a.accentColor || '#0ea5e9';
+              var inferred = a.kind === 'inferred_absent';
+              var chip = inferred ? ' <span class="text-[9px] px-1 py-0.5 bg-surface-elevated border border-subtle rounded text-muted">inferred</span>' : '';
+              if (a.kind === 'observed_mixed') {
+                var head = '<div class="flex justify-between font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span><span class="text-accent">'+Math.round(a.lo*100)+'\\u2013'+Math.round(a.hi*100)+'%</span></div>'
+                         + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>';
+                var rows = (a.breakdown||[]).map(function(b){
+                  var bp = Math.round(b.pct*100);
+                  return '<div class="mt-1.5 ml-3"><div class="flex justify-between font-mono text-[10px]"><span class="text-secondary">'+esc(b.hint||'')+': '+esc(b.label)+'</span><span class="text-accent">'+bp+'% ('+b.equipped+'/'+b.total+')</span></div>'+bar(bp,color,false)+'</div>';
+                }).join('');
+                return '<div class="mb-3">'+head+rows+'</div>';
+              }
+              var pct = Math.round(a.probability*100);
+              return '<div class="mb-3"><div class="flex justify-between font-mono text-xs"><span class="text-primary">'+esc(a.name)+chip+'</span><span class="text-accent">'+pct+'%</span></div>'
+                   + '<div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar(pct,color,inferred)+'</div>';
+            }
+            function doCompare(origin, dest) {
               rr.classList.remove('hidden');
               rr.textContent = 'Comparing…';
-              fetch('/api/compare-route?origin=' + encodeURIComponent(fd.get('origin')) + '&destination=' + encodeURIComponent(fd.get('destination')))
+              fetch('/api/compare-route?origin=' + encodeURIComponent(origin) + '&destination=' + encodeURIComponent(dest))
                 .then(function(r){return r.json()})
                 .then(function(d){
                   if (d.error) { rr.innerHTML = '<span class="text-amber-400 font-mono text-xs">' + esc(d.error) + '</span>'; return; }
-                  rr.innerHTML = (d.results || []).map(function(a){
-                    var pct = Math.round(a.probability * 100);
-                    var bar = '<div class="h-1.5 bg-surface-elevated rounded overflow-hidden mt-1"><div class="h-full" style="width:'+pct+'%;background:'+esc(a.accentColor||'#0ea5e9')+'"></div></div>';
-                    return '<div class="mb-2"><div class="flex justify-between font-mono text-xs"><span class="text-primary">'+esc(a.name)+'</span><span class="text-accent">'+pct+'%</span></div><div class="font-mono text-[10px] text-muted">'+esc(a.reason)+'</div>'+bar+'</div>';
-                  }).join('') || '<span class="font-mono text-xs text-muted">No tracked airline serves this route.</span>';
+                  var O = esc((d.origin||'').toUpperCase()), D = esc((d.destination||'').toUpperCase());
+                  var html = (d.results||[]).map(renderResult).join('');
+                  rr.innerHTML = html || '<span class="font-mono text-xs text-muted">No tracked airline shows a Starlink-equipped nonstop on '+O+' \\u21c4 '+D+' yet.</span>';
+                  if (rfoot) rfoot.classList.remove('hidden');
+                  if (rplnk) rplnk.href = '/route-planner?from='+O+'&to='+D;
                 })
                 .catch(function(){ rr.textContent = 'Lookup failed.'; });
+            }
+            if (rf) rf.addEventListener('submit', function(e) {
+              e.preventDefault();
+              var fd = new FormData(rf);
+              doCompare(fd.get('origin'), fd.get('destination'));
+            });
+            if (rf) Array.prototype.forEach.call(document.querySelectorAll('.hub-route-preset'), function(btn) {
+              btn.addEventListener('click', function() {
+                var o = btn.getAttribute('data-preset-origin') || '';
+                var d = btn.getAttribute('data-preset-dest') || '';
+                rf.elements.origin.value = o;
+                rf.elements.destination.value = d;
+                doCompare(o, d);
+              });
             });
           });
         `,
@@ -98,14 +126,12 @@ export const content: AirlineContent = {
     <span key="mbps">
       <span className="text-accent font-semibold">250</span> Mbps
     </span>,
-    <span key="leo">Low-Earth-orbit</span>,
   ],
 
   intro: () => (
     <p className="text-sm text-secondary leading-relaxed mb-3">
-      Tracking the rollout of SpaceX Starlink in-flight WiFi across major airlines. Browse every
-      equipped aircraft by airline and tail number, with live flight schedules so you can see which
-      flights have fast, free connectivity.
+      Live rollout status for SpaceX Starlink in-flight WiFi across United, Hawaiian, and Alaska —
+      by fleet segment, with per-tail verification.
     </p>
   ),
 
@@ -134,17 +160,18 @@ export const content: AirlineContent = {
           ld: "United Airlines is mid-rollout across mainline and Express fleets. Hawaiian Airlines completed its rollout in September 2024 — every A330 and A321neo has Starlink. Alaska Airlines is rolling out through 2027.",
         },
         {
-          q: "Hawaiian's rollout is complete — why isn't it 100%?",
+          q: "Hawaiian shows under 100% but says 'Complete' — why?",
           a: () => (
             <p>
-              Hawaiian completed Starlink on <strong>100% of its Airbus fleet</strong> — every A330
-              and A321neo. The remaining aircraft are Boeing 717s flying short interisland hops;
-              those were never in scope for any WiFi provider and are being retired. So every
-              in-scope aircraft is done; the headline percentage just includes the 717s in the
-              denominator.
+              Hawaiian's Starlink rollout is <strong>finished</strong>: every A330 and A321neo has
+              it, gate-to-gate, since September 2024. The Boeing 717 interisland jets were never in
+              scope — short hops, no WiFi, and the type is being retired. The card's percentage is
+              over Hawaiian's <em>whole</em> fleet so you can read it as "odds on a random Hawaiian
+              flight." The Complete badge means every plane that's ever going to get Starlink
+              already has it.
             </p>
           ),
-          ld: "Hawaiian completed Starlink on 100% of its Airbus fleet. The remaining Boeing 717s fly short interisland routes and were never in scope for WiFi.",
+          ld: "Hawaiian's Starlink rollout is finished: every A330 and A321neo has it since September 2024. The Boeing 717 interisland fleet was never in scope and is being retired. The percentage is over the whole fleet; the Complete badge means every plane that will ever get Starlink already has it.",
         },
         {
           q: "Does Delta have Starlink?",

--- a/src/airlines/registry.ts
+++ b/src/airlines/registry.ts
@@ -8,12 +8,16 @@
 // E175LR"), alaskaair.com ("E175"/"ERJ-175"), and 3-char IATA ("E75").
 export const ALASKA_E175_RE = /E175|ERJ.?175|EMB.?175|^E75\b/i;
 
+import type { RolloutStatus } from "../types";
+
 export type AirlineCode = string;
 
 export interface SubfleetDef {
   key: string;
   label: string;
   match: (flightNumber: string) => boolean;
+  /** Display-only flight-number-range hint for the route-compare "mixed equipment" row. */
+  flightNumberHint?: string;
 }
 
 export interface PageBrand {
@@ -90,9 +94,19 @@ export interface AirlineConfig {
   /** Per-flight wifi verification source; null = none (type-map only). */
   verifierBackend?: "united" | "alaska-json" | "qatar-fltstatus" | null;
   /** Type-deterministic route rule for airlines whose Starlink status depends only on aircraft type / route class, not per-tail observation. */
-  routeTypeRule?: (origin: string, destination: string) => { probability: number; reason: string };
+  routeTypeRule?: (
+    origin: string,
+    destination: string
+  ) => { probability: number; reason: string } | null;
   /** Canonical lowercase tag for Datadog `airline:` — preserves history (`united`, not `UA`). */
   metricTag: string;
+  /** Hub status-card config — editorial label + prose, plus a structured status
+   * discriminant so the UI doesn't parse the label string. */
+  rollout?: {
+    status: RolloutStatus;
+    statusLabel: string;
+    phaseNote: string;
+  };
   brand: PageBrand;
 }
 
@@ -130,6 +144,7 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
       {
         key: "express",
         label: "United Express Fleet",
+        flightNumberHint: "UA3000-6999",
         match: (fn) => {
           const n = flightNum(fn);
           return n >= 3000 && n <= 6999;
@@ -138,6 +153,7 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
       {
         key: "mainline",
         label: "United Mainline Fleet",
+        flightNumberHint: "UA1-2999",
         match: (fn) => {
           const n = flightNum(fn);
           return Number.isFinite(n) && !(n >= 3000 && n <= 6999);
@@ -153,6 +169,13 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
     metricTag: "united",
     minFleetSanity: 800,
     verifierBackend: "united",
+    // Whole fleet eligible — Express + mainline both in the program.
+    rollout: {
+      status: "in_progress",
+      statusLabel: "In progress",
+      phaseNote:
+        "Started with regional jets in early 2025; rolling out across United Express and mainline.",
+    },
     brand: {
       title: "United Airlines Starlink Tracker",
       tagline: "Tracking United Airlines aircraft with Starlink WiFi",
@@ -188,8 +211,18 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
     metricTag: "hawaiian",
     minFleetSanity: 30,
     verifierBackend: "alaska-json",
+    // 717 interisland fleet was never in scope (no WiFi provider) and is being retired —
+    // see HA's own press release. Denominator is the Airbus fleet only.
+    rollout: {
+      status: "complete",
+      statusLabel: "Complete",
+      phaseNote: "Every A330 and A321neo has Starlink. The 717 interisland jets won't get it.",
+    },
     routeTypeRule: (o, d) => {
+      // Hawaiian's network is hub-and-spoke from Hawai'i — every route touches
+      // an island airport. Routes between two mainland cities aren't HA routes.
       const HI = new Set(["HNL", "OGG", "KOA", "LIH", "ITO", "MKK", "LNY"]);
+      if (!HI.has(o) && !HI.has(d)) return null;
       return HI.has(o) && HI.has(d)
         ? { probability: 0, reason: "Interisland — Boeing 717, no WiFi" }
         : { probability: 1, reason: "All Hawaiian A330/A321neo have Starlink" };
@@ -231,6 +264,7 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
       {
         key: "mainline",
         label: "Mainline (737/787)",
+        flightNumberHint: "AS1-1999",
         match: (fn) => {
           const n = flightNum(fn);
           return Number.isFinite(n) && n < 2000;
@@ -239,6 +273,7 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
       {
         key: "horizon",
         label: "Horizon (E175)",
+        flightNumberHint: "AS2000+",
         match: (fn) => {
           const n = flightNum(fn);
           return Number.isFinite(n) && n >= 2000;
@@ -251,6 +286,12 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
     metricTag: "alaska",
     minFleetSanity: 200,
     verifierBackend: "alaska-json",
+    // Phase 1 (E175 regional) complete. Update status/phaseNote when 737/787 mainline starts.
+    rollout: {
+      status: "phase_done",
+      statusLabel: "Regional fleet done",
+      phaseNote: "All 90 regional E175s have Starlink. Mainline 737s and 787s start later in 2026.",
+    },
     brand: {
       title: "Alaska Airlines Starlink Tracker",
       tagline: "Tracking Alaska Airlines aircraft with Starlink WiFi",

--- a/src/airlines/registry.ts
+++ b/src/airlines/registry.ts
@@ -18,6 +18,9 @@ export interface SubfleetDef {
   match: (flightNumber: string) => boolean;
   /** Display-only flight-number-range hint for the route-compare "mixed equipment" row. */
   flightNumberHint?: string;
+  /** Fixed Starlink rate when this subfleet flies on another carrier's metal
+   * (e.g. AS800-899 on Hawaiian A330/A321neo). */
+  penetrationOverride?: number;
 }
 
 export interface PageBrand {
@@ -261,13 +264,26 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
     // AS flight numbers to tails yet.
     carrierPrefixes: ["ASA", "QXE", "AS", "QX"],
     subfleets: [
+      // AS800-899 are AS-marketed flights on Hawaiian A330/A321neo metal
+      // post-merger — every one of those aircraft has Starlink. Listed first
+      // so it wins the find() over mainline.
+      {
+        key: "hawaiian_metal",
+        label: "Hawaiian-operated (A330/A321neo)",
+        flightNumberHint: "AS800-899",
+        penetrationOverride: 1,
+        match: (fn) => {
+          const n = flightNum(fn);
+          return Number.isFinite(n) && n >= 800 && n <= 899;
+        },
+      },
       {
         key: "mainline",
         label: "Mainline (737/787)",
         flightNumberHint: "AS1-1999",
         match: (fn) => {
           const n = flightNum(fn);
-          return Number.isFinite(n) && n < 2000;
+          return Number.isFinite(n) && n < 2000 && !(n >= 800 && n <= 899);
         },
       },
       {

--- a/src/components/atoms.tsx
+++ b/src/components/atoms.tsx
@@ -5,126 +5,197 @@ import type { Aircraft, PerAirlineStat } from "../types";
 
 export type { PerAirlineStat };
 
-function fmtEta(starlink: number, fleetTotal: number, installs30d: number): string {
-  if (fleetTotal > 0 && starlink >= fleetTotal) return "Complete";
-  if (installs30d <= 0) return "—";
-  const remaining = fleetTotal - starlink;
-  const days = Math.ceil(remaining / (installs30d / 30));
-  const eta = new Date(Date.now() + days * 86400_000);
-  return `est. ${eta.toLocaleDateString("en-US", { month: "short", year: "numeric" })}`;
-}
+/**
+ * Hub status cards — one per airline, equal-height grid. % is over the FULL
+ * fleet so a viewer can read it as "odds on a random flight"; the status pill
+ * + prose explain the nuance (HA at 69% but Complete: 717s won't get it).
+ */
+const STATUS_TONE = {
+  complete: { color: "#3fb950", bg: "rgba(63,185,80,.12)" },
+  phase_done: { color: "#d4a72c", bg: "rgba(212,167,44,.12)" },
+  in_progress: { color: "#58a6ff", bg: "rgba(88,166,255,.12)" },
+} as const;
 
-export function RolloutLeaderboard({ stats }: { stats: PerAirlineStat[] }) {
+export function AirlineStatusCards({ stats }: { stats: PerAirlineStat[] }) {
   const ranked = [...stats]
-    .map((a) => ({
-      ...a,
-      pct: (a.fleetTotal ?? a.total) > 0 ? (a.starlink / (a.fleetTotal ?? a.total)) * 100 : 0,
-    }))
+    .map((a) => {
+      const fleet = a.fleetTotal ?? a.total;
+      return { ...a, fleet, pct: fleet > 0 ? (a.starlink / fleet) * 100 : 0 };
+    })
     .sort((a, b) => b.pct - a.pct);
+
+  const r = 30;
+  const c = 2 * Math.PI * r;
+
   return (
-    <div className="bg-surface border border-subtle rounded-lg p-5">
-      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-3">
-        Rollout progress by airline
+    <section>
+      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-2">
+        Where each rollout stands
       </div>
-      <div className="space-y-3">
-        {ranked.map((a) => (
-          <a key={a.code} href={a.href || "#"} className="block group">
-            <div className="flex items-baseline justify-between mb-1.5">
-              <div className="flex items-baseline gap-2">
-                <span
-                  className="font-mono text-xs px-1.5 py-0.5 rounded"
-                  style={{
-                    color: a.accentColor,
-                    background: `color-mix(in srgb, ${a.accentColor} 15%, transparent)`,
-                  }}
-                >
-                  {a.code}
-                </span>
-                <span className="font-display text-sm text-primary group-hover:text-accent transition-colors">
-                  {a.name}
-                </span>
-                {(a.installs30d ?? 0) > 0 && (
-                  <span className="font-mono text-[10px] text-green-400">+{a.installs30d}/30d</span>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        {ranked.map((a) => {
+          const tone = STATUS_TONE[a.status ?? "in_progress"];
+          return (
+            <a
+              key={a.code}
+              href={a.href || "#"}
+              className="group relative bg-surface border border-subtle rounded-xl overflow-hidden flex flex-col hover:border-accent transition-all hover:-translate-y-0.5"
+              style={{
+                boxShadow: "inset 0 1px 0 0 rgba(255,255,255,.03)",
+              }}
+            >
+              {/* Accent top edge */}
+              <div
+                className="h-[3px] w-full"
+                style={{
+                  background: `linear-gradient(90deg, ${a.accentColor}, ${a.accentColor}40)`,
+                  boxShadow: `0 1px 8px ${a.accentColor}60`,
+                }}
+              />
+              {/* Subtle accent wash */}
+              <div
+                className="absolute inset-0 pointer-events-none opacity-[0.04]"
+                style={{
+                  background: `radial-gradient(circle at 0% 0%, ${a.accentColor}, transparent 60%)`,
+                }}
+              />
+
+              <div className="relative p-4 flex flex-col gap-3">
+                {/* Header: chip + name + status pill */}
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span
+                      className="font-mono text-xs px-1.5 py-0.5 rounded shrink-0"
+                      style={{
+                        color: a.accentColor,
+                        background: `color-mix(in srgb, ${a.accentColor} 18%, transparent)`,
+                      }}
+                    >
+                      {a.code}
+                    </span>
+                    <span className="font-display text-sm text-primary truncate group-hover:text-accent transition-colors">
+                      {a.name}
+                    </span>
+                  </div>
+                  <span
+                    className="font-mono text-[10px] uppercase tracking-wide px-2 py-1 rounded-full shrink-0"
+                    style={{ color: tone.color, background: tone.bg }}
+                  >
+                    {a.statusLabel ?? "In progress"}
+                  </span>
+                </div>
+
+                {/* Hero: ring + counts */}
+                <div className="flex items-center gap-4">
+                  <div className="relative w-[72px] h-[72px] shrink-0">
+                    <svg
+                      width="72"
+                      height="72"
+                      viewBox="0 0 72 72"
+                      className="-rotate-90"
+                      role="img"
+                      aria-label={`${a.name} ${Math.round(a.pct)}% Starlink`}
+                    >
+                      <circle cx="36" cy="36" r={r} stroke="#1d2536" strokeWidth="7" fill="none" />
+                      <circle
+                        cx="36"
+                        cy="36"
+                        r={r}
+                        stroke={a.accentColor}
+                        strokeWidth="7"
+                        fill="none"
+                        strokeLinecap="round"
+                        strokeDasharray={c}
+                        strokeDashoffset={c * (1 - Math.min(100, a.pct) / 100)}
+                        style={{ filter: `drop-shadow(0 0 5px ${a.accentColor}90)` }}
+                      />
+                    </svg>
+                    <div className="absolute inset-0 flex items-center justify-center">
+                      <span className="font-mono text-lg font-semibold text-primary">
+                        {Math.round(Math.min(100, a.pct))}
+                        <span className="text-[10px] text-muted">%</span>
+                      </span>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1 min-w-0">
+                    <div className="font-mono text-2xl font-semibold text-primary leading-none">
+                      {a.starlink}
+                      <span className="text-sm text-muted font-normal"> / {a.fleet}</span>
+                    </div>
+                    <div className="font-mono text-[10px] text-muted uppercase tracking-wider">
+                      aircraft equipped
+                    </div>
+                    {(a.installs30d ?? 0) > 0 ? (
+                      <div className="font-mono text-[11px] mt-1" style={{ color: tone.color }}>
+                        +{a.installs30d} in the last 30 days
+                      </div>
+                    ) : (
+                      <div className="font-mono text-[11px] text-muted mt-1">
+                        {a.status === "complete" ? "rollout finished" : "—"}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Prose */}
+                {a.phaseNote && (
+                  <p className="text-[11.5px] text-secondary leading-snug border-t border-subtle pt-2.5 mt-auto">
+                    {a.phaseNote}
+                  </p>
                 )}
               </div>
-              <span className="font-mono text-xs text-muted">
-                {fmtEta(a.starlink, a.fleetTotal ?? a.total, a.installs30d ?? 0)}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="flex-1 h-2 bg-surface-elevated rounded overflow-hidden">
-                <div
-                  className="h-full transition-all"
-                  style={{
-                    width: `${Math.min(100, a.pct)}%`,
-                    background: a.accentColor,
-                    boxShadow: `0 0 8px ${a.accentColor}80`,
-                  }}
-                />
-              </div>
-              <span className="font-mono text-sm font-semibold text-primary w-12 text-right">
-                {a.pct.toFixed(0)}%
-              </span>
-              <span className="font-mono text-[10px] text-muted w-20 text-right">
-                {a.starlink} / {a.fleetTotal ?? a.total}
-              </span>
-            </div>
-          </a>
-        ))}
+            </a>
+          );
+        })}
       </div>
-    </div>
+    </section>
   );
-}
-
-function relativeBucket(dateStr: string): string {
-  const days = Math.floor((Date.now() - new Date(dateStr).getTime()) / 86400_000);
-  if (days < 7) return "This week";
-  if (days < 14) return "Last week";
-  return "Earlier";
 }
 
 export function RecentInstallsFeed({
   items,
   airlines,
 }: { items: RecentInstall[]; airlines: PerAirlineStat[] }) {
-  const cfgByCode = Object.fromEntries(airlines.map((a) => [a.code, a]));
-  const buckets = ["This week", "Last week", "Earlier"];
-  const grouped = buckets
-    .map((b) => ({ b, rows: items.filter((i) => relativeBucket(i.DateFound) === b) }))
+  // Group once per airline — the per-row airline name was 90%+ "United Airlines".
+  const grouped = airlines
+    .map((a) => ({ cfg: a, rows: items.filter((i) => i.airline === a.code) }))
     .filter((g) => g.rows.length > 0);
   return (
     <div className="bg-surface border border-subtle rounded-lg p-5">
       <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-3">
-        Latest installs
+        Recent installs
       </div>
       {grouped.length === 0 ? (
         <div className="text-xs text-muted font-mono">No recent installs</div>
       ) : (
-        grouped.map((g) => (
-          <div key={g.b} className="mb-3 last:mb-0">
-            <div className="text-[10px] font-mono text-muted mb-1.5">{g.b}</div>
-            <div className="space-y-1">
-              {g.rows.map((r) => {
-                const cfg = cfgByCode[r.airline];
-                return (
+        <>
+          {grouped.map((g) => (
+            <div key={g.cfg.code} className="mb-3 last:mb-0">
+              <div className="flex items-center gap-1.5 text-[10px] font-mono text-muted mb-1.5">
+                <span
+                  className="w-1.5 h-1.5 rounded-full flex-shrink-0"
+                  style={{ background: g.cfg.accentColor || "#5a6a80" }}
+                />
+                {g.cfg.name}
+              </div>
+              <div className="space-y-1">
+                {g.rows.map((r) => (
                   <a
                     key={r.TailNumber}
-                    href={cfg ? airlineHomeUrl(cfg.code, { q: r.TailNumber }) : "#"}
+                    href={airlineHomeUrl(g.cfg.code, { q: r.TailNumber })}
                     className="flex items-center gap-2 px-2 py-1 rounded hover:bg-surface-elevated transition-colors group"
                   >
-                    <span
-                      className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                      style={{ background: cfg?.accentColor || "#5a6a80" }}
-                    />
                     <span className="font-mono text-xs text-primary group-hover:text-accent transition-colors w-16">
                       {r.TailNumber}
                     </span>
                     <span className="font-mono text-[10px] text-muted flex-1 truncate">
                       {r.Aircraft}
                     </span>
-                    <span className="font-mono text-[10px] text-secondary">
-                      {cfg?.name || r.airline}
-                    </span>
+                    {r.OperatedBy && (
+                      <span className="font-mono text-[10px] text-secondary truncate hidden sm:inline">
+                        {r.OperatedBy}
+                      </span>
+                    )}
                     <span className="font-mono text-[10px] text-muted w-12 text-right">
                       {new Date(r.DateFound).toLocaleDateString("en-US", {
                         month: "short",
@@ -132,11 +203,11 @@ export function RecentInstallsFeed({
                       })}
                     </span>
                   </a>
-                );
-              })}
+                ))}
+              </div>
             </div>
-          </div>
-        ))
+          ))}
+        </>
       )}
     </div>
   );
@@ -145,12 +216,13 @@ export function RecentInstallsFeed({
 /**
  * Universal flight-number check input. Renders an inert form; client-side
  * script in hub.tsx fetches /api/check-any-flight and renders the result.
+ * Compact variant — secondary action below route compare.
  */
 export function FlightCheckInput() {
   return (
-    <div className="bg-surface border border-subtle rounded-lg p-5">
-      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-3">
-        Check any flight
+    <div className="bg-surface border border-subtle rounded-lg p-3">
+      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-2">
+        Already booked? Check a flight
       </div>
       <form id="hub-check-flight" className="flex flex-col sm:flex-row gap-2">
         <input
@@ -173,16 +245,28 @@ export function FlightCheckInput() {
           Check
         </button>
       </form>
-      <div id="hub-check-result" className="mt-3 text-sm font-mono hidden" />
+      <div id="hub-check-result" className="mt-2 text-sm font-mono hidden" />
     </div>
   );
 }
 
+// Preset chips: pick city pairs that exercise the comparison — mainland routes
+// with UA-vs-AS overlap, plus one Hawai'i route where HA is the answer.
+const PRESET_ROUTES: { o: string; d: string }[] = [
+  { o: "SEA", d: "SFO" },
+  { o: "DEN", d: "SAN" },
+  { o: "SFO", d: "HNL" },
+];
+
 export function RouteComparePanel() {
   return (
     <div className="bg-surface border border-subtle rounded-lg p-5">
-      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-3">
-        Compare airlines on a route
+      <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-1">
+        Starlink odds by airline — nonstop
+      </div>
+      <div className="text-[10px] font-mono text-muted leading-relaxed mb-3">
+        Install rate across the aircraft each carrier flies nonstop on this route. Tails rotate
+        daily, so this is fleet penetration, not a per-flight guarantee.
       </div>
       <form id="hub-compare-route" className="flex flex-col sm:flex-row gap-2">
         <input
@@ -208,7 +292,30 @@ export function RouteComparePanel() {
           Compare
         </button>
       </form>
+      <div className="flex flex-wrap items-center gap-2 mt-2">
+        {PRESET_ROUTES.map((r) => (
+          <button
+            key={`${r.o}-${r.d}`}
+            type="button"
+            data-preset-origin={r.o}
+            data-preset-dest={r.d}
+            className="hub-route-preset font-mono text-xs px-2.5 py-1.5 bg-surface-elevated border border-subtle rounded text-secondary hover:text-accent hover:border-accent transition-colors"
+          >
+            {r.o} → {r.d}
+          </button>
+        ))}
+      </div>
       <div id="hub-compare-result" className="mt-3 hidden" />
+      <div
+        id="hub-compare-footer"
+        className="mt-3 text-[10px] font-mono text-muted leading-relaxed hidden"
+      >
+        Don't see your airline? We can only confirm an airline at an airport once one of its
+        Starlink aircraft has flown there. For connecting itineraries, try the{" "}
+        <a id="hub-compare-rp" href="/route-planner" className="text-accent hover:underline">
+          Route Planner →
+        </a>
+      </div>
     </div>
   );
 }

--- a/src/components/atoms.tsx
+++ b/src/components/atoms.tsx
@@ -262,11 +262,10 @@ export function RouteComparePanel() {
   return (
     <div className="bg-surface border border-subtle rounded-lg p-5">
       <div className="text-[10px] font-mono text-muted uppercase tracking-wider mb-1">
-        Starlink odds by airline — nonstop
+        Starlink odds by airline
       </div>
       <div className="text-[10px] font-mono text-muted leading-relaxed mb-3">
-        Install rate across the aircraft each carrier flies nonstop on this route. Tails rotate
-        daily, so this is fleet penetration, not a per-flight guarantee.
+        Share of each carrier's planes on this nonstop route that have Starlink today.
       </div>
       <form id="hub-compare-route" className="flex flex-col sm:flex-row gap-2">
         <input
@@ -310,8 +309,7 @@ export function RouteComparePanel() {
         id="hub-compare-footer"
         className="mt-3 text-[10px] font-mono text-muted leading-relaxed hidden"
       >
-        Don't see your airline? We can only confirm an airline at an airport once one of its
-        Starlink aircraft has flown there. For connecting itineraries, try the{" "}
+        Carrier missing? It only shows up once one of its Starlink planes has flown here.{" "}
         <a id="hub-compare-rp" href="/route-planner" className="text-accent hover:underline">
           Route Planner →
         </a>

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -629,12 +629,25 @@ export function getAirlineByTail(db: Database, airline?: AirlineFilter): Record<
 export function getRecentInstalls(
   db: Database,
   airline: AirlineFilter,
-  limit = 25
+  limit = 25,
+  perAirlineCap?: number
 ): RecentInstall[] {
-  const q = withAirline(
-    "SELECT airline, TailNumber, aircraft as Aircraft, OperatedBy, DateFound FROM starlink_planes WHERE (verified_wifi IS NULL OR verified_wifi = 'Starlink')",
-    airline
-  );
+  const cols = "airline, TailNumber, aircraft as Aircraft, OperatedBy, DateFound";
+  const filter = "(verified_wifi IS NULL OR verified_wifi = 'Starlink')";
+  if (perAirlineCap && perAirlineCap > 0) {
+    const q = withAirline(
+      `SELECT ${cols}, ROW_NUMBER() OVER (PARTITION BY airline ORDER BY DateFound DESC) AS rn
+       FROM starlink_planes WHERE ${filter}`,
+      airline
+    );
+    return db
+      .query(
+        `SELECT airline, TailNumber, Aircraft, OperatedBy, DateFound FROM (${q.sql})
+         WHERE rn <= ? ORDER BY DateFound DESC LIMIT ?`
+      )
+      .all(...q.params, perAirlineCap, limit) as RecentInstall[];
+  }
+  const q = withAirline(`SELECT ${cols} FROM starlink_planes WHERE ${filter}`, airline);
   return db
     .query(`${q.sql} ORDER BY DateFound DESC LIMIT ?`)
     .all(...q.params, limit) as RecentInstall[];
@@ -649,30 +662,48 @@ export interface HubAirlineStat {
 }
 
 export function getHubStats(db: Database, codes: readonly string[]): HubAirlineStat[] {
+  const placeholders = codes.map(() => "?").join(",");
   const fleet = db
     .query(
-      `SELECT airline, COUNT(*) total, SUM(starlink_status='confirmed') equipped
-       FROM united_fleet WHERE airline IN (${codes.map(() => "?").join(",")})
+      `SELECT airline, COUNT(*) total FROM united_fleet
+       WHERE airline IN (${placeholders}) GROUP BY airline`
+    )
+    .all(...codes) as { airline: string; total: number }[];
+  // Equipped count from starlink_planes — the authoritative table — not from
+  // united_fleet.starlink_status, which lags during reconcile cycles. Same
+  // source /api/fleet-summary uses, so the cards never contradict it.
+  const equipped = db
+    .query(
+      `SELECT airline, COUNT(*) n FROM starlink_planes
+       WHERE (verified_wifi IS NULL OR verified_wifi = 'Starlink')
+         AND airline IN (${placeholders})
        GROUP BY airline`
     )
-    .all(...codes) as { airline: string; total: number; equipped: number }[];
+    .all(...codes) as { airline: string; n: number }[];
+  const equippedBy = Object.fromEntries(equipped.map((r) => [r.airline, r.n]));
+  // Exclude seed batches (sheet_gid '*_seed') — those bootstrap a known-equipped
+  // fleet on a single date and would otherwise read as a 90-aircraft "install spike".
   const v = db
     .query(
       `SELECT airline, COUNT(*) n FROM starlink_planes
        WHERE DateFound >= date('now','-30 day')
          AND (verified_wifi IS NULL OR verified_wifi = 'Starlink')
-         AND airline IN (${codes.map(() => "?").join(",")})
+         AND (sheet_gid IS NULL OR sheet_gid NOT LIKE '%\\_seed' ESCAPE '\\')
+         AND airline IN (${placeholders})
        GROUP BY airline`
     )
     .all(...codes) as { airline: string; n: number }[];
   const v30 = Object.fromEntries(v.map((r) => [r.airline, r.n]));
-  return fleet.map((f) => ({
-    code: f.airline,
-    starlink: f.equipped,
-    total: getTotalCount(db, f.airline) || f.total,
-    fleetTotal: f.total,
-    installs30d: v30[f.airline] ?? 0,
-  }));
+  return fleet.map((f) => {
+    const starlink = equippedBy[f.airline] ?? 0;
+    return {
+      code: f.airline,
+      starlink,
+      total: getTotalCount(db, f.airline) || f.total,
+      fleetTotal: f.total,
+      installs30d: v30[f.airline] ?? 0,
+    };
+  });
 }
 
 export function getStarlinkPlanes(db: Database, airline?: AirlineFilter): Aircraft[] {
@@ -1045,27 +1076,109 @@ export function getConfirmedStarlinkEdges(
   return db.query(q.sql).all(...q.params) as ConfirmedEdge[];
 }
 
-export function getRouteAirlineCoverage(
+export interface SubfleetPenetration {
+  equipped: number;
+  total: number;
+  pct: number;
+}
+
+/**
+ * Unbiased per-subfleet Starlink install rate from the FULL fleet roster
+ * (united_fleet), not from any Starlink-biased observation table. Numerator
+ * is the same starlink_planes count getHubStats() uses (united_fleet's
+ * starlink_status lags during reconcile cycles), so the route-compare
+ * percentages and the hub cards directly above them can never disagree.
+ */
+export function getSubfleetPenetration(
   db: Database,
-  origin: string,
-  destination: string,
   airline: string
-): { tail_number: string; sl: number }[] {
-  return db
+): Map<string, SubfleetPenetration> {
+  const rows = db
     .query(
-      `SELECT uf.tail_number,
-              EXISTS(SELECT 1 FROM starlink_planes sp
-                     WHERE sp.TailNumber = uf.tail_number
-                       AND (sp.verified_wifi IS NULL OR sp.verified_wifi = 'Starlink')) AS sl
-       FROM upcoming_flights uf
-       WHERE ((uf.departure_airport = ? AND uf.arrival_airport = ?)
-           OR (uf.departure_airport = ? AND uf.arrival_airport = ?))
-         AND uf.airline = ?`
+      `SELECT uf.fleet, COUNT(*) AS total,
+              SUM(CASE WHEN sp.TailNumber IS NOT NULL THEN 1 ELSE 0 END) AS equipped
+       FROM united_fleet uf
+       LEFT JOIN starlink_planes sp
+              ON sp.TailNumber = uf.tail_number
+             AND sp.airline = uf.airline
+             AND (sp.verified_wifi IS NULL OR sp.verified_wifi = 'Starlink')
+       WHERE uf.airline = ?
+       GROUP BY uf.fleet`
     )
-    .all(origin, destination, destination, origin, airline) as {
-    tail_number: string;
-    sl: number;
-  }[];
+    .all(airline) as { fleet: string; total: number; equipped: number }[];
+  const out = new Map<string, SubfleetPenetration>();
+  for (const r of rows) {
+    out.set(r.fleet, {
+      equipped: r.equipped,
+      total: r.total,
+      pct: r.total > 0 ? r.equipped / r.total : 0,
+    });
+  }
+  return out;
+}
+
+/**
+ * All flight numbers observed flying NONSTOP between two airports (either
+ * direction) for a given marketing carrier. Union of upcoming_flights
+ * (operator-correct, ~48h window) and flight_routes (longer history,
+ * filtered by carrier-prefix GLOB since it has no airline column).
+ * Returns bare numeric strings so OO5579/SKW5579/UA5579 dedupe.
+ */
+export function getObservedDirectFlightNumbers(
+  db: Database,
+  airline: string,
+  prefixes: readonly string[],
+  origin: string,
+  destination: string
+): string[] {
+  const upcoming = db
+    .query(
+      `SELECT DISTINCT flight_number FROM upcoming_flights
+       WHERE airline = ?
+         AND ((departure_airport = ? AND arrival_airport = ?)
+           OR (departure_airport = ? AND arrival_airport = ?))`
+    )
+    .all(airline, origin, destination, destination, origin) as { flight_number: string }[];
+
+  const globClauses = prefixes.map(() => "flight_number GLOB ?").join(" OR ");
+  const globParams = prefixes.map((p) => `${p}[0-9]*`);
+  const cached = globClauses
+    ? (db
+        .query(
+          `SELECT DISTINCT flight_number FROM flight_routes
+           WHERE ((origin = ? AND destination = ?) OR (origin = ? AND destination = ?))
+             AND (${globClauses})`
+        )
+        .all(origin, destination, destination, origin, ...globParams) as {
+        flight_number: string;
+      }[])
+    : [];
+
+  const seen = new Set<string>();
+  for (const r of [...upcoming, ...cached]) {
+    const m = r.flight_number.match(/(\d+)$/);
+    if (m) seen.add(m[1]);
+  }
+  return [...seen];
+}
+
+/** True if the airline has any scheduled flight at both airports — gates the
+ * routeTypeRule fallback so it never fires for routes the airline doesn't serve. */
+export function airlineServesAirports(
+  db: Database,
+  airline: string,
+  ...airports: string[]
+): boolean {
+  for (const ap of airports) {
+    const row = db
+      .query(
+        `SELECT 1 FROM upcoming_flights
+         WHERE airline = ? AND (departure_airport = ? OR arrival_airport = ?) LIMIT 1`
+      )
+      .get(airline, ap, ap);
+    if (!row) return false;
+  }
+  return true;
 }
 
 export interface DirectRouteEdge {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1162,20 +1162,34 @@ export function getObservedDirectFlightNumbers(
   return [...seen];
 }
 
-/** True if the airline has any scheduled flight at both airports — gates the
- * routeTypeRule fallback so it never fires for routes the airline doesn't serve. */
+/** True if the airline serves both airports — gates inferred_absent so it
+ * never fires for routes the airline doesn't fly. Checks flight_routes (the
+ * historical cache, populated by any lookup) in addition to upcoming_flights
+ * (Starlink-only, ~48h) so coverage is symmetric across carriers. */
 export function airlineServesAirports(
   db: Database,
   airline: string,
+  prefixes: readonly string[],
   ...airports: string[]
 ): boolean {
+  const globClauses = prefixes.map(() => "flight_number GLOB ?").join(" OR ");
+  const globParams = prefixes.map((p) => `${p}[0-9]*`);
   for (const ap of airports) {
-    const row = db
-      .query(
-        `SELECT 1 FROM upcoming_flights
-         WHERE airline = ? AND (departure_airport = ? OR arrival_airport = ?) LIMIT 1`
-      )
-      .get(airline, ap, ap);
+    const row =
+      db
+        .query(
+          `SELECT 1 FROM upcoming_flights
+           WHERE airline = ? AND (departure_airport = ? OR arrival_airport = ?) LIMIT 1`
+        )
+        .get(airline, ap, ap) ??
+      (globClauses
+        ? db
+            .query(
+              `SELECT 1 FROM flight_routes
+               WHERE (origin = ? OR destination = ?) AND (${globClauses}) LIMIT 1`
+            )
+            .get(ap, ap, ...globParams)
+        : undefined);
     if (!row) return false;
   }
   return true;

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -28,9 +28,11 @@ import {
   type RouteEntryRow,
   type RouteFlightRow,
   type RouteGraphEdge,
+  type SubfleetPenetration,
   type VerificationObservation,
   type WifiConsensus,
   type WifiMismatch,
+  airlineServesAirports,
   bumpDiscoveryPriority,
   cacheFlightRoute,
   computeWifiConsensus,
@@ -49,17 +51,18 @@ import {
   getHubStats,
   getLastUpdated,
   getMeta,
+  getObservedDirectFlightNumbers,
   getPendingFleetTails,
   getQatarScheduleByFlight,
   getQatarScheduleByRoute,
   getQatarScheduleStats,
   getRecentInstalls,
-  getRouteAirlineCoverage,
   getRouteFlights,
   getRouteGraphEdges,
   getRoutesForFlightVariants,
   getStarlinkPlaneByTail,
   getStarlinkPlanes,
+  getSubfleetPenetration,
   getTotalCount,
   getUpcomingFlights,
   getVerificationObservations,
@@ -77,7 +80,7 @@ export interface ScopedReader {
   readonly airlines: readonly AirlineCode[];
   getStarlinkPlanes(): Aircraft[];
   getAirlineByTail(): Record<string, string>;
-  getRecentInstalls(limit?: number): RecentInstall[];
+  getRecentInstalls(limit?: number, perAirlineCap?: number): RecentInstall[];
   getPerAirlineStats(): PerAirlineStat[];
   getUpcomingFlights(tailNumber?: string): Flight[];
   getFleetStats(): FleetStats;
@@ -115,11 +118,13 @@ export interface ScopedReader {
   getRouteFlights(origin: string | null, destination: string | null): RouteFlightRow[];
   getRouteGraphEdges(): RouteGraphEdge[];
   getConfirmedStarlinkEdges(startOfDay: number, endOfDay: number): ConfirmedEdge[];
-  getRouteAirlineCoverage(
+  airlineServesAirports(...airports: string[]): boolean;
+  getSubfleetPenetration(): Map<string, SubfleetPenetration>;
+  getObservedDirectFlightNumbers(
+    prefixes: readonly string[],
     origin: string,
-    destination: string,
-    code: AirlineCode
-  ): { tail_number: string; sl: number }[];
+    destination: string
+  ): string[];
   getDirectRouteEdge(origin: string, destination: string): DirectRouteEdge | null;
 
   // flight_routes cache (airline-agnostic; PK carries IATA prefix)
@@ -184,6 +189,9 @@ function buildPerAirlineStats(db: Database, codes: readonly AirlineCode[]): PerA
       total: h?.total ?? getTotalCount(db, code),
       fleetTotal: h?.fleetTotal,
       installs30d: h?.installs30d,
+      status: cfg.rollout?.status,
+      statusLabel: cfg.rollout?.statusLabel,
+      phaseNote: cfg.rollout?.phaseNote,
       accentColor: cfg.brand.accentColor,
       href: airlineHomeUrl(code),
     });
@@ -197,12 +205,19 @@ function buildReader(db: Database, scope: Scope): ScopedReader {
   const airlines = scope === "ALL" ? publicCodes() : ([scope] as const);
   // Meta keys are namespaced per-airline; ALL has no single namespace.
   const metaCode = scope === "ALL" ? "UA" : scope;
+  // Route-compare methods are only meaningful per-airline; assert it.
+  const soleAirline = () => {
+    if (airlines.length !== 1)
+      throw new Error(`ScopedReader method requires a single-airline scope, got ${scope}`);
+    return airlines[0];
+  };
   const r: ScopedReader = {
     scope,
     airlines,
     getStarlinkPlanes: () => getStarlinkPlanes(db, airlines),
     getAirlineByTail: () => getAirlineByTail(db, airlines),
-    getRecentInstalls: (limit) => getRecentInstalls(db, airlines, limit),
+    getRecentInstalls: (limit, perAirlineCap) =>
+      getRecentInstalls(db, airlines, limit, perAirlineCap),
     getPerAirlineStats: () => buildPerAirlineStats(db, airlines),
     getUpcomingFlights: (t) => getUpcomingFlights(db, t, airlines),
     // FleetStats shape is UA-subfleet-specific (express/mainline); hub aggregation deferred until
@@ -237,7 +252,10 @@ function buildReader(db: Database, scope: Scope): ScopedReader {
     getRouteFlights: (o, d) => getRouteFlights(db, o, d, airlines),
     getRouteGraphEdges: () => getRouteGraphEdges(db, airlines),
     getConfirmedStarlinkEdges: (s, e) => getConfirmedStarlinkEdges(db, s, e, airlines),
-    getRouteAirlineCoverage: (o, d, code) => getRouteAirlineCoverage(db, o, d, code),
+    airlineServesAirports: (...aps) => airlineServesAirports(db, soleAirline(), ...aps),
+    getSubfleetPenetration: () => getSubfleetPenetration(db, soleAirline()),
+    getObservedDirectFlightNumbers: (px, o, d) =>
+      getObservedDirectFlightNumbers(db, soleAirline(), px, o, d),
     getDirectRouteEdge: (o, d) => getDirectRouteEdge(db, o, d, airlines),
 
     getCachedFlightRoutes: (fn, after) => getCachedFlightRoutes(db, fn, after),

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -118,7 +118,7 @@ export interface ScopedReader {
   getRouteFlights(origin: string | null, destination: string | null): RouteFlightRow[];
   getRouteGraphEdges(): RouteGraphEdge[];
   getConfirmedStarlinkEdges(startOfDay: number, endOfDay: number): ConfirmedEdge[];
-  airlineServesAirports(...airports: string[]): boolean;
+  airlineServesAirports(prefixes: readonly string[], ...airports: string[]): boolean;
   getSubfleetPenetration(): Map<string, SubfleetPenetration>;
   getObservedDirectFlightNumbers(
     prefixes: readonly string[],
@@ -252,7 +252,7 @@ function buildReader(db: Database, scope: Scope): ScopedReader {
     getRouteFlights: (o, d) => getRouteFlights(db, o, d, airlines),
     getRouteGraphEdges: () => getRouteGraphEdges(db, airlines),
     getConfirmedStarlinkEdges: (s, e) => getConfirmedStarlinkEdges(db, s, e, airlines),
-    airlineServesAirports: (...aps) => airlineServesAirports(db, soleAirline(), ...aps),
+    airlineServesAirports: (px, ...aps) => airlineServesAirports(db, soleAirline(), px, ...aps),
     getSubfleetPenetration: () => getSubfleetPenetration(db, soleAirline()),
     getObservedDirectFlightNumbers: (px, o, d) =>
       getObservedDirectFlightNumbers(db, soleAirline(), px, o, d),

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -533,8 +533,6 @@ export interface RouteCompareResult {
   hi?: number;
   breakdown: SubfleetBreakdown[];
   reason: string;
-  /** observed_mixed only: the high-penetration subfleet's FN range, for the chip. */
-  bestPick?: { hint: string; pct: number };
 }
 
 const fmt = (n: number) => n.toLocaleString("en-US");
@@ -634,9 +632,6 @@ export function compareRoute(
         lo,
         hi,
         breakdown: bd,
-        // The chip surfaces the high-penetration subfleet's flight-number range
-        // as the actionable hint; the breakdown rows show the rest.
-        bestPick: { hint: bd[0].hint ?? "", pct: bd[0].pct },
         reason: "Depends on flight number",
       });
     } else {

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -18,7 +18,12 @@
  */
 
 import { Database } from "bun:sqlite";
-import { type AirlineConfig, airlineHomeUrl, publicAirlines } from "../airlines/registry";
+import {
+  type AirlineConfig,
+  airlineHomeUrl,
+  publicAirlines,
+  siteForAirline,
+} from "../airlines/registry";
 import type { VerificationObservation as Observation } from "../database/database";
 import { type Scope, type ScopedReader, createReaderFactory } from "../database/reader";
 import { ensureUAPrefix, inferFleet } from "../utils/constants";
@@ -525,8 +530,10 @@ export interface SubfleetBreakdown {
 export interface RouteCompareResult {
   airline: string;
   name: string;
+  shortName: string;
   accentColor: string;
   canonicalHost: string;
+  routePlannerBase: string | null;
   kind: RouteCompareKind;
   /** Point value (or midpoint of [lo,hi] for observed_mixed) — sort key only. */
   probability: number;
@@ -540,11 +547,18 @@ const fmt = (n: number) => n.toLocaleString("en-US");
 const shortLabel = (s: string) => s.replace(/\s*Fleet$/i, "").trim();
 
 function brand(cfg: AirlineConfig) {
+  const site = siteForAirline(cfg.code, true);
   return {
     airline: cfg.code,
     name: cfg.name,
+    shortName: cfg.shortName,
     accentColor: cfg.brand.accentColor,
     canonicalHost: new URL(airlineHomeUrl(cfg.code)).host,
+    // Path-style URL the per-airline route planner reads; null when that
+    // tenant doesn't have a planner page (the chip hides).
+    routePlannerBase: site?.features.routePlannerPage
+      ? `https://${site.canonicalHost}/route-planner`
+      : null,
   };
 }
 

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -18,7 +18,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { airlineHomeUrl, enabledAirlines } from "../airlines/registry";
+import { type AirlineConfig, airlineHomeUrl, publicAirlines } from "../airlines/registry";
 import type { VerificationObservation as Observation } from "../database/database";
 import { type Scope, type ScopedReader, createReaderFactory } from "../database/reader";
 import { ensureUAPrefix, inferFleet } from "../utils/constants";
@@ -503,69 +503,181 @@ export function predictRoute(
 }
 
 // ============================================================================
-// Itinerary planning (multi-stop graph search)
+// Route comparison (per-airline subfleet penetration on a nonstop)
 // ============================================================================
 
-// Minimum leg probability to include in the graph (full-coverage or partial)
+export type RouteCompareKind =
+  | "type_rule"
+  | "observed_single"
+  | "observed_mixed"
+  | "inferred_absent";
+
+export interface SubfleetBreakdown {
+  key: string;
+  label: string;
+  hint?: string;
+  equipped: number;
+  total: number;
+  pct: number;
+}
+
 export interface RouteCompareResult {
   airline: string;
   name: string;
-  probability: number;
-  reason: string;
-  n: number;
   accentColor: string;
   canonicalHost: string;
+  kind: RouteCompareKind;
+  /** Point value (or midpoint of [lo,hi] for observed_mixed) — sort key only. */
+  probability: number;
+  lo?: number;
+  hi?: number;
+  breakdown: SubfleetBreakdown[];
+  reason: string;
+}
+
+const fmt = (n: number) => n.toLocaleString("en-US");
+
+function brand(cfg: AirlineConfig) {
+  return {
+    airline: cfg.code,
+    name: cfg.name,
+    accentColor: cfg.brand.accentColor,
+    canonicalHost: new URL(airlineHomeUrl(cfg.code)).host,
+  };
 }
 
 /**
- * Per-airline Starlink probability for an O-D pair. Hub-only — answers
- * "should I fly UA or HA on SFO-HNL?". Uses observed upcoming_flights when
- * available, falls back to routeTypeRule for type-deterministic airlines,
- * skips airlines that neither serve the route nor have a rule.
+ * Per-airline Starlink odds for a NONSTOP O-D pair. Hub-only.
+ *
+ * Reports the install rate across the subfleet(s) each carrier flies nonstop
+ * on this route — equipped tails ÷ all tails in that subfleet, from the full
+ * fleet roster. NOT a best-case-routing optimizer (the previous planItinerary
+ * approach returned 97% for UA SFO-AUS via OMA, which nobody books).
  */
 export function compareRoute(
-  reader: ScopedReader,
+  getReader: (code: string) => ScopedReader,
   origin: string,
   destination: string
 ): RouteCompareResult[] {
   const o = origin.toUpperCase().trim();
   const d = destination.toUpperCase().trim();
-  const results: RouteCompareResult[] = [];
-  const airlines = enabledAirlines().filter((a) => reader.airlines.includes(a.code));
+  const out: RouteCompareResult[] = [];
+  const ceilings = new Map<string, number>();
 
-  for (const cfg of airlines) {
-    const rows = reader.getRouteAirlineCoverage(o, d, cfg.code);
+  for (const cfg of publicAirlines()) {
+    const reader = getReader(cfg.code);
 
-    let probability: number;
-    let reason: string;
-    let n = rows.length;
-
-    if (rows.length > 0) {
-      const sl = rows.filter((r) => r.sl).length;
-      probability = sl / rows.length;
-      reason = `${sl} of ${rows.length} scheduled flights on Starlink-equipped aircraft (next ~48h)`;
-    } else if (cfg.routeTypeRule) {
+    // ---- 1. Type-deterministic carriers (HA today) ----
+    if (cfg.routeTypeRule) {
       const rule = cfg.routeTypeRule(o, d);
-      probability = rule.probability;
-      reason = rule.reason;
-      n = 0;
-    } else {
+      if (!rule) continue;
+      if (!reader.airlineServesAirports(o, d)) continue;
+      out.push({
+        ...brand(cfg),
+        kind: "type_rule",
+        probability: rule.probability,
+        breakdown: [],
+        reason: rule.reason,
+      });
       continue;
     }
 
-    results.push({
-      airline: cfg.code,
-      name: cfg.name,
-      probability,
-      reason,
-      n,
-      accentColor: cfg.brand.accentColor,
-      canonicalHost: new URL(airlineHomeUrl(cfg.code)).host,
+    // ---- 2. Unbiased per-subfleet penetration from full roster ----
+    const pen = reader.getSubfleetPenetration();
+    if (pen.size === 0) continue;
+    const penArr: SubfleetBreakdown[] = cfg.subfleets.map((sf) => {
+      const p = pen.get(sf.key) ?? { equipped: 0, total: 0, pct: 0 };
+      return {
+        key: sf.key,
+        label: sf.label,
+        hint: sf.flightNumberHint,
+        equipped: p.equipped,
+        total: p.total,
+        pct: p.pct,
+      };
     });
+    const maxPct = Math.max(...penArr.map((p) => p.pct));
+    const minSub = penArr.reduce((a, b) => (a.pct <= b.pct ? a : b));
+    ceilings.set(cfg.code, maxPct);
+
+    // ---- 3. Which subfleet(s) fly this nonstop? ----
+    const prefixes = [cfg.iata, cfg.icao, ...cfg.carrierPrefixes];
+    const fns = reader.getObservedDirectFlightNumbers(prefixes, o, d);
+    const seen = new Set<string>();
+    for (const fn of fns) {
+      const sf = cfg.subfleets.find((s) => s.match(fn));
+      if (sf) seen.add(sf.key);
+    }
+
+    if (seen.size === 1) {
+      const sf = penArr.find((p) => seen.has(p.key))!;
+      out.push({
+        ...brand(cfg),
+        kind: "observed_single",
+        probability: sf.pct,
+        breakdown: [sf],
+        reason: `Nonstop on ${sf.label} — ${fmt(sf.equipped)} of ${fmt(sf.total)} equipped`,
+      });
+    } else if (seen.size >= 2) {
+      // Do NOT frequency-weight by observed FN count: the observation set is
+      // Starlink-biased toward the high-penetration subfleet, so weighting
+      // would systematically overstate. Show the honest range + the rule.
+      const bd = penArr.filter((p) => seen.has(p.key)).sort((a, b) => b.pct - a.pct);
+      const lo = Math.min(...bd.map((b) => b.pct));
+      const hi = Math.max(...bd.map((b) => b.pct));
+      out.push({
+        ...brand(cfg),
+        kind: "observed_mixed",
+        probability: (lo + hi) / 2,
+        lo,
+        hi,
+        breakdown: bd,
+        reason: "Mixed equipment — depends on flight number",
+      });
+    } else {
+      // ---- 4. Unobserved nonstop ----
+      // Gate A: airline must touch both airports (Starlink-biased; failure
+      //   mode is omission, not a wrong number — covered by footer copy).
+      // Gate B: max subfleet penetration ≥ 0.5. With ≥50% of a subfleet tracked
+      //   over ~65 days, a daily nonstop on that subfleet would have appeared
+      //   with P > 1 - 0.5^65 ≈ 1. Absence ⇒ that subfleet does not fly the route.
+      if (!reader.airlineServesAirports(o, d)) continue;
+      if (maxPct < 0.5) continue;
+      // Both subfleets ≥50% would mean BOTH are ruled out by the same
+      // absence argument — i.e. the airline doesn't fly the nonstop. Omit.
+      if (minSub.pct >= 0.5) continue;
+      out.push({
+        ...brand(cfg),
+        kind: "inferred_absent",
+        probability: minSub.pct,
+        breakdown: [minSub],
+        reason: `No Starlink-equipped ${cfg.shortName} aircraft seen on this route — likely ${minSub.label} (${fmt(minSub.equipped)} of ${fmt(minSub.total)} equipped)`,
+      });
+    }
   }
 
-  return results.sort((a, b) => b.probability - a.probability);
+  // ---- 5. Invariant guard ----
+  // No non-rule result may exceed that airline's best-equipped subfleet rate.
+  // This is the bug class we're fixing (UA SFO-AUS at 97% > 64% express ceiling).
+  for (const r of out) {
+    if (r.kind === "type_rule") continue;
+    const ceil = ceilings.get(r.airline) ?? 1;
+    const top = r.hi ?? r.probability;
+    if (top > ceil + 1e-6) {
+      throw new Error(
+        `compareRoute invariant: ${r.airline} ${o}-${d} = ${top.toFixed(3)} > ceiling ${ceil.toFixed(3)}`
+      );
+    }
+  }
+
+  // Sort: confident kinds by upper bound desc; inferred_absent always last.
+  const rank = (r: RouteCompareResult) => (r.kind === "inferred_absent" ? 0 : 1);
+  return out.sort((a, b) => rank(b) - rank(a) || (b.hi ?? b.probability) - (a.hi ?? a.probability));
 }
+
+// ============================================================================
+// Itinerary planning (multi-stop graph search)
+// ============================================================================
 
 const MIN_LEG_PROBABILITY = 0.3;
 

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -510,7 +510,8 @@ export type RouteCompareKind =
   | "type_rule"
   | "observed_single"
   | "observed_mixed"
-  | "inferred_absent";
+  | "inferred_absent"
+  | "no_data";
 
 export interface SubfleetBreakdown {
   key: string;
@@ -566,12 +567,13 @@ export function compareRoute(
 
   for (const cfg of publicAirlines()) {
     const reader = getReader(cfg.code);
+    const prefixes = [cfg.iata, cfg.icao, ...cfg.carrierPrefixes];
 
     // ---- 1. Type-deterministic carriers (HA today) ----
     if (cfg.routeTypeRule) {
       const rule = cfg.routeTypeRule(o, d);
       if (!rule) continue;
-      if (!reader.airlineServesAirports(o, d)) continue;
+      if (!reader.airlineServesAirports(prefixes, o, d)) continue;
       out.push({
         ...brand(cfg),
         kind: "type_rule",
@@ -601,7 +603,6 @@ export function compareRoute(
     ceilings.set(cfg.code, maxPct);
 
     // ---- 3. Which subfleet(s) fly this nonstop? ----
-    const prefixes = [cfg.iata, cfg.icao, ...cfg.carrierPrefixes];
     const fns = reader.getObservedDirectFlightNumbers(prefixes, o, d);
     const seen = new Set<string>();
     for (const fn of fns) {
@@ -641,18 +642,32 @@ export function compareRoute(
       // Gate B: max subfleet penetration ≥ 0.5. With ≥50% of a subfleet tracked
       //   over ~65 days, a daily nonstop on that subfleet would have appeared
       //   with P > 1 - 0.5^65 ≈ 1. Absence ⇒ that subfleet does not fly the route.
-      if (!reader.airlineServesAirports(o, d)) continue;
-      if (maxPct < 0.5) continue;
-      // Both subfleets ≥50% would mean BOTH are ruled out by the same
-      // absence argument — i.e. the airline doesn't fly the nonstop. Omit.
-      if (minSub.pct >= 0.5) continue;
-      out.push({
-        ...brand(cfg),
-        kind: "inferred_absent",
-        probability: minSub.pct,
-        breakdown: [minSub],
-        reason: `${fmt(minSub.equipped)} of ${fmt(minSub.total)} aircraft equipped`,
-      });
+      if (
+        reader.airlineServesAirports(prefixes, o, d) &&
+        maxPct >= 0.5 &&
+        // Both subfleets ≥50% would mean BOTH are ruled out by the same
+        // absence argument — i.e. the airline doesn't fly the nonstop. no_data.
+        minSub.pct < 0.5
+      ) {
+        out.push({
+          ...brand(cfg),
+          kind: "inferred_absent",
+          probability: minSub.pct,
+          breakdown: [minSub],
+          reason: `${fmt(minSub.equipped)} of ${fmt(minSub.total)} aircraft equipped`,
+        });
+      } else {
+        // Always render every public airline so the panel is symmetric — a
+        // missing carrier reads as inconsistent ("why is AS shown but UA
+        // isn't on the same route?"). no_data is honest about the gap.
+        out.push({
+          ...brand(cfg),
+          kind: "no_data",
+          probability: -1,
+          breakdown: [],
+          reason: "No route data yet",
+        });
+      }
     }
   }
 
@@ -660,7 +675,7 @@ export function compareRoute(
   // No non-rule result may exceed that airline's best-equipped subfleet rate.
   // This is the bug class we're fixing (UA SFO-AUS at 97% > 64% express ceiling).
   for (const r of out) {
-    if (r.kind === "type_rule") continue;
+    if (r.kind === "type_rule" || r.kind === "no_data") continue;
     const ceil = ceilings.get(r.airline) ?? 1;
     const top = r.hi ?? r.probability;
     if (top > ceil + 1e-6) {
@@ -670,8 +685,13 @@ export function compareRoute(
     }
   }
 
-  // Sort: confident kinds by upper bound desc; inferred_absent always last.
-  const rank = (r: RouteCompareResult) => (r.kind === "inferred_absent" ? 0 : 1);
+  // Every-carrier-no_data ⇒ garbage route ⇒ empty (the panel's empty-state copy
+  // covers it). If ANY carrier has data, keep the no_data rows for symmetry.
+  if (out.every((r) => r.kind === "no_data")) return [];
+
+  // Sort: confident kinds by upper bound desc; inferred_absent then no_data last.
+  const rank = (r: RouteCompareResult) =>
+    r.kind === "no_data" ? -1 : r.kind === "inferred_absent" ? 0 : 1;
   return out.sort((a, b) => rank(b) - rank(a) || (b.hi ?? b.probability) - (a.hi ?? a.probability));
 }
 

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -537,6 +537,7 @@ export interface RouteCompareResult {
 }
 
 const fmt = (n: number) => n.toLocaleString("en-US");
+const shortLabel = (s: string) => s.replace(/\s*Fleet$/i, "").trim();
 
 function brand(cfg: AirlineConfig) {
   return {
@@ -567,20 +568,26 @@ export function compareRoute(
 
   for (const cfg of publicAirlines()) {
     const reader = getReader(cfg.code);
-    const prefixes = [cfg.iata, cfg.icao, ...cfg.carrierPrefixes];
+    // flight_routes has no airline column, so the prefix glob would attribute
+    // shared-regional rows (OO/SKW for SkyWest, ENY/PDT etc.) to UA. flight_routes
+    // is written via ensureAirlinePrefix → marketing IATA, so iata+icao is enough.
+    const prefixes = [cfg.iata, cfg.icao];
 
     // ---- 1. Type-deterministic carriers (HA today) ----
     if (cfg.routeTypeRule) {
       const rule = cfg.routeTypeRule(o, d);
-      if (!rule) continue;
-      if (!reader.airlineServesAirports(prefixes, o, d)) continue;
-      out.push({
-        ...brand(cfg),
-        kind: "type_rule",
-        probability: rule.probability,
-        breakdown: [],
-        reason: rule.reason,
-      });
+      if (rule && reader.airlineServesAirports(prefixes, o, d)) {
+        out.push({
+          ...brand(cfg),
+          kind: "type_rule",
+          probability: rule.probability,
+          breakdown: [],
+          reason: rule.reason,
+        });
+      } else {
+        // Symmetry: HA renders no_data on mainland-mainland instead of vanishing.
+        out.push({ ...brand(cfg), kind: "no_data", probability: -1, breakdown: [], reason: "" });
+      }
       continue;
     }
 
@@ -588,7 +595,13 @@ export function compareRoute(
     const pen = reader.getSubfleetPenetration();
     if (pen.size === 0) continue;
     const penArr: SubfleetBreakdown[] = cfg.subfleets.map((sf) => {
-      const p = pen.get(sf.key) ?? { equipped: 0, total: 0, pct: 0 };
+      // penetrationOverride: subfleets that fly on another carrier's metal
+      // (e.g. AS800-899 on Hawaiian A330/A321neo) — the roster has those tails
+      // under the operating airline, not the marketing one.
+      const p =
+        sf.penetrationOverride != null
+          ? { equipped: 1, total: 1, pct: sf.penetrationOverride }
+          : (pen.get(sf.key) ?? { equipped: 0, total: 0, pct: 0 });
       return {
         key: sf.key,
         label: sf.label,
@@ -612,13 +625,31 @@ export function compareRoute(
 
     if (seen.size === 1) {
       const sf = penArr.find((p) => seen.has(p.key))!;
-      out.push({
-        ...brand(cfg),
-        kind: "observed_single",
-        probability: sf.pct,
-        breakdown: [sf],
-        reason: `${fmt(sf.equipped)} of ${fmt(sf.total)} aircraft equipped`,
-      });
+      // We can prove the high-pen subfleet flies the route, but NOT that the
+      // low-pen one doesn't (it's invisible to us). When the seen subfleet is
+      // the high one and a low-pen (<50%) sibling exists, show the honest
+      // range — otherwise SEA-ANC reads "AS 100%" when it's mostly 737s at 0%.
+      const lowSibling = penArr.find((p) => p.key !== sf.key && p.pct < 0.5);
+      if (sf.pct === maxPct && lowSibling) {
+        const bd = [sf, lowSibling].sort((a, b) => b.pct - a.pct);
+        out.push({
+          ...brand(cfg),
+          kind: "observed_mixed",
+          probability: (sf.pct + lowSibling.pct) / 2,
+          lo: lowSibling.pct,
+          hi: sf.pct,
+          breakdown: bd,
+          reason: "Depends on flight number",
+        });
+      } else {
+        out.push({
+          ...brand(cfg),
+          kind: "observed_single",
+          probability: sf.pct,
+          breakdown: [sf],
+          reason: `${shortLabel(sf.label)} on this route — ${fmt(sf.equipped)} of ${fmt(sf.total)} equipped`,
+        });
+      }
     } else if (seen.size >= 2) {
       // Do NOT frequency-weight by observed FN count: the observation set is
       // Starlink-biased toward the high-penetration subfleet, so weighting

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -533,6 +533,8 @@ export interface RouteCompareResult {
   hi?: number;
   breakdown: SubfleetBreakdown[];
   reason: string;
+  /** observed_mixed only: the high-penetration subfleet's FN range, for the chip. */
+  bestPick?: { hint: string; pct: number };
 }
 
 const fmt = (n: number) => n.toLocaleString("en-US");
@@ -616,7 +618,7 @@ export function compareRoute(
         kind: "observed_single",
         probability: sf.pct,
         breakdown: [sf],
-        reason: `Nonstop on ${sf.label} — ${fmt(sf.equipped)} of ${fmt(sf.total)} equipped`,
+        reason: `${fmt(sf.equipped)} of ${fmt(sf.total)} aircraft equipped`,
       });
     } else if (seen.size >= 2) {
       // Do NOT frequency-weight by observed FN count: the observation set is
@@ -632,7 +634,10 @@ export function compareRoute(
         lo,
         hi,
         breakdown: bd,
-        reason: "Mixed equipment — depends on flight number",
+        // The chip surfaces the high-penetration subfleet's flight-number range
+        // as the actionable hint; the breakdown rows show the rest.
+        bestPick: { hint: bd[0].hint ?? "", pct: bd[0].pct },
+        reason: "Depends on flight number",
       });
     } else {
       // ---- 4. Unobserved nonstop ----
@@ -651,7 +656,7 @@ export function compareRoute(
         kind: "inferred_absent",
         probability: minSub.pct,
         breakdown: [minSub],
-        reason: `No Starlink-equipped ${cfg.shortName} aircraft seen on this route — likely ${minSub.label} (${fmt(minSub.equipped)} of ${fmt(minSub.total)} equipped)`,
+        reason: `${fmt(minSub.equipped)} of ${fmt(minSub.total)} aircraft equipped`,
       });
     }
   }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -665,7 +665,7 @@ const apiCheckAnyFlight: Handler = ({ req, url, reader, getReader, tenant }) => 
   );
 };
 
-const apiCompareRoute: Handler = ({ req, url, reader, tenant }) => {
+const apiCompareRoute: Handler = ({ req, url, getReader, tenant }) => {
   if (req.method !== "GET") return methodNotAllowed(true);
   const guard = hubOnly(tenant);
   if (guard) return guard;
@@ -679,7 +679,7 @@ const apiCompareRoute: Handler = ({ req, url, reader, tenant }) => {
     );
   }
 
-  const results = compareRoute(reader, origin, destination);
+  const results = compareRoute(getReader, origin, destination);
   return new Response(
     JSON.stringify({
       origin: origin.toUpperCase(),
@@ -1270,7 +1270,7 @@ const homePage: Handler = async (ctx) => {
       content,
       airlineByTail: reader.getAirlineByTail(),
       perAirlineStats: isHub ? reader.getPerAirlineStats() : undefined,
-      recentInstalls: isHub ? reader.getRecentInstalls(25) : undefined,
+      recentInstalls: isHub ? reader.getRecentInstalls(15, 5) : undefined,
       flightsByTail,
       airportDepartures: reader.getAirportDepartures(),
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface FleetStats {
   mainline: FleetMetrics;
 }
 
+export type RolloutStatus = "complete" | "phase_done" | "in_progress";
+
 export interface PerAirlineStat {
   code: string;
   name: string;
@@ -36,6 +38,9 @@ export interface PerAirlineStat {
   total: number;
   fleetTotal?: number;
   installs30d?: number;
+  status?: RolloutStatus;
+  statusLabel?: string;
+  phaseNote?: string;
   accentColor?: string;
   href?: string;
 }

--- a/tests/route-compare.test.ts
+++ b/tests/route-compare.test.ts
@@ -71,7 +71,7 @@ describe("compareRoute", () => {
       pHi: 0.4,
       why: "AS serves both, horizon 100% would have appeared → mainline rate",
     },
-    { o: "SFO", d: "AUS", code: "HA", kind: "omitted", why: "neither endpoint in HI" },
+    { o: "SFO", d: "AUS", code: "HA", kind: "no_data", why: "neither endpoint in HI" },
 
     // SEA-SFO: UA mixed (express + mainline both observed)
     {
@@ -93,7 +93,7 @@ describe("compareRoute", () => {
       pHi: 0.4,
       why: "AS serves both, no AS-prefix direct observed → mainline rate",
     },
-    { o: "SEA", d: "SFO", code: "HA", kind: "omitted", why: "routeTypeRule null on mainland-only" },
+    { o: "SEA", d: "SFO", code: "HA", kind: "no_data", why: "routeTypeRule null on mainland-only" },
 
     // SFO-HNL: HA type rule fires; UA/AS omitted (no Starlink tail at HNL)
     {
@@ -165,16 +165,17 @@ describe("compareRoute", () => {
     expect(find("SFO", "HNL", "HA")?.reason).toMatch(/A330|A321/i);
   });
 
-  // AS on SFO-HNL is open_question #1 in the spec: AS811-822 are HA-operated
-  // post-merger but cached in flight_routes with the AS prefix. Either omitted
-  // (if the snapshot lacks those rows) or observed_single at the AS-mainline
-  // rate is acceptable; both are materially honest. What's NOT acceptable is
-  // a high number.
-  test("AS SFO-HNL: omitted or low — never high", () => {
+  // AS on SFO-HNL: AS800-899 are AS-marketed flights on Hawaiian A330/A321neo
+  // metal post-merger (verified: tails N209HA, N213HA in upcoming_flights for
+  // AS8xx). When the fixture has those routes cached, AS should map to the
+  // hawaiian_metal subfleet at ~100%, NOT mainline 0%.
+  test("AS SFO-HNL: maps to hawaiian_metal subfleet, not mainline", () => {
     const r = find("SFO", "HNL", "AS");
-    if (r) {
-      expect(r.kind).not.toBe("observed_mixed");
-      expect(r.probability).toBeLessThan(0.1);
+    if (r && r.kind !== "no_data" && r.kind !== "inferred_absent") {
+      // hawaiian_metal observed: AS800-899 should resolve to ≥90%
+      const ha = r.breakdown.find((b) => b.key === "hawaiian_metal");
+      expect(ha).toBeDefined();
+      expect(ha!.pct).toBeGreaterThanOrEqual(0.9);
     }
   });
 
@@ -182,12 +183,25 @@ describe("compareRoute", () => {
     expect(find("OGG", "KOA", "HA")?.reason).toMatch(/717/);
   });
 
-  test("inferred_absent rows sort after confident rows", () => {
-    const results = compareRoute(getReader, "SEA", "SFO");
-    let seenInferred = false;
-    for (const r of results) {
-      if (r.kind === "inferred_absent") seenInferred = true;
-      else expect(seenInferred).toBe(false);
+  test("rows sort: confident → inferred → no_data", () => {
+    const rank = {
+      type_rule: 2,
+      observed_single: 2,
+      observed_mixed: 2,
+      inferred_absent: 1,
+      no_data: 0,
+    };
+    for (const [o, d] of [
+      ["SEA", "SFO"],
+      ["SFO", "HNL"],
+      ["SFO", "AUS"],
+    ]) {
+      let prev = 99;
+      for (const r of compareRoute(getReader, o, d)) {
+        const cur = rank[r.kind];
+        expect(cur).toBeLessThanOrEqual(prev);
+        prev = cur;
+      }
     }
   });
 
@@ -208,11 +222,14 @@ describe("compareRoute", () => {
     for (const cfg of publicAirlines()) {
       if (cfg.routeTypeRule) continue;
       const pen = getSubfleetPenetration(db, cfg.code);
-      ceiling.set(cfg.code, Math.max(0, ...[...pen.values()].map((p) => p.pct)));
+      // Same ceiling the model uses: max over per-subfleet penetration,
+      // including any penetrationOverride (e.g. AS800-899 on HA metal).
+      const pcts = cfg.subfleets.map((sf) => sf.penetrationOverride ?? pen.get(sf.key)?.pct ?? 0);
+      ceiling.set(cfg.code, Math.max(0, ...pcts));
     }
     for (const [o, d] of ROUTES) {
       for (const r of compareRoute(getReader, o, d)) {
-        if (r.kind === "type_rule") continue;
+        if (r.kind === "type_rule" || r.kind === "no_data") continue;
         const ceil = ceiling.get(r.airline);
         expect(ceil).toBeDefined();
         expect(r.hi ?? r.probability).toBeLessThanOrEqual(ceil! + 1e-6);
@@ -222,6 +239,40 @@ describe("compareRoute", () => {
 
   test("nonexistent airports → empty", () => {
     expect(compareRoute(getReader, "ZZZ", "YYY")).toEqual([]);
+  });
+
+  // OO/SKW prefix collision regression: SkyWest (OO) operates for Alaska,
+  // Delta, and American — not just United. The flight_routes glob must NOT
+  // attribute OO-prefixed rows to UA Express. Pre-fix, BOI-SEA showed UA at
+  // 65% (phantom — UA doesn't fly it).
+  test.each([
+    ["SEA", "PDX"],
+    ["BOI", "SEA"],
+  ])("OO collision guard: UA on %s-%s is not observed_*", (o, d) => {
+    const r = find(o, d, "UA");
+    expect(["no_data", "inferred_absent", undefined]).toContain(r?.kind);
+  });
+
+  // SEA-ANC overstatement regression: AS flies it on ~10x daily mainline 737
+  // (0% Starlink, structurally invisible) plus ~1x Horizon E175 (100%, the
+  // only observable). Pre-fix, observed_single said "AS 100%". Now: when ONLY
+  // the high-pen subfleet is seen and a <50% sibling exists, render a range.
+  test("low-pen-sibling guard: never observed_single ≥50% when a <50% sibling exists", () => {
+    for (const [o, d] of [
+      ["SEA", "ANC"],
+      ["DEN", "SAN"],
+      ["SEA", "LAX"],
+      ["SFO", "HNL"],
+      ["PDX", "SFO"],
+    ]) {
+      for (const code of ["AS", "UA"]) {
+        const r = find(o, d, code);
+        if (r?.kind === "observed_single") {
+          // Single is only allowed for the LOW-pen subfleet (no overstatement risk).
+          expect(r.probability).toBeLessThan(0.5);
+        }
+      }
+    }
   });
 
   test("symmetry: every non-routeTypeRule carrier appears on every real route", () => {

--- a/tests/route-compare.test.ts
+++ b/tests/route-compare.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Route-compare + planner behavior tests against the hermetic /tmp/ua-test.sqlite
+ * snapshot. Asserts shapes and bounded ranges (not exact values) so they
+ * survive data drift; the SFO-AUS regression guard is the load-bearing case.
+ */
+import { Database } from "bun:sqlite";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { publicAirlines } from "../src/airlines/registry";
+import { getSubfleetPenetration } from "../src/database/database";
+import {
+  type RouteCompareResult,
+  compareRoute,
+  planItinerary,
+} from "../src/scripts/starlink-predictor";
+import { createReaderFactory } from "../src/server/context";
+
+const TEST_DB = "/tmp/ua-test.sqlite";
+let db: Database;
+let hubReader: ReturnType<ReturnType<typeof createReaderFactory>>;
+let getReader: (code: string) => ReturnType<ReturnType<typeof createReaderFactory>>;
+
+beforeAll(() => {
+  db = new Database(TEST_DB, { readonly: true });
+  const factory = createReaderFactory(db);
+  hubReader = factory("ALL");
+  getReader = (code: string) => factory(code);
+});
+afterAll(() => db.close());
+
+const find = (o: string, d: string, code: string): RouteCompareResult | undefined =>
+  compareRoute(getReader, o, d).find((r) => r.airline === code);
+
+// ── compareRoute ──────────────────────────────────────────────────────────────
+//
+// Asserts RANGES, not exact values — the test snapshot drifts as the rollout
+// progresses. The hard regression target is UA SFO-AUS: the old planItinerary
+// path returned ~97% (cherry-picked SFO→OMA→AUS). Mainline penetration is the
+// honest answer.
+
+describe("compareRoute", () => {
+  type Case = {
+    o: string;
+    d: string;
+    code: string;
+    kind: RouteCompareResult["kind"] | "omitted";
+    pLo?: number;
+    pHi?: number;
+    rangeLoMax?: number;
+    rangeHiMin?: number;
+    rangeHiMax?: number;
+    why: string;
+  };
+
+  const CASES: Case[] = [
+    // SFO-AUS: primary regression guard. Zero observed; both airports served.
+    {
+      o: "SFO",
+      d: "AUS",
+      code: "UA",
+      kind: "inferred_absent",
+      pLo: 0,
+      pHi: 0.4,
+      why: "no Starlink tail seen → mainline rate, NOT 97% via OMA",
+    },
+    {
+      o: "SFO",
+      d: "AUS",
+      code: "AS",
+      kind: "inferred_absent",
+      pLo: 0,
+      pHi: 0.4,
+      why: "AS serves both, horizon 100% would have appeared → mainline rate",
+    },
+    { o: "SFO", d: "AUS", code: "HA", kind: "omitted", why: "neither endpoint in HI" },
+
+    // SEA-SFO: UA mixed (express + mainline both observed)
+    {
+      o: "SEA",
+      d: "SFO",
+      code: "UA",
+      kind: "observed_mixed",
+      rangeLoMax: 0.4,
+      rangeHiMin: 0.5,
+      rangeHiMax: 1.0,
+      why: "UA499/737 mainline + UA5xxx/6xxx express both observed",
+    },
+    {
+      o: "SEA",
+      d: "SFO",
+      code: "AS",
+      kind: "inferred_absent",
+      pLo: 0,
+      pHi: 0.4,
+      why: "AS serves both, no AS-prefix direct observed → mainline rate",
+    },
+    { o: "SEA", d: "SFO", code: "HA", kind: "omitted", why: "routeTypeRule null on mainland-only" },
+
+    // SFO-HNL: HA type rule fires; UA/AS omitted (no Starlink tail at HNL)
+    {
+      o: "SFO",
+      d: "HNL",
+      code: "HA",
+      kind: "type_rule",
+      pLo: 1,
+      pHi: 1,
+      why: "transpacific A330/A321neo",
+    },
+    { o: "SFO", d: "HNL", code: "UA", kind: "omitted", why: "UA@HNL=0 (widebodies only)" },
+
+    // OGG-KOA: HA interisland 717
+    {
+      o: "OGG",
+      d: "KOA",
+      code: "HA",
+      kind: "type_rule",
+      pLo: 0,
+      pHi: 0,
+      why: "interisland 717, no WiFi",
+    },
+    { o: "OGG", d: "KOA", code: "UA", kind: "omitted", why: "UA does not touch OGG/KOA" },
+
+    // ORD-LAX: UA mainline-only trunk route. Second regression guard.
+    {
+      o: "ORD",
+      d: "LAX",
+      code: "UA",
+      kind: "observed_single",
+      pLo: 0,
+      pHi: 0.4,
+      why: "UA1967/UA353 observed, both <3000 → mainline only, NOT ~100%",
+    },
+    { o: "ORD", d: "LAX", code: "AS", kind: "omitted", why: "AS@ORD=0" },
+  ];
+
+  test.each(CASES)("$o-$d $code → $kind ($why)", (c) => {
+    const r = find(c.o, c.d, c.code);
+    if (c.kind === "omitted") {
+      expect(r).toBeUndefined();
+      return;
+    }
+    expect(r).toBeDefined();
+    expect(r!.kind).toBe(c.kind);
+    expect(r!.reason.length).toBeGreaterThan(5);
+
+    if (c.kind === "observed_mixed") {
+      expect(r!.lo).toBeDefined();
+      expect(r!.hi).toBeDefined();
+      expect(r!.breakdown.length).toBeGreaterThanOrEqual(2);
+      if (c.rangeLoMax !== undefined) expect(r!.lo!).toBeLessThan(c.rangeLoMax);
+      if (c.rangeHiMin !== undefined) expect(r!.hi!).toBeGreaterThan(c.rangeHiMin);
+      if (c.rangeHiMax !== undefined) expect(r!.hi!).toBeLessThan(c.rangeHiMax);
+    } else {
+      if (c.pLo !== undefined) expect(r!.probability).toBeGreaterThanOrEqual(c.pLo);
+      if (c.pHi !== undefined) expect(r!.probability).toBeLessThanOrEqual(c.pHi);
+      if (c.kind !== "type_rule") expect(r!.breakdown.length).toBe(1);
+    }
+  });
+
+  test("HA SFO-HNL reason mentions A330/A321neo", () => {
+    expect(find("SFO", "HNL", "HA")?.reason).toMatch(/A330|A321/i);
+  });
+
+  // AS on SFO-HNL is open_question #1 in the spec: AS811-822 are HA-operated
+  // post-merger but cached in flight_routes with the AS prefix. Either omitted
+  // (if the snapshot lacks those rows) or observed_single at the AS-mainline
+  // rate is acceptable; both are materially honest. What's NOT acceptable is
+  // a high number.
+  test("AS SFO-HNL: omitted or low — never high", () => {
+    const r = find("SFO", "HNL", "AS");
+    if (r) {
+      expect(r.kind).not.toBe("observed_mixed");
+      expect(r.probability).toBeLessThan(0.1);
+    }
+  });
+
+  test("HA OGG-KOA reason mentions 717", () => {
+    expect(find("OGG", "KOA", "HA")?.reason).toMatch(/717/);
+  });
+
+  test("inferred_absent rows sort after confident rows", () => {
+    const results = compareRoute(getReader, "SEA", "SFO");
+    let seenInferred = false;
+    for (const r of results) {
+      if (r.kind === "inferred_absent") seenInferred = true;
+      else expect(seenInferred).toBe(false);
+    }
+  });
+
+  // Structural ceiling: no non-rule result may exceed that airline's
+  // best-equipped subfleet rate. This single assertion would have caught
+  // the 97% bug and guards every code path that feeds compareRoute.
+  test("INVARIANT: probability ≤ max subfleet penetration", () => {
+    const ROUTES = [
+      ["SFO", "AUS"],
+      ["SEA", "SFO"],
+      ["SFO", "HNL"],
+      ["OGG", "KOA"],
+      ["ORD", "LAX"],
+      ["DEN", "SAN"],
+      ["SEA", "LAX"],
+    ];
+    const ceiling = new Map<string, number>();
+    for (const cfg of publicAirlines()) {
+      if (cfg.routeTypeRule) continue;
+      const pen = getSubfleetPenetration(db, cfg.code);
+      ceiling.set(cfg.code, Math.max(0, ...[...pen.values()].map((p) => p.pct)));
+    }
+    for (const [o, d] of ROUTES) {
+      for (const r of compareRoute(getReader, o, d)) {
+        if (r.kind === "type_rule") continue;
+        const ceil = ceiling.get(r.airline);
+        expect(ceil).toBeDefined();
+        expect(r.hi ?? r.probability).toBeLessThanOrEqual(ceil! + 1e-6);
+      }
+    }
+  });
+
+  test("nonexistent airports → empty", () => {
+    expect(compareRoute(getReader, "ZZZ", "YYY")).toEqual([]);
+  });
+});
+
+// ── planItinerary (unchanged behavior) ────────────────────────────────────────
+
+describe("planItinerary", () => {
+  const CASES: Array<[string, string, number, string]> = [
+    ["SEA", "LAX", 1, "direct AS route"],
+    ["HNL", "LAX", 1, "direct HA route"],
+    ["SEA", "BOI", 1, "AS spoke"],
+    ["ZZZ", "YYY", 0, "nonexistent → empty"],
+  ];
+
+  test.each(CASES)("%s → %s: ≥%d itineraries", (o, d, minN) => {
+    const its = planItinerary(hubReader, o, d, { maxItineraries: 5 });
+    expect(its.length).toBeGreaterThanOrEqual(minN);
+  });
+
+  test("itinerary shape: legs, joint probability, totals", () => {
+    const its = planItinerary(hubReader, "SEA", "LAX", { maxItineraries: 3 });
+    for (const it of its) {
+      expect(it.legs.length).toBeGreaterThan(0);
+      expect(it.joint_probability).toBeGreaterThanOrEqual(0);
+      expect(it.joint_probability).toBeLessThanOrEqual(1);
+      expect(it.at_least_one_probability).toBeGreaterThanOrEqual(it.joint_probability);
+      for (const leg of it.legs) {
+        expect(leg.route).toMatch(/^[A-Z]{3}-[A-Z]{3}$/);
+        expect(leg.probability).toBeGreaterThanOrEqual(0);
+        expect(leg.probability).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test("maxStops is respected", () => {
+    for (const maxStops of [0, 1, 2]) {
+      const its = planItinerary(hubReader, "SEA", "LAX", { maxStops, maxItineraries: 10 });
+      for (const it of its) {
+        expect(it.legs.length).toBeLessThanOrEqual(maxStops + 1);
+      }
+    }
+  });
+
+  test("origin == destination returns empty", () => {
+    expect(planItinerary(hubReader, "SEA", "SEA")).toEqual([]);
+    expect(planItinerary(hubReader, "sea", "SEA")).toEqual([]);
+  });
+});

--- a/tests/route-compare.test.ts
+++ b/tests/route-compare.test.ts
@@ -105,7 +105,7 @@ describe("compareRoute", () => {
       pHi: 1,
       why: "transpacific A330/A321neo",
     },
-    { o: "SFO", d: "HNL", code: "UA", kind: "omitted", why: "UA@HNL=0 (widebodies only)" },
+    { o: "SFO", d: "HNL", code: "UA", kind: "no_data", why: "UA@HNL=0 (widebodies only)" },
 
     // OGG-KOA: HA interisland 717
     {
@@ -117,7 +117,7 @@ describe("compareRoute", () => {
       pHi: 0,
       why: "interisland 717, no WiFi",
     },
-    { o: "OGG", d: "KOA", code: "UA", kind: "omitted", why: "UA does not touch OGG/KOA" },
+    { o: "OGG", d: "KOA", code: "UA", kind: "no_data", why: "UA does not touch OGG/KOA" },
 
     // ORD-LAX: UA mainline-only trunk route. Second regression guard.
     {
@@ -129,13 +129,18 @@ describe("compareRoute", () => {
       pHi: 0.4,
       why: "UA1967/UA353 observed, both <3000 → mainline only, NOT ~100%",
     },
-    { o: "ORD", d: "LAX", code: "AS", kind: "omitted", why: "AS@ORD=0" },
+    { o: "ORD", d: "LAX", code: "AS", kind: "no_data", why: "AS@ORD=0" },
   ];
 
   test.each(CASES)("$o-$d $code → $kind ($why)", (c) => {
     const r = find(c.o, c.d, c.code);
     if (c.kind === "omitted") {
       expect(r).toBeUndefined();
+      return;
+    }
+    if (c.kind === "no_data") {
+      expect(r?.kind).toBe("no_data");
+      expect(r?.probability).toBeLessThan(0);
       return;
     }
     expect(r).toBeDefined();
@@ -217,6 +222,32 @@ describe("compareRoute", () => {
 
   test("nonexistent airports → empty", () => {
     expect(compareRoute(getReader, "ZZZ", "YYY")).toEqual([]);
+  });
+
+  test("symmetry: every non-routeTypeRule carrier appears on every real route", () => {
+    // The bug this guards: AS shows on SFO-HNL but UA doesn't, despite both
+    // flying it. Now every carrier without a routeTypeRule renders as one of
+    // observed_*/inferred_absent/no_data — never silently absent.
+    for (const [o, d] of [
+      ["SFO", "AUS"],
+      ["SFO", "HNL"],
+      ["SEA", "SFO"],
+      ["ORD", "LAX"],
+    ]) {
+      const codes = compareRoute(getReader, o, d).map((r) => r.airline);
+      expect(codes).toContain("UA");
+      expect(codes).toContain("AS");
+    }
+  });
+
+  test("no_data rows sort after everything", () => {
+    const r = compareRoute(getReader, "SFO", "HNL");
+    const noDataIdx = r.findIndex((x) => x.kind === "no_data");
+    if (noDataIdx >= 0) {
+      for (let i = noDataIdx; i < r.length; i++) {
+        expect(r[i].kind).toBe("no_data");
+      }
+    }
   });
 });
 


### PR DESCRIPTION
The hub page had two structural problems: a 2-up grid leaving a ~500px dead rectangle below a 3-row leaderboard, with percentages that misled (Hawaiian at 39% when its rollout finished in 2024, Alaska at 26% when its E175 phase is 100% done); and a route compare panel showing the optimizer's best-case routing instead of an honest forecast (UA SFO-AUS at 97% via OMA when the realistic answer is ~4%).

Status cards are now three equal-height cards, % over the full fleet so it reads as 'odds on a random flight,' with a status pill and one sentence of prose explaining the nuance. Route compare now uses per-subfleet penetration from the unbiased `united_fleet` roster, mapped to which subfleet flies the route via flight-number ranges, with an invariant guard that throws if any result exceeds the airline's best-equipped subfleet rate. 25 parameterized tests cover all four cases plus the SFO-AUS regression guard.

Per-airline pages are unchanged.