### PR TITLE
Observability fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ ENV LOG_DIR=/srv/ua-starlink-tracker/logs
 ENV DD_ENV=prod
 ENV DD_SERVICE=ua-starlink-tracker
 ENV DD_VERSION=${SOURCE_COMMIT}
+ENV DD_GIT_COMMIT_SHA=${SOURCE_COMMIT}
+ENV DD_GIT_REPOSITORY_URL=github.com/martinamps/ua-starlink-tracker
 ENV DD_TRACE_AGENT_HOSTNAME=host.docker.internal
 ENV DD_RUNTIME_METRICS_ENABLED=false
 

--- a/server.ts
+++ b/server.ts
@@ -24,7 +24,10 @@ import { createApp } from "./src/server/app";
 import { info, error as logError } from "./src/utils/logger";
 import { fetchAllSheets } from "./src/utils/utils";
 
-process.on("unhandledRejection", (reason) => logError("Unhandled Rejection", reason));
+process.on("unhandledRejection", (reason) => {
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  logError("Unhandled Rejection", err);
+});
 process.on("uncaughtException", (err) => logError("Uncaught Exception", err));
 
 const PORT = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 3000;

--- a/src/observability/tracer.ts
+++ b/src/observability/tracer.ts
@@ -68,7 +68,7 @@ if (isEnabled) {
     logInjection: true,
     profiling: false,
     runtimeMetrics: false,
-    startupLogs: true,
+    startupLogs: false,
     // Disable auto-instrumentation by default — `net`/`dns` plugins trace
     // Playwright pipe FDs (tcp.connect localhost:0 noise). Re-enable only fetch.
     plugins: false,

--- a/src/scripts/alaska-verifier.ts
+++ b/src/scripts/alaska-verifier.ts
@@ -210,7 +210,7 @@ export function startAlaskaVerifier(): void {
     if (!target) return;
 
     return withSpan(
-      "alaska_verifier.run",
+      "airline_verifier.run",
       async (span) => {
         span.setTag("airline", normalizeAirlineTag(airline));
         try {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1490,6 +1490,7 @@ export function createApp(db: Database): App {
       async (span) => {
         span.setTag("http.method", req.method);
         span.setTag("http.route", route);
+        span.setTag("resource.name", `${req.method} ${route}`);
         span.setTag("tenant", tenantScope(tenant));
         span.setTag("http.client_ip", clientIp(req));
         const ua = req.headers.get("user-agent");


### PR DESCRIPTION
From a sweep of metrics/traces/logs/monitors, May 9–15:

- **`web.request` resource_name**: APM Service page showed one aggregate blob because `resource.name` was never set. Now `"{method} {route}"`.
- **dd-trace startup banners at error level**: ~2/restart, accounted for the entire steady-state error log count after May 10. `startupLogs: false`.
- **`alaska_verifier.run` span name**: hardcoded but the loop also runs for HA — May 15 spans show `operation:alaska_verifier.run, airline:hawaiian`. Renamed to `airline_verifier.run`.
- **Unhandled rejection logging**: a May 11 occurrence had no stack because `reason` wasn't an `Error`. Coerce before logging.
- **`DD_GIT_*`**: every span carried `git.repository_url: github.com/oven-sh/bun`. Pinned the real repo