### PR TITLE
Fix HA flight-cache starvation in trickle updater

### DIFF
--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -2,6 +2,7 @@ import "dotenv/config";
 import {
   getAllStarlinkPlanes,
   getNextFleetTailNeedingFlights,
+  getStarlinkTailsByCheckAge,
   initializeDatabase,
   needsFlightCheck,
   updateFlights,
@@ -364,14 +365,14 @@ export function startFlightUpdater() {
 
           const db = initializeDatabase();
 
-          // Find a plane that needs updating (includes mismatches so they can be re-verified later)
-          const planes = getAllStarlinkPlanes(db);
+          // Stalest-first so no airline starves; DateFound DESC left HA permanently
+          // queued behind ~470 UA/AS tails whose 1-8h cache churn saturates the trickle.
+          const tails = getStarlinkTailsByCheckAge(db);
           let tailToUpdate: string | null = null;
 
-          for (const plane of planes) {
-            if (!plane.TailNumber) continue;
-            if (needsFlightCheck(db, plane.TailNumber)) {
-              tailToUpdate = plane.TailNumber;
+          for (const tail of tails) {
+            if (needsFlightCheck(db, tail)) {
+              tailToUpdate = tail;
               break;
             }
           }

--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -365,8 +365,7 @@ export function startFlightUpdater() {
 
           const db = initializeDatabase();
 
-          // Stalest-first so no airline starves; DateFound DESC left HA permanently
-          // queued behind ~470 UA/AS tails whose 1-8h cache churn saturates the trickle.
+          // Stalest-first so no airline starves behind the UA/AS DateFound-ordered block.
           const tails = getStarlinkTailsByCheckAge(db);
           let tailToUpdate: string | null = null;
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1316,9 +1316,6 @@ export function getFleetEntryByTail(
   } | null;
 }
 
-// Stalest-first ordering for the trickle updater. getAllStarlinkPlanes orders by
-// DateFound DESC which starves airlines whose tails were all added on one old date
-// (HA sat at indices 473-514 and never got picked while UA/AS churn saturated the queue).
 export function getStarlinkTailsByCheckAge(db: Database): string[] {
   return (
     db

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1316,6 +1316,19 @@ export function getFleetEntryByTail(
   } | null;
 }
 
+// Stalest-first ordering for the trickle updater. getAllStarlinkPlanes orders by
+// DateFound DESC which starves airlines whose tails were all added on one old date
+// (HA sat at indices 473-514 and never got picked while UA/AS churn saturated the queue).
+export function getStarlinkTailsByCheckAge(db: Database): string[] {
+  return (
+    db
+      .query(
+        "SELECT TailNumber FROM starlink_planes WHERE TailNumber IS NOT NULL ORDER BY last_flight_check ASC"
+      )
+      .all() as { TailNumber: string }[]
+  ).map((r) => r.TailNumber);
+}
+
 export function updateLastFlightCheck(db: Database, tailNumber: string, success = true) {
   const now = Math.floor(Date.now() / 1000);
   if (success) {


### PR DESCRIPTION
## Symptom

`upcoming_flights` rows for `airline='HA'` go 9-17h stale while UA stays at ~9s and AS at ~4min. `starlink.data.freshness_seconds{airline:hawaiian,job:flight_updater}` cycles up to ~56k then resets roughly once a day.

## Root cause

The 22.5s trickle loop in `startFlightUpdater` iterates `getAllStarlinkPlanes()` (ordered by `DateFound DESC`) and picks the **first** tail where `needsFlightCheck` is true. All 42 HA tails share `DateFound = 2024-09-24`, placing them at indices **473-514** of the 515-plane list. The 473 UA/AS tails ahead of them generate enough cache-expiry churn (1-8h windows, ~100+/hr) to saturate the ~160 ticks/hr capacity, so iteration never reaches HA in steady state.

Prod evidence:
- Right now, 96 UA/AS tails need a check before the first HA index.
- Last `Fetching upcoming flights for N*HA` log line: `2026-05-17T09:07:48Z` — before the current container started 9h ago. Zero HA fetches since.
- Same starvation hits older UA tails too: 25+ UA tails are sitting at 13-14h stale.

## Fix

Add `getStarlinkTailsByCheckAge()` returning tails ordered by `last_flight_check ASC`, and use it in the trickle loop instead of `getAllStarlinkPlanes()`. The stalest tail is now serviced first regardless of airline or DateFound.

Simulated against the live DB: under the new ordering the first 50 picks are 25 UA + 25 HA (the current stalest), vs. 50 UA/AS + 0 HA under the old ordering. After deploy all 42 HA tails should refresh within ~30 min, then settle into the same 1-8h cadence as UA/AS.

`updateAllFlights` (bulk path) is unchanged — it already processes the full list.