### PR TITLE
Fix nightly verification error spikes and FR24 launch wedge

### DIFF
--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -333,17 +333,15 @@ export function startFlightUpdater() {
     return;
   }
 
-  let isRunning = false;
+  // 0 = idle; otherwise the start time of the in-progress run. A wedged vendor
+  // call held this for 19h on 2026-05-20 — past the deadline, abandon the run.
+  let runningSince = 0;
   let lastHeartbeat = Date.now();
   let totalUpdates = 0;
   let totalErrors = 0;
+  const STUCK_RUN_TIMEOUT_MS = 15 * 60 * 1000;
 
   const runSingleUpdate = async () => {
-    if (isRunning) {
-      warn("Skipping flight update - previous update still in progress");
-      return;
-    }
-
     // Check circuit breaker
     if (circuitBreakerOpenedAt) {
       const timeSinceOpened = Date.now() - circuitBreakerOpenedAt;
@@ -355,7 +353,18 @@ export function startFlightUpdater() {
       consecutiveApiFailures = 0;
     }
 
-    isRunning = true;
+    if (runningSince) {
+      if (Date.now() - runningSince < STUCK_RUN_TIMEOUT_MS) {
+        warn("Skipping flight update - previous update still in progress");
+        return;
+      }
+      error(
+        `Flight update stuck for ${Math.round((Date.now() - runningSince) / 60000)}min — abandoning it and starting a new run`
+      );
+    }
+
+    const myRun = Date.now();
+    runningSince = myRun;
 
     try {
       await withSpan(
@@ -426,7 +435,8 @@ export function startFlightUpdater() {
       consecutiveApiFailures++;
       totalErrors++;
     } finally {
-      isRunning = false;
+      // An abandoned run that finally settles must not clear its successor's flag.
+      if (runningSince === myRun) runningSince = 0;
     }
   };
 

--- a/src/api/fr24-browser-transport.ts
+++ b/src/api/fr24-browser-transport.ts
@@ -31,6 +31,17 @@ let browser: Browser | null = null;
 let page: Page | null = null;
 let launching: Promise<Page> | null = null;
 let consecutiveFailures = 0;
+// Bumped to disown an in-flight launch; a disowned launch must not publish to
+// module state or tear it down — it closes whatever it created and bails.
+let launchGen = 0;
+// Browser an in-flight launch() has spawned but not yet published. Lets the
+// launch deadline kill a Chromium whose setup calls never settle, instead of
+// leaking one orphaned process per abandoned launch.
+let pendingBrowser: Browser | null = null;
+
+// A launch that neither resolves nor rejects would leave `launching` set forever
+// and wedge every FR24 caller (19h flight-data outage on 2026-05-20).
+const LAUNCH_TIMEOUT_MS = 60_000;
 
 export interface FR24FetchResult {
   status: number;
@@ -52,14 +63,18 @@ async function teardown(): Promise<void> {
   }
 }
 
+// Builds the browser in locals and publishes to module state only once fully
+// ready, so a concurrent teardown() can never strand a half-initialized launch.
 async function launch(): Promise<Page> {
+  const gen = ++launchGen;
   await teardown();
   info("Launching FR24 browser transport...");
   const t0 = Date.now();
 
+  let b: Browser | null = null;
   try {
     const chromium = await getChromium();
-    browser = await chromium.launch({
+    b = await chromium.launch({
       headless: true,
       args: [
         "--no-sandbox",
@@ -74,21 +89,26 @@ async function launch(): Promise<Page> {
         "--js-flags=--max-old-space-size=128",
       ],
     });
+    if (gen === launchGen) pendingBrowser = b;
 
-    browser.on("disconnected", () => {
-      warn("FR24 browser disconnected");
-      browser = null;
-      page = null;
-    });
-
-    const ctx = await browser.newContext({
+    const ctx = await b.newContext({
       userAgent: BROWSER_USER_AGENT,
       locale: "en-US",
       viewport: { width: 1280, height: 720 },
     });
-    page = await ctx.newPage();
+    const pg = await ctx.newPage();
+    await pg.goto(BOOTSTRAP_URL, { waitUntil: "domcontentloaded", timeout: 30000 });
 
-    await page.goto(BOOTSTRAP_URL, { waitUntil: "domcontentloaded", timeout: 30000 });
+    if (gen !== launchGen) throw new Error("launch superseded");
+
+    b.on("disconnected", () => {
+      warn("FR24 browser disconnected");
+      browser = null;
+      page = null;
+    });
+    browser = b;
+    page = pg;
+    pendingBrowser = null;
 
     info(`FR24 browser transport ready in ${Date.now() - t0}ms`);
     metrics.increment(COUNTERS.VENDOR_REQUEST, {
@@ -96,14 +116,15 @@ async function launch(): Promise<Page> {
       type: "browser_launch",
       status: "success",
     });
-    return page;
+    return pg;
   } catch (err) {
     metrics.increment(COUNTERS.VENDOR_REQUEST, {
       vendor: "fr24",
       type: "browser_launch",
       status: "error",
     });
-    await teardown();
+    if (pendingBrowser === b) pendingBrowser = null;
+    if (b) await b.close().catch(() => {});
     throw err;
   }
 }
@@ -111,7 +132,20 @@ async function launch(): Promise<Page> {
 async function ensurePage(): Promise<Page> {
   if (isAlive()) return page as Page;
   if (!launching) {
-    launching = launch().finally(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        error(`FR24 browser launch exceeded ${LAUNCH_TIMEOUT_MS}ms, abandoning it`);
+        launchGen++;
+        // Closing the half-built browser also rejects its hung setup calls,
+        // letting the abandoned launch promise settle.
+        void pendingBrowser?.close().catch(() => {});
+        pendingBrowser = null;
+        reject(new Error("fr24 browser launch timeout"));
+      }, LAUNCH_TIMEOUT_MS);
+    });
+    launching = Promise.race([launch(), deadline]).finally(() => {
+      clearTimeout(timer);
       launching = null;
     });
   }
@@ -156,8 +190,9 @@ export async function fr24Fetch(url: string, timeoutMs = 15000): Promise<FR24Fet
     return result;
   } catch (err) {
     consecutiveFailures++;
-    // Likely a dead/navigated/hung page. Tear down so the next call relaunches.
-    if (consecutiveFailures >= 3 || !isAlive()) {
+    // Likely a dead/navigated/hung page. Tear down so the next call relaunches —
+    // unless a relaunch is already underway (teardown would be a no-op anyway).
+    if ((consecutiveFailures >= 3 || !isAlive()) && !launching) {
       error("FR24 browser transport unhealthy, tearing down", err);
       metrics.increment(COUNTERS.VENDOR_REQUEST, {
         vendor: "fr24",

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -33,7 +33,7 @@ import {
   withSpan,
 } from "../observability";
 import type { FleetAircraft, StarlinkStatus } from "../types";
-import { normalizeFlightNumber } from "../utils/constants";
+import { extractFlightNumber, pickVerifiableFlight, unitedLookupDate } from "../utils/constants";
 import { info, error as logError, warn } from "../utils/logger";
 import type { StarlinkCheckResult } from "./united-starlink-checker";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
@@ -44,10 +44,6 @@ const DISCOVERY_INTERVAL_MS = 30 * 1000; // 30 seconds
 const MAINTENANCE_INTERVAL_MS = 90 * 1000; // 90 seconds
 // Heartbeat interval for logging
 const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
-// united.com flight-status only resolves flights ≤2 days out
-// united.com flight-status resolves today/tomorrow/day-after in *US local time*,
-// so a flight 2.2 days away by UTC seconds can still be calendar-day +3 → 404.
-const MAX_VERIFIABLE_HORIZON_SEC = 2 * 86400;
 
 const fr24Api = new FlightRadar24API();
 
@@ -78,29 +74,6 @@ function icaoToIata(icao: string): string {
     return icao.substring(1);
   }
   return icao;
-}
-
-/**
- * Extract bare flight digits for United.com URL. Must strip carrier prefix
- * FIRST: G74460 → 4460, not 74460 (which 404s). normalizeFlightNumber knows
- * the 2-3 char prefixes (G7, OO, SKW, GJS, ...) so use it, then drop UA.
- */
-function extractFlightNumber(flightNumber: string): string {
-  const normalized = normalizeFlightNumber(flightNumber);
-  return normalized.replace(/^UA/, "");
-}
-
-type RawFlight = { flight_number: string; departure_time: number };
-
-/** First flight whose number normalizes to bare digits and departs within the united.com lookup horizon. */
-export function pickVerifiableFlight<T extends RawFlight>(
-  flights: T[],
-  nowSec = Date.now() / 1000
-): T | undefined {
-  const horizon = nowSec + MAX_VERIFIABLE_HORIZON_SEC;
-  return flights.find(
-    (f) => /^\d+$/.test(extractFlightNumber(f.flight_number)) && f.departure_time < horizon
-  );
 }
 
 interface FlightInfo {
@@ -138,12 +111,12 @@ async function getUpcomingFlightsForPlane(tailNumber: string): Promise<{
     const verifiable = pickVerifiableFlight(flights);
     if (!verifiable) {
       info(
-        `No verifiable flight for ${tailNumber} (next: ${flights[0].flight_number} on ${new Date(flights[0].departure_time * 1000).toISOString().split("T")[0]})`
+        `No verifiable flight for ${tailNumber} (next: ${flights[0].flight_number} on ${unitedLookupDate(flights[0].departure_time)})`
       );
       return null;
     }
 
-    const departureDate = new Date(verifiable.departure_time * 1000).toISOString().split("T")[0];
+    const departureDate = unitedLookupDate(verifiable.departure_time);
 
     return {
       forVerification: {
@@ -507,17 +480,26 @@ export function startFleetDiscovery(mode: "discovery" | "maintenance" = "mainten
   const intervalMs = mode === "discovery" ? DISCOVERY_INTERVAL_MS : MAINTENANCE_INTERVAL_MS;
 
   let runCount = 0;
-  let isRunning = false;
+  // 0 = idle; otherwise the start time of the in-progress run. A never-settling
+  // vendor call must not hold the loop forever — past the deadline, abandon it.
+  let runningSince = 0;
   let lastHeartbeat = Date.now();
   const totalStats = { checked: 0, starlink: 0, notStarlink: 0, errors: 0, noFlights: 0 };
+  const STUCK_RUN_TIMEOUT_MS = 15 * 60 * 1000;
 
   const runVerification = async () => {
-    if (isRunning) {
-      info("Skipping run - previous verification still in progress");
-      return;
+    if (runningSince) {
+      if (Date.now() - runningSince < STUCK_RUN_TIMEOUT_MS) {
+        info("Skipping run - previous verification still in progress");
+        return;
+      }
+      logError(
+        `Discovery run stuck for ${Math.round((Date.now() - runningSince) / 60000)}min — abandoning it and starting a new run`
+      );
     }
 
-    isRunning = true;
+    const myRun = Date.now();
+    runningSince = myRun;
     runCount++;
 
     try {
@@ -571,7 +553,8 @@ export function startFleetDiscovery(mode: "discovery" | "maintenance" = "mainten
     } catch (err) {
       logError("Discovery batch failed", err);
     } finally {
-      isRunning = false;
+      // An abandoned run that finally settles must not clear its successor's flag.
+      if (runningSince === myRun) runningSince = 0;
     }
   };
 

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -25,7 +25,7 @@ import {
   normalizeWifiProvider,
   withSpan,
 } from "../observability";
-import { normalizeFlightNumber } from "../utils/constants";
+import { extractFlightNumber, pickVerifiableFlight, unitedLookupDate } from "../utils/constants";
 import { verifierLog } from "../utils/logger";
 import type { StarlinkCheckResult } from "./united-starlink-checker";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
@@ -44,15 +44,6 @@ function icaoToIata(icao: string): string {
     return icao.substring(1);
   }
   return icao;
-}
-
-/**
- * Extract bare flight digits for United.com URL. Must strip carrier prefix
- * FIRST: G74460 → 4460, not 74460 (regex-trailing-digits grabs the 7 from
- * the G7 prefix → 404). normalizeFlightNumber knows the 2-3 char prefixes.
- */
-function extractFlightNumber(flightNumber: string): string {
-  return normalizeFlightNumber(flightNumber).replace(/^UA/, "");
 }
 
 interface Flight {
@@ -108,14 +99,19 @@ function getPlanesNeedingVerification(
     if (result.length >= limit) break;
 
     const flights = flightsByTail.get(plane.TailNumber) || [];
-    const futureFlights = flights.filter((f) => f.departure_time > now);
-    if (futureFlights.length === 0) continue;
+    // Skip flights united.com can't resolve yet (lookup date too far out) —
+    // checking them is a guaranteed "redirected to search page" error.
+    const candidate = pickVerifiableFlight(
+      flights.filter((f) => f.departure_time > now),
+      now
+    );
+    if (!candidate) continue;
 
     if (!forceAll && !needsVerification(db, plane.TailNumber, "united")) {
       continue;
     }
 
-    result.push({ plane, flight: futureFlights[0] });
+    result.push({ plane, flight: candidate });
   }
 
   return result;
@@ -145,7 +141,7 @@ export async function verifyPlaneStarlink(
       span.setTag("aircraft_type", aircraftTypeTag);
       span.setTag("fleet", fleetTag);
 
-      const departureDate = new Date(flight.departure_time * 1000).toISOString().split("T")[0];
+      const departureDate = unitedLookupDate(flight.departure_time);
       const flightNumber = extractFlightNumber(flight.flight_number);
       const origin = icaoToIata(flight.departure_airport);
       const destination = icaoToIata(flight.arrival_airport);

--- a/src/scripts/verify-tails.ts
+++ b/src/scripts/verify-tails.ts
@@ -22,7 +22,7 @@ import { Database } from "bun:sqlite";
 import { writeFileSync } from "node:fs";
 import { FlightRadar24API } from "../api/flightradar24-api";
 import { getShipToTailMap } from "../database/database";
-import { DB_PATH, normalizeFlightNumber } from "../utils/constants";
+import { DB_PATH, extractFlightNumber, unitedLookupDate } from "../utils/constants";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
 
 // The subprocess mutex's .finally() chain can leak an unhandled rejection when
@@ -123,7 +123,7 @@ async function verifyTail(
     const upcoming = await fr24.getUpcomingFlights(tail);
     const seen = new Set(candidates.map((c) => c.flight_number + c.fdate));
     for (const u of upcoming) {
-      const fdate = new Date(u.departure_time * 1000).toISOString().slice(0, 10);
+      const fdate = unitedLookupDate(u.departure_time);
       const key = u.flight_number + fdate;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -153,7 +153,7 @@ async function verifyTail(
   for (let i = 0; i < candidates.length; i++) {
     if (i > 0) await new Promise((r) => setTimeout(r, retryDelayMs));
     const flight = candidates[i];
-    const uaNum = normalizeFlightNumber(flight.flight_number).replace(/^UA/, "");
+    const uaNum = extractFlightNumber(flight.flight_number);
     const f = {
       number: uaNum,
       date: flight.fdate,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -42,6 +42,33 @@ export const buildFlightNumberVariants = (fn: string): string[] =>
 export const inferFleet = (fn: string): "express" | "mainline" | "unknown" =>
   inferSubfleet(AIRLINES.UA, fn) as "express" | "mainline" | "unknown";
 
+/** UTC calendar date string used for united.com flight-status lookups. */
+export const unitedLookupDate = (epochSec: number): string =>
+  new Date(epochSec * 1000).toISOString().slice(0, 10);
+
+// united.com redirects flight-status lookups dated past UTC-today+1 to the search
+// page. Compare calendar dates, not seconds: 1.9d away by seconds can be day +2.
+function isWithinUnitedLookupWindow(departureTimeSec: number, nowSec: number): boolean {
+  return unitedLookupDate(departureTimeSec) <= unitedLookupDate(nowSec + 86400);
+}
+
+/** Bare flight digits for united.com URLs. Strip the carrier prefix first: G74460 → 4460, not 74460 (404s). */
+export function extractFlightNumber(flightNumber: string): string {
+  return normalizeFlightNumber(flightNumber).replace(/^UA/, "");
+}
+
+/** First flight whose number normalizes to bare digits and whose lookup date united.com can resolve. */
+export function pickVerifiableFlight<T extends { flight_number: string; departure_time: number }>(
+  flights: T[],
+  nowSec = Date.now() / 1000
+): T | undefined {
+  return flights.find(
+    (f) =>
+      /^\d+$/.test(extractFlightNumber(f.flight_number)) &&
+      isWithinUnitedLookupWindow(f.departure_time, nowSec)
+  );
+}
+
 // Security headers
 const { scriptOrigins: ANALYTICS_SCRIPT_ORIGINS, connectOrigins: ANALYTICS_CONNECT_ORIGINS } =
   analyticsOrigins();

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -30,7 +30,6 @@ import {
   getTotalCount,
   getUpcomingFlights,
 } from "../src/database/database";
-import { pickVerifiableFlight } from "../src/scripts/fleet-discovery";
 import { computePrecision } from "../src/scripts/precision-backtest";
 import { planItinerary, predictFlight, predictRoute } from "../src/scripts/starlink-predictor";
 import { computeSurfaceContradictions } from "../src/scripts/surface-sweep";
@@ -42,6 +41,7 @@ import {
   ensureUAPrefix,
   inferFleet,
   normalizeFlightNumber,
+  pickVerifiableFlight,
 } from "../src/utils/constants";
 
 const TEST_DB = "/tmp/ua-test.sqlite";
@@ -862,6 +862,9 @@ describe("flight number utils", () => {
     expect(normalizeFlightNumber(input)).toBe(expected);
   });
 
+  // The window is a calendar-date comparison on the UTC date string sent to
+  // united.com: lookup date must be ≤ UTC-today + 1. Raw seconds don't matter.
+  // now = 2023-11-14T22:13:20Z → dates 11-14 and 11-15 are verifiable.
   test.each<[string, { fn: string; days: number }[], string | undefined]>([
     [
       "skips ATC callsign, picks next",
@@ -872,18 +875,26 @@ describe("flight number utils", () => {
       "UA1268",
     ],
     [
-      "skips >2d-out, picks next",
+      "skips far-out flights, picks the in-window one",
       [
         { fn: "UA314", days: 4 },
-        { fn: "OO4680", days: 1.5 },
+        { fn: "OO4680", days: 0.9 },
       ],
       "OO4680",
     ],
     ["normalizes regional prefix in-window", [{ fn: "C54287", days: 1 }], "C54287"],
     [
+      // 2026-05-23 prod regression: at 04:40Z the verifier asked united.com for
+      // flights dated UTC-today+2 (1.5–2d away by seconds) and every one was
+      // redirected to the search page. >50% error rate nightly, 00:00–08:00 UTC.
+      "rejects calendar-day +2 even when <2d away by seconds",
+      [{ fn: "UA930", days: 1.5 }],
+      undefined,
+    ],
+    [
       // N76265 prod regression: UA2236 on calendar-day+3 was 2.2d away by UTC
-      // seconds — passed the old 2.5d horizon but united.com still 404'd.
-      "rejects 2.2d-out (calendar-day +3 in US local)",
+      // seconds — passed the old seconds-based horizon but united.com still 404'd.
+      "rejects 2.2d-out (calendar-day +3)",
       [{ fn: "UA2236", days: 2.2 }],
       undefined,
     ],
@@ -902,6 +913,15 @@ describe("flight number utils", () => {
       now
     );
     expect(picked?.flight_number).toBe(expected);
+  });
+
+  test("pickVerifiableFlight: accepts UTC-today+1 even when nearly 2d away by seconds", () => {
+    // now just after UTC midnight; flight departs 23:00Z the next day (1.96d away).
+    const now = Date.UTC(2026, 4, 23, 0, 30, 0) / 1000;
+    const dep = Date.UTC(2026, 4, 24, 23, 0, 0) / 1000;
+    expect(
+      pickVerifiableFlight([{ flight_number: "UA930", departure_time: dep }], now)
+    ).toBeDefined();
   });
 
   test("buildFlightNumberVariants: UA number → all carrier variants", () => {


### PR DESCRIPTION
The verification error-rate monitor flaps nightly: every united.com lookup dated UTC-today+2 gets redirected to the search page, and the picker's seconds-based horizon admits those each US evening. Separately, on 5/20 a single FR24 browser launch hung without resolving or rejecting and held the in-progress flag for 19 hours — flight updates and discovery were dead until the next deploy.

- Pick only flights whose lookup date is ≤ UTC-today+1, and share the date derivation between the window check and the lookup call sites so they can't drift
- Build the FR24 browser in locals and publish to module state only on success; bound the launch at 60s and close the half-built browser when abandoning it
- Abandon background runs stuck >15 min so a hung vendor call can't wedge the loop until the next deploy
- Consolidate `extractFlightNumber`/`pickVerifiableFlight` into `utils/constants` (previously duplicated across two scripts)