### PR TITLE
Handle empty FR24 fleet pages in scraper (fixes qx-qxe timeout)

### DIFF
--- a/src/scripts/flightradar24-scraper.ts
+++ b/src/scripts/flightradar24-scraper.ts
@@ -105,10 +105,14 @@ export async function scrapeFlightRadar24Fleet(
 
     await page.waitForTimeout(2000);
 
-    // Wait for fleet table to load
+    // FR24 can report a 0-aircraft roster (e.g. a regional whose tails are listed
+    // under the parent), so accept the fleet-count header as a ready signal too.
     console.log("Waiting for fleet data...");
     await page.waitForFunction(
-      () => document.querySelectorAll('a[href*="/data/aircraft/"]').length > 0,
+      () =>
+        document.querySelectorAll('a[href*="/data/aircraft/"]').length > 0 ||
+        /Number of aircraft/i.test(document.body?.textContent ?? ""),
+      undefined,
       { timeout: 15000 }
     );
 
@@ -117,7 +121,7 @@ export async function scrapeFlightRadar24Fleet(
     await page.waitForTimeout(1000);
 
     // Check if all aircraft are visible or if we need to expand sections
-    let totalExpected = 0;
+    let totalExpected = -1;
     try {
       const countText = await page
         .locator("text=/Number of aircraft in fleet:\\s*\\d+/")
@@ -181,7 +185,7 @@ export async function scrapeFlightRadar24Fleet(
     });
 
     result.aircraft = aircraft;
-    result.success = aircraft.length > 0;
+    result.success = aircraft.length > 0 || totalExpected === 0;
 
     console.log(`Successfully scraped ${aircraft.length} aircraft`);
   } catch (error) {


### PR DESCRIPTION
## Problem

Horizon Air (`qx-qxe`) FR24 fleet sync has failed 100% of attempts over the last 42h with `waitForFunction: Timeout 30000ms exceeded`, while `as-asa` / `ha-hal` / `ua-ual` / `qr-qtr` all succeed.

## Root cause

FR24 has consolidated Horizon's roster under the parent: `https://www.flightradar24.com/data/airlines/qx-qxe/fleet` now renders **"Number of aircraft in fleet: 0"** with no `<dl>` and no `a[href*="/data/aircraft/"]` links. The scraper's ready predicate `querySelectorAll('a[href*="/data/aircraft/"]').length > 0` can never become true on that page, so `waitForFunction` always times out.

The 90 Horizon E175s (46 `N6xxQX` + 44 SkyWest `N1xxSY`) are all listed under `as-asa` (343 total) and `AS.classifyFleet` already routes them to `subfleet: "horizon"`, so no data is lost — just 30s wasted per run plus a logged error and `partial` span tag.

(The prod error said 30000ms even though the code passes `{timeout: 15000}` — that object was being passed as the `arg` to `waitForFunction`, not the options. Fixed in passing.)

## Fix

- Broaden the `waitForFunction` predicate to also accept the "Number of aircraft" header — present even when the count is 0. Pass the timeout in the correct positional slot.
- Initialise `totalExpected` to `-1` (unknown) instead of `0` so we can distinguish "FR24 says 0" from "couldn't parse the count".
- Treat `aircraft.length === 0 && totalExpected === 0` as success — let the caller's `minFleetSanity` gate catch genuinely-broken scrapes.

## Verification

Ran the patched scraper locally with a shared browser:

```
>>> qx-qxe: success=true aircraft=0 error=none elapsed=7790ms
>>> as-asa: success=true aircraft=343 error=none elapsed=8412ms  (E175 count: 90)
```

`bun run lint` clean, 218/218 tests pass.