### PR TITLE
Add prediction fallback to /api/check-flight

### DIFF
--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -49,8 +49,9 @@ async function checkFlightForStarlink(flightNumber, date) {
 
     const hasStarlink = response.data.hasStarlink || false;
     const confidence = response.data.confidence || (hasStarlink ? "verified" : undefined);
+    const prediction = response.data.prediction;
 
-    const result = { hasStarlink, confidence, timestamp: Date.now() };
+    const result = { hasStarlink, confidence, prediction, timestamp: Date.now() };
     flightCache.set(cacheKey, result);
     return result;
   } catch (error) {
@@ -59,13 +60,30 @@ async function checkFlightForStarlink(flightNumber, date) {
   }
 }
 
-function createStarlinkBadge(confidence) {
-  const likely = confidence === "likely";
+// Aircraft assignments only exist ~2 days before departure. Above this
+// historical rate we show a "likely" badge instead of nothing.
+const PREDICTION_BADGE_THRESHOLD = 0.8;
+
+// Mobile has no tooltips, so the predicted badge carries the percentage in its
+// text — "Starlink ~85%" — instead of the firm-assignment "(likely)" wording.
+function badgeLabel(confidence, prediction) {
+  if (confidence === "predicted") return `Starlink ~${Math.round(prediction.probability * 100)}%`;
+  return confidence === "likely" ? "Starlink (likely)" : "Starlink";
+}
+
+function badgeTitle(confidence, prediction) {
+  if (confidence === "predicted")
+    return `~${Math.round(prediction.probability * 100)}% of recent departures of this flight used a Starlink-equipped aircraft. United assigns the actual aircraft ~2 days before departure.`;
+  if (confidence === "likely")
+    return "Tracked as Starlink-equipped; not yet verified against united.com";
+  return "Verified Starlink WiFi";
+}
+
+function createStarlinkBadge(confidence, prediction) {
+  const likely = confidence === "likely" || confidence === "predicted";
   const badge = document.createElement("span");
   badge.className = `starlink-wifi-badge${likely ? " starlink-wifi-badge--likely" : ""}`;
-  badge.title = likely
-    ? "Tracked as Starlink-equipped; not yet verified against united.com"
-    : "Verified Starlink WiFi";
+  badge.title = badgeTitle(confidence, prediction);
   badge.style.cssText = `
     margin-left: 12px;
     display: inline-flex;
@@ -80,15 +98,15 @@ function createStarlinkBadge(confidence) {
   const icon = likely
     ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="vertical-align: -2px; margin-right: 4px;"><path d="M11 17h2v2h-2zm0-10h2v8h-2zM12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16z"/></svg>'
     : '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="vertical-align: -2px; margin-right: 4px;"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>';
-  badge.innerHTML = `${icon}Starlink${likely ? " (likely)" : ""}`;
+  badge.innerHTML = `${icon}${badgeLabel(confidence, prediction)}`;
   return badge;
 }
 
-function addStarlinkBadge(card, confidence) {
+function addStarlinkBadge(card, confidence, prediction) {
   if (card.querySelector(".starlink-wifi-badge")) return;
 
-  const badge = createStarlinkBadge(confidence);
-  const likely = confidence === "likely";
+  const badge = createStarlinkBadge(confidence, prediction);
+  const likely = confidence === "likely" || confidence === "predicted";
   const isDesktop = window.innerWidth >= 1024;
 
   if (isDesktop) {
@@ -121,7 +139,7 @@ function addStarlinkBadge(card, confidence) {
       z-index: 10;
       box-shadow: 0 1px 2px rgba(0,0,0,0.08);
     `;
-    badge.innerHTML = likely ? "Starlink (likely)" : "Starlink";
+    badge.textContent = badgeLabel(confidence, prediction);
     liElement.insertBefore(badge, liElement.firstChild);
   }
 }
@@ -189,11 +207,25 @@ async function processFlights() {
       processedElements.add(card);
       processedCount++;
 
-      const { hasStarlink, confidence } = await checkFlightForStarlink(flightNumber, date);
+      const { hasStarlink, confidence, prediction } = await checkFlightForStarlink(
+        flightNumber,
+        date
+      );
       if (hasStarlink) {
         starlinkCount++;
         addStarlinkBadge(card, confidence);
         if (!DEBUG) console.log(`✈️ ${flightNumber} has Starlink WiFi (${confidence})`);
+      } else if (
+        prediction &&
+        prediction.probability >= PREDICTION_BADGE_THRESHOLD &&
+        prediction.confidence !== "low"
+      ) {
+        starlinkCount++;
+        addStarlinkBadge(card, "predicted", prediction);
+        if (!DEBUG)
+          console.log(
+            `✈️ ${flightNumber} likely Starlink (${Math.round(prediction.probability * 100)}%, ${prediction.n_observations} obs)`
+          );
       }
     }
 

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Google Flights Starlink Indicator",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Highlights flights with Starlink WiFi on Google Flights",
   "permissions": ["storage"],
   "host_permissions": ["https://unitedstarlinktracker.com/*"],

--- a/docs/NODATA-DEEP-DIVE-2026-05-22.md
+++ b/docs/NODATA-DEEP-DIVE-2026-05-22.md
@@ -1,0 +1,109 @@
+# Why 60% of /api/check-flight lookups return no_data
+
+Investigation date: 2026-05-22. Data: Datadog metrics (7-day window), prod SQLite,
+code paths in `src/server/app.ts` / `src/api/flight-verdict.ts` / `src/api/mcp-server.ts`,
+and a simulation of the lookup chain over all 5,489 known UA flight numbers.
+
+## The number
+
+Over the last 7 days, the United `/api/check-flight` endpoint (the Chrome extension's
+backend) served 6,144 lookups:
+
+| outcome | count | % | what the user sees |
+|---|---|---|---|
+| no_data | 3,749 | **61%** | nothing (extension only badges `hasStarlink: true`) |
+| verified_no | 2,028 | 33% | nothing |
+| verified_yes | 313 | 5% | a Starlink badge |
+| predicted | 54 | 1% | a badge |
+
+96% of requests are `client_class:browser` — real extension users, not bots.
+The practical effect: a user shopping for flights on Google Flights sees a badge on
+~1 in 20 flight cards. For trips more than 3 days out, they see no badges at all.
+
+## The lookup chain and where it dies
+
+`/api/check-flight` has two data paths:
+
+1. **`upcoming_flights ⨝ starlink_planes`** — only contains flights operated by the
+   385 Starlink-equipped tails (24% of the 1,603-aircraft fleet), and only extends
+   ~2 days into the future (day+0: 896 legs, day+1: 1,515, day+2: 826, day+3: 1, day+4+: 0).
+   Simulated hit rate over all 5,489 known UA flight numbers: 17% at day+0, 30% at
+   day+1, 25% at day+2, **0% at day+7**.
+2. **Live FR24 tail lookup** (`lookupFlightTailVerdict`) — only runs when the queried
+   date is within **[-1 day, +3 days]** of now (`flight-verdict.ts:129`). 2,424
+   invocations in 7 days produced ~2,150 answers (mostly verified_no) and 400 errors.
+3. **There is no third path.** Both misses → `no_data` → `{ hasStarlink: false,
+   message: "No Starlink-equipped aircraft found..." }`.
+
+## Root cause
+
+**Aircraft tail assignments do not exist more than ~2–3 days before departure.**
+United assigns tails day-of or day-before; FR24 reflects that. Google Flights users
+shop days to weeks ahead. For the majority of real queries, *no tail-assignment-based
+lookup can ever produce an answer* — the data doesn't exist yet anywhere on Earth.
+
+Bounding it from the metrics: 3,749 no_data vs at most ~500 in-window lookups that
+reached FR24 and got nothing (400 errors + a handful of empty results — empty results
+aren't cached, so each one is a distinct FR24 call). **≥85% of the no_data responses
+(≈52% of all queries) are for dates outside the ±3-day window** and never even reach
+the FR24 fallback.
+
+## The fix already exists in the codebase
+
+The MCP `check_flight` tool (`mcp-server.ts:621-644`) has a third stage: when no tail
+assignment exists, it calls `predictFlight()` — the historical tail-assignment
+probability for that flight number — and answers "~85% Starlink probability
+(n historical obs). Aircraft assignment not yet published — that happens ~2 days out."
+
+**The MCP tool's no_data rate is 4%. The HTTP endpoint's is 61%. Same database, same
+question — the HTTP endpoint just never got the third stage.**
+
+Predictor coverage, simulated over all 5,489 known UA flight numbers:
+- 60% get a history-based prediction (`flight_history_smoothed`, n_observations > 0)
+- 56% land at high or medium confidence
+- The probability distribution is strongly bimodal: 43% of flight numbers predict
+  <10% (confident no) and 25% predict >80% (confident yes). Only 8% fall in the
+  uninformative 30–70% band. These are decisive answers, not coin flips.
+- The remaining 40% get the fleet-prior cold start (no history for that number) —
+  mostly codeshares, seasonal routes, and numbers we haven't observed.
+
+## Secondary findings
+
+1. **The date window is UTC but users pass local dates.** The endpoint windows on
+   `[date T00:00Z, +24h)`. 406 of 3,238 upcoming UA flights (12.5%) depart between
+   00:00–08:00 UTC — i.e., US-evening local departures whose UTC calendar date is one
+   day after the date Google Flights displays. For those flights the user's date and
+   our window disagree by a day → guaranteed miss even when the data exists. Same bug
+   class as the united.com lookup-window fix in PR #44.
+2. **`verified_no` conflates "verified non-Starlink" with "tail we know nothing
+   about"** (`app.ts:531`): any non-empty FR24 segment list with no Starlink segments
+   returns `hasStarlink: false` tagged verified_no — including segments whose tail
+   resolves to `hasStarlink: null / confidence: unknown`. The MCP version filters on
+   `hasStarlink === false` explicitly and falls through to the predictor otherwise.
+   Only ~4% of the fleet is status=unknown, so the impact is small, but it is another
+   case of "unknown presented as no".
+3. The no_data response body (`hasStarlink: false`, "No Starlink-equipped aircraft
+   found for this flight on the specified date") is semantically a "no" when the
+   truth is "we don't know yet". The extension happens not to render negatives, so
+   no user currently sees a wrong "no" — but any other API consumer would.
+
+## Recommendations
+
+1. **Port the MCP predictor fallback to `/api/check-flight`.** When both lookup paths
+   miss, return the prediction as additive fields (`prediction: { probability,
+   confidence, n_observations }`, `confidence: "predicted"`) without changing the
+   `hasStarlink: boolean` contract. Update the extension to render a "likely
+   Starlink" badge for high-probability predictions. Converts ~85% of today's
+   no_data into an answer. Pure DB lookup (the model is cached) — no new vendor load.
+2. **Threshold the displayed prediction.** The audience fact-checks percentages.
+   Until the predictor's calibration (not just the firm-call precision) is
+   backtested, only badge ≥80%-probability/high-confidence predictions as "likely"
+   and render nothing below that — which still covers the 25% of flight numbers in
+   the >80% bucket.
+3. **Make the date window local-date-aware** (widen by ±8h or resolve the departure
+   airport's UTC offset). Recovers the 12.5% of flights that straddle the UTC
+   boundary.
+4. **Tag `flight.lookup_result` with a `days_out` bucket** so the query-date
+   distribution — the one number this investigation could not measure historically —
+   becomes observable, and the improvement from #1 is measurable.
+5. Fix the verified_no/unknown conflation (#2 above) while in the handler.

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -18,5 +18,6 @@ export {
   normalizeAirlineTag,
   normalizeStarlinkStatus,
   classifyUserAgent,
+  bucketDaysOut,
 } from "./metrics";
 export type { Tags } from "./metrics";

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -145,6 +145,18 @@ export function normalizeAirlineTag(code: string | null | undefined): string {
   return AIRLINES[code.toUpperCase()]?.metricTag ?? "unmapped";
 }
 
+/** Bounded-cardinality bucket for how many calendar days ahead a flight lookup's date is. */
+export function bucketDaysOut(days: number): string {
+  if (!Number.isFinite(days)) return "unknown";
+  const d = Math.floor(days);
+  if (d < 0) return "past";
+  if (d <= 3) return String(d);
+  if (d <= 7) return "4_7";
+  if (d <= 14) return "8_14";
+  if (d <= 30) return "15_30";
+  return "31_plus";
+}
+
 // ============ Metric Names ============
 
 /**
@@ -194,7 +206,8 @@ export const COUNTERS = {
 
   // User-facing flight lookup outcome — how often we actually answer the question.
   // tags: endpoint (api_check|api_predict|mcp), outcome (verified_yes|verified_no|
-  //   predicted|no_data|error), confidence (high|medium|low|none), airline
+  //   predicted|no_data|error), confidence (high|medium|low|none), airline,
+  //   days_out (past|0..3|4_7|8_14|15_30|31_plus — only the /api/check-flight handler, non-QR)
   FLIGHT_LOOKUP_RESULT: "flight.lookup_result",
 
   // MCP tool dispatch — tags: tool, airline, outcome (success|error|unknown_tool)

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -40,6 +40,7 @@ import RoutePlannerPage from "../components/route-planner-page";
 import {
   COUNTERS,
   DISTRIBUTIONS,
+  bucketDaysOut,
   classifyUserAgent,
   metrics,
   normalizeAirlineTag,
@@ -331,13 +332,15 @@ function recordFlightLookup(
   endpoint: "api_check" | "api_predict" | "mcp",
   outcome: LookupOutcome,
   confidence: LookupConfidence,
-  airlineCode: string
+  airlineCode: string,
+  daysOut?: number
 ): void {
   metrics.increment(COUNTERS.FLIGHT_LOOKUP_RESULT, {
     endpoint,
     outcome,
     confidence,
     airline: normalizeAirlineTag(airlineCode),
+    ...(daysOut !== undefined && { days_out: bucketDaysOut(daysOut) }),
   });
 }
 
@@ -479,6 +482,8 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
   }
   const startOfDay = Math.floor(dateObj.getTime() / 1000);
   const endOfDay = startOfDay + 86400;
+  // Calendar days between the queried date and today (UTC) — drives the days_out tag.
+  const daysOut = Math.floor(startOfDay / 86400) - Math.floor(Date.now() / 1000 / 86400);
 
   if (cfg.code === "QR") {
     return apiCheckFlightQatar(reader, cfg, flightNumber, startOfDay, endOfDay);
@@ -503,7 +508,8 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
           "api_check",
           allVerified ? "verified_yes" : "predicted",
           allVerified ? "high" : "medium",
-          cfg.code
+          cfg.code,
+          daysOut
         );
         return new Response(
           JSON.stringify({
@@ -528,8 +534,10 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
           { headers: SECURITY_HEADERS.api }
         );
       }
-      if (segments.length > 0) {
-        recordFlightLookup("api_check", "verified_no", "medium", cfg.code);
+      // Segments whose tail we know nothing about are not a "no" — only a
+      // verified non-Starlink tail is. Otherwise fall through to probability.
+      if (segments.some((s) => s.hasStarlink === false)) {
+        recordFlightLookup("api_check", "verified_no", "medium", cfg.code, daysOut);
         return new Response(
           JSON.stringify({
             hasStarlink: false,
@@ -541,11 +549,33 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
         );
       }
     }
-    recordFlightLookup("api_check", "no_data", "none", cfg.code);
+
+    // No assignment anywhere — tails aren't published until ~2 days out, so
+    // serve the historical probability. hasStarlink stays false (the extension
+    // contract is boolean and means "firm assignment"); prediction is additive.
+    const pred = predictFlight(reader, normalizedFlightNumber);
+    recordFlightLookup(
+      "api_check",
+      pred.n_observations > 0 ? "predicted" : "no_data",
+      pred.n_observations > 0 ? pred.confidence : "none",
+      cfg.code,
+      daysOut
+    );
+    recordPrediction(pred, cfg.code);
+    const pct = Math.round(pred.probability * 100);
     return new Response(
       JSON.stringify({
         hasStarlink: false,
-        message: "No Starlink-equipped aircraft found for this flight on the specified date",
+        confidence: "predicted",
+        prediction: {
+          probability: pred.probability,
+          confidence: pred.confidence,
+          n_observations: pred.n_observations,
+        },
+        message:
+          pred.n_observations > 0
+            ? `Aircraft assignment not yet published — ${cfg.name} assigns aircraft ~2 days before departure. ~${pct}% of recent departures of this flight used a Starlink-equipped aircraft (${pred.n_observations} observation${pred.n_observations === 1 ? "" : "s"}).`
+            : `Aircraft assignment not yet published — ${cfg.name} assigns aircraft ~2 days before departure. No history for this flight number; ~${pct}% reflects the fleet-wide install rate.`,
         flights: [],
       }),
       { headers: SECURITY_HEADERS.api }
@@ -553,7 +583,13 @@ const apiCheckFlight: Handler = async ({ req, url, reader, tenant }) => {
   }
 
   const allVerified = matchingFlights.every((f) => f.verified_wifi === "Starlink");
-  recordFlightLookup("api_check", "verified_yes", allVerified ? "high" : "medium", cfg.code);
+  recordFlightLookup(
+    "api_check",
+    "verified_yes",
+    allVerified ? "high" : "medium",
+    cfg.code,
+    daysOut
+  );
   const response = {
     hasStarlink: true,
     confidence: allVerified ? "verified" : "likely",

--- a/tests/golden.test.ts
+++ b/tests/golden.test.ts
@@ -68,9 +68,17 @@ describe("golden snapshots (refactor must be byte-identical)", () => {
     expect(Object.keys(liveF).sort()).toEqual(Object.keys(fixtureF).sort());
   });
 
-  test("/api/check-flight UA123 (false)", async () => {
+  test("/api/check-flight UA123 (miss → prediction fallback)", async () => {
     const live = await getJSON("/api/check-flight?flight_number=UA123&date=2026-03-20");
-    expect(live).toEqual(load("api-check-flight-UA123.json"));
+    // The miss response intentionally changed (2026-05): it now carries a
+    // prediction block whose values are recomputed from the verification log on
+    // every snapshot. Compare shape, not values — same softening as the
+    // /api/data flightsByTail comparison above.
+    const { prediction, message, ...rest } = live;
+    expect(rest).toEqual({ hasStarlink: false, confidence: "predicted", flights: [] });
+    expect(typeof prediction.probability).toBe("number");
+    expect(typeof prediction.n_observations).toBe("number");
+    expect(typeof message).toBe("string");
   });
 
   test("/api/check-flight UA4421 (true, verified)", async () => {

--- a/tests/golden/api-check-flight-UA123.json
+++ b/tests/golden/api-check-flight-UA123.json
@@ -1,5 +1,0 @@
-{
-  "hasStarlink": false,
-  "message": "No Starlink-equipped aircraft found for this flight on the specified date",
-  "flights": []
-}

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -125,6 +125,35 @@ describe("/api/check-flight contract", () => {
     expect(resp.flights.length).toBe(0);
   });
 
+  test("no-assignment miss: contract fields intact, prediction rides along", async () => {
+    // A date far outside both lookup windows (no upcoming_flights row, FR24
+    // fallback skipped) exercises the predictor fallback without any network.
+    const farOut = new Date(Date.now() + 60 * 86400 * 1000).toISOString().slice(0, 10);
+    const app = createApp(db);
+    const res = await app.dispatch(
+      new Request(`http://x/api/check-flight?flight_number=UA1234&date=${farOut}`, {
+        headers: { Host: "unitedstarlinktracker.com" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      hasStarlink: boolean;
+      flights: unknown[];
+      confidence?: string;
+      prediction?: { probability: number; confidence: string; n_observations: number };
+    };
+    // Chrome extension contract — must not break
+    expect(body.hasStarlink).toBe(false);
+    expect(Array.isArray(body.flights)).toBe(true);
+    // Additive prediction block
+    expect(body.confidence).toBe("predicted");
+    expect(typeof body.prediction?.probability).toBe("number");
+    expect(body.prediction!.probability).toBeGreaterThanOrEqual(0);
+    expect(body.prediction!.probability).toBeLessThanOrEqual(1);
+    expect(["high", "medium", "low"]).toContain(body.prediction!.confidence);
+    expect(typeof body.prediction?.n_observations).toBe("number");
+  });
+
   test("hit: returns { hasStarlink: true, flights: [...] } with full field shape", () => {
     // Find ANY real flight in the DB so this test is stable across data refreshes
     const sample = db


### PR DESCRIPTION
>40% /api/check-flight lookups return no_data because aircraft tail assignments don't exist more than ~2 days before departure and both lookup paths require one. The MCP check_flight tool already falls back to the historical per-flight-number probability and answers 96% of queries; the HTTP endpoint never got that third stage. 

- When neither the upcoming_flights JOIN nor the FR24 tail lookup produces an answer, return `confidence: "predicted"` + a `prediction: {probability, confidence, n_observations}` block. `hasStarlink` stays a boolean and stays `false` — the extension contract is unchanged and old extension copies see no behavior change
- Only report `verified_no` when a segment's tail is verified non-Starlink; unknown tails fall through to the prediction instead of being presented as a firm no
- Tag `flight.lookup_result` with a `days_out` bucket so the query-date distribution becomes observable
- Extension v1.4.0 renders a "Starlink ~85%" badge for predictions ≥80% with non-low confidence; the percentage is in the badge text because mobile has no tooltips
- Golden miss-case fixture replaced with a shape assertion — the prediction values are recomputed from the verification log on every snapshot