### PR TITLE
Return hasStarlink=null on checker error instead of false

### DIFF
--- a/src/scripts/null-error-hasstarlink.ts
+++ b/src/scripts/null-error-hasstarlink.ts
@@ -1,0 +1,34 @@
+/**
+ * One-shot: null out has_starlink on rows where the checker errored.
+ *
+ * Before the checker returned hasStarlink=null on error, the redirected-to-
+ * search and catch paths returned the init value `false`, so error rows landed
+ * as has_starlink=0. computeWifiConsensus already filters error IS NULL, but
+ * db-status, getVerificationObservations, and getVerificationStats read
+ * has_starlink directly and miscount these as real "no Starlink" observations.
+ *
+ * Prod check (2026-05-17): 1,728 such rows, all wifi_provider=NULL — no real
+ * observation lost.
+ *
+ * Run with: bun run src/scripts/null-error-hasstarlink.ts
+ */
+import { Database } from "bun:sqlite";
+import { DB_PATH } from "../utils/constants";
+
+const db = new Database(DB_PATH);
+
+const before = db
+  .query(
+    "SELECT COUNT(*) AS n FROM starlink_verification_log WHERE error IS NOT NULL AND has_starlink = 0"
+  )
+  .get() as { n: number };
+console.log(`Found ${before.n} rows with error set and has_starlink=0`);
+
+const result = db
+  .query(
+    "UPDATE starlink_verification_log SET has_starlink = NULL WHERE error IS NOT NULL AND has_starlink = 0"
+  )
+  .run();
+console.log(`Updated ${result.changes} rows → has_starlink=NULL`);
+
+db.close();

--- a/src/scripts/null-error-hasstarlink.ts
+++ b/src/scripts/null-error-hasstarlink.ts
@@ -1,16 +1,8 @@
 /**
- * One-shot: null out has_starlink on rows where the checker errored.
- *
- * Before the checker returned hasStarlink=null on error, the redirected-to-
- * search and catch paths returned the init value `false`, so error rows landed
- * as has_starlink=0. computeWifiConsensus already filters error IS NULL, but
- * db-status, getVerificationObservations, and getVerificationStats read
- * has_starlink directly and miscount these as real "no Starlink" observations.
- *
- * Prod check (2026-05-17): 1,728 such rows, all wifi_provider=NULL — no real
- * observation lost.
- *
- * Run with: bun run src/scripts/null-error-hasstarlink.ts
+ * One-shot: null out has_starlink on rows where the checker errored. Before
+ * hasStarlink defaulted to null, error paths leaked the init `false` → 0,
+ * miscounted by readers that don't gate on `error IS NULL`.
+ * Run: bun run src/scripts/null-error-hasstarlink.ts
  */
 import { Database } from "bun:sqlite";
 import { DB_PATH } from "../utils/constants";

--- a/src/scripts/united-starlink-checker.ts
+++ b/src/scripts/united-starlink-checker.ts
@@ -12,7 +12,8 @@ chromium.use(StealthPlugin());
 const RAW_LOG_DIR = path.join(LOG_DIR, "raw");
 
 export interface StarlinkCheckResult {
-  hasStarlink: boolean;
+  // null when error is set — the page produced no observation
+  hasStarlink: boolean | null;
   tailNumber: string | null;
   shipNumber: string | null;
   aircraftType: string | null;
@@ -71,7 +72,7 @@ export async function checkStarlinkStatus(
   destination: string
 ): Promise<StarlinkCheckResult> {
   const result: StarlinkCheckResult = {
-    hasStarlink: false,
+    hasStarlink: null,
     tailNumber: null,
     shipNumber: null,
     aircraftType: null,
@@ -313,7 +314,7 @@ if (import.meta.main) {
   // direct-CLI case where a human reads $?.
   const isSubprocess = process.env.SUBPROCESS_MODE === "1";
   const emptyResult = (errorMsg: string): StarlinkCheckResult => ({
-    hasStarlink: false,
+    hasStarlink: null,
     tailNumber: null,
     shipNumber: null,
     aircraftType: null,

--- a/src/scripts/verify-tails.ts
+++ b/src/scripts/verify-tails.ts
@@ -52,7 +52,7 @@ type VerifyResult = {
         url: string;
         tail_shown: string | null;
         aircraft_shown: string | null;
-        has_starlink: boolean;
+        has_starlink: boolean | null;
         provider: string | null;
         tail_match: boolean;
       }


### PR DESCRIPTION
## Problem

`checkStarlinkStatus` initialises `hasStarlink: false` and returns that unchanged on the redirected-to-search and catch error paths. `logVerification` writes that as `has_starlink=0`, so error rows look like real "no Starlink" observations to anything that doesn't also filter `error IS NULL`.

`computeWifiConsensus` does filter on `error IS NULL` so consensus is unaffected, but `db-status`, `getVerificationObservations` (predictor input), and `getVerificationStats` read `has_starlink` directly and miscount.

Prod: 1,728 such rows since May 9 (1,727 "Flight not found (redirected to search page)" + 1 older browser-crash row), all with `wifi_provider=NULL`.

## Fix

- `StarlinkCheckResult.hasStarlink` is now `boolean | null`, initialised to `null`. The success path still assigns the page-evaluated boolean, so error ⇔ null and clean-scrape ⇔ boolean are now mutually exclusive.
- Widened `verify-tails.ts` result type to match.
- Audited every caller (`starlink-verifier.ts`, `fleet-discovery.ts`, `verify-tails.ts`, subprocess wrapper): all either gate on `result.error` first or test truthiness, so null behaves identically to the old false everywhere except the DB write — which is the intended change.
- One-shot `src/scripts/null-error-hasstarlink.ts` to clean the existing rows. Verified on prod that all targets have `wifi_provider=NULL`, so no real observation is dropped.

## Deploy

After deploy, run once:
```
bun run src/scripts/null-error-hasstarlink.ts
```