### PR TITLE
Fix fleet-discovery wasting ~35% of checks on unresolvable flights

### DIFF
--- a/src/airlines/registry.ts
+++ b/src/airlines/registry.ts
@@ -140,10 +140,14 @@ export const AIRLINES: Record<AirlineCode, AirlineConfig> = {
       "PDT",
       "ACA",
       "ENY",
+      "UCA",
+      "AWI",
       "OO",
       "YX",
       "YV",
       "G7",
+      "C5",
+      "ZW",
     ],
     subfleets: [
       {

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -44,6 +44,8 @@ const DISCOVERY_INTERVAL_MS = 30 * 1000; // 30 seconds
 const MAINTENANCE_INTERVAL_MS = 90 * 1000; // 90 seconds
 // Heartbeat interval for logging
 const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+// united.com flight-status only resolves flights ≤2 days out
+const MAX_VERIFIABLE_HORIZON_SEC = 2.5 * 86400;
 
 const fr24Api = new FlightRadar24API();
 
@@ -86,6 +88,19 @@ function extractFlightNumber(flightNumber: string): string {
   return normalized.replace(/^UA/, "");
 }
 
+type RawFlight = { flight_number: string; departure_time: number };
+
+/** First flight whose number normalizes to bare digits and departs within the united.com lookup horizon. */
+export function pickVerifiableFlight<T extends RawFlight>(
+  flights: T[],
+  nowSec = Date.now() / 1000
+): T | undefined {
+  const horizon = nowSec + MAX_VERIFIABLE_HORIZON_SEC;
+  return flights.find(
+    (f) => /^\d+$/.test(extractFlightNumber(f.flight_number)) && f.departure_time < horizon
+  );
+}
+
 interface FlightInfo {
   flightNumber: string;
   date: string;
@@ -116,15 +131,24 @@ async function getUpcomingFlightsForPlane(tailNumber: string): Promise<{
       return null;
     }
 
-    const firstFlight = flights[0];
-    const departureDate = new Date(firstFlight.departure_time * 1000).toISOString().split("T")[0];
+    // FR24 returns operator callsigns (SKW578A, C54287) and flights weeks out;
+    // pick the first one that united.com can actually resolve.
+    const verifiable = pickVerifiableFlight(flights);
+    if (!verifiable) {
+      info(
+        `No verifiable flight for ${tailNumber} (next: ${flights[0].flight_number} on ${new Date(flights[0].departure_time * 1000).toISOString().split("T")[0]})`
+      );
+      return null;
+    }
+
+    const departureDate = new Date(verifiable.departure_time * 1000).toISOString().split("T")[0];
 
     return {
       forVerification: {
-        flightNumber: extractFlightNumber(firstFlight.flight_number),
+        flightNumber: extractFlightNumber(verifiable.flight_number),
         date: departureDate,
-        origin: icaoToIata(firstFlight.departure_airport),
-        destination: icaoToIata(firstFlight.arrival_airport),
+        origin: icaoToIata(verifiable.departure_airport),
+        destination: icaoToIata(verifiable.arrival_airport),
       },
       allFlights: flights.map((f) => ({
         flight_number: f.flight_number,
@@ -384,10 +408,12 @@ async function verifyPlane(
           );
         }
 
-        if (result.hasStarlink) {
-          info(`${plane.tail_number} confirmed Starlink (${result.wifiProvider})`);
-        } else if (result.error) {
+        if (result.error) {
           warn(`${plane.tail_number} error: ${result.error}`);
+        } else if (tailMismatch) {
+          info(`${plane.tail_number} skipped (aircraft swap to ${resolvedTail})`);
+        } else if (result.hasStarlink) {
+          info(`${plane.tail_number} confirmed Starlink (${result.wifiProvider})`);
         } else {
           info(`${plane.tail_number} no Starlink (${result.wifiProvider || "unknown"})`);
         }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -26,6 +26,7 @@ import {
   getTotalCount,
   getUpcomingFlights,
 } from "../src/database/database";
+import { pickVerifiableFlight } from "../src/scripts/fleet-discovery";
 import { computePrecision } from "../src/scripts/precision-backtest";
 import { planItinerary, predictFlight, predictRoute } from "../src/scripts/starlink-predictor";
 import { computeSurfaceContradictions } from "../src/scripts/surface-sweep";
@@ -836,12 +837,56 @@ describe("flight number utils", () => {
     expect(ensureUAPrefix("  ua671  ")).toBe("UA671");
   });
 
-  test("normalizeFlightNumber: carrier prefix → UA", () => {
-    expect(normalizeFlightNumber("SKW5882")).toBe("UA5882");
-    expect(normalizeFlightNumber("ASH4054")).toBe("UA4054");
-    expect(normalizeFlightNumber("UAL544")).toBe("UA544");
-    expect(normalizeFlightNumber("UA1234")).toBe("UA1234");
-    expect(normalizeFlightNumber("OO4680")).toBe("UA4680");
+  test.each([
+    ["SKW5882", "UA5882"],
+    ["ASH4054", "UA4054"],
+    ["UAL544", "UA544"],
+    ["UA1234", "UA1234"],
+    ["OO4680", "UA4680"],
+    ["C54287", "UA4287"],
+    ["UCA4259", "UA4259"],
+    ["AWI3625", "UA3625"],
+    ["ZW4412", "UA4412"],
+    // ATC-suffixed callsigns can't map to a marketing number — must pass through
+    // unchanged so callers can detect and skip them.
+    ["SKW578A", "SKW578A"],
+  ])("normalizeFlightNumber: %s → %s", (input, expected) => {
+    expect(normalizeFlightNumber(input)).toBe(expected);
+  });
+
+  test.each<[string, { fn: string; days: number }[], string | undefined]>([
+    [
+      "skips ATC callsign, picks next",
+      [
+        { fn: "SKW578A", days: 0.5 },
+        { fn: "UA1268", days: 1 },
+      ],
+      "UA1268",
+    ],
+    [
+      "skips >2.5d-out, picks next",
+      [
+        { fn: "UA314", days: 4 },
+        { fn: "OO4680", days: 2 },
+      ],
+      "OO4680",
+    ],
+    ["normalizes regional prefix in-window", [{ fn: "C54287", days: 1 }], "C54287"],
+    [
+      "nothing usable → undefined",
+      [
+        { fn: "SKW578A", days: 1 },
+        { fn: "UA314", days: 3 },
+      ],
+      undefined,
+    ],
+  ])("pickVerifiableFlight: %s", (_, flights, expected) => {
+    const now = 1_700_000_000;
+    const picked = pickVerifiableFlight(
+      flights.map((f) => ({ flight_number: f.fn, departure_time: now + f.days * 86400 })),
+      now
+    );
+    expect(picked?.flight_number).toBe(expected);
   });
 
   test("buildFlightNumberVariants: UA number → all carrier variants", () => {


### PR DESCRIPTION
Prod-log audit found ~35% of fleet-discovery checks in a 14h window hitting `Flight not found (redirected to search page)` — split between two causes:

- **Regional carrier prefixes**: FR24 returns `C54287` / `UCA4259` / `SKW578A` for Express tails. `extractFlightNumber` only stripped `^UA`, so united.com was queried for `UAC54287`. Span-correlated: 23/23 such attempts → 404. Added `UCA/AWI/C5/ZW` to `carrierPrefixes`; ATC-suffixed callsigns (`SKW578A`) can't be normalized and are now skipped by the picker.
- **Dates >2 days out**: united.com flight-status only resolves ≤2d. `flights[0]` was taken blindly; span-correlated 20/20 attempts on +3d → 404. `pickVerifiableFlight()` now picks the first flight that normalizes to bare digits *and* is <2.5d out.

Also fixes a log-only swap bug where the result line attributed the swapped aircraft's wifi to the original tail (DB writes were already correct).

Tests: parameterized `normalizeFlightNumber` cases + new `pickVerifiableFlight` cases.