### PR TITLE
Back off parked planes to weekly checks

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -2421,8 +2421,10 @@ export function updateFleetVerificationResult(
       .query("SELECT check_attempts FROM united_fleet WHERE tail_number = ?")
       .get(tailNumber) as { check_attempts: number } | null;
     const attempts = (current?.check_attempts || 0) + 1;
-    // 1h, 2h, 4h, 8h, max 24h
-    nextCheckDelay = Math.min(24 * 3600, 3600 * 2 ** (attempts - 1));
+    // 1h, 2h, 4h, 8h, max 24h — but 20+ consecutive failures means parked/stored,
+    // and weekly is enough to catch a return to service.
+    nextCheckDelay =
+      attempts >= 20 ? 7 * 24 * 3600 : Math.min(24 * 3600, 3600 * 2 ** (attempts - 1));
   } else if (result.needsMoreObs) {
     // Consensus is ambiguous/insufficient — re-check in ~36h so it converges
     // within a few days instead of waiting 7-14 days between observations.

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -160,11 +160,11 @@ async function verifyPlane(
       const flightData = await getUpcomingFlightsForPlane(plane.tail_number);
 
       if (!flightData) {
-        const attempts = plane.check_attempts ?? 0;
-        if (attempts >= 20) {
-          warn(
-            `${plane.tail_number}: ${attempts} consecutive no-flights — likely grounded, manual review needed`
-          );
+        // Counting this check, to match the increment updateFleetVerificationResult applies.
+        const failures = (plane.check_attempts ?? 0) + 1;
+        if (failures === 20) {
+          // Warn once at the parked threshold; after that it's weekly backoff and repeats are noise.
+          warn(`${plane.tail_number}: ${failures} consecutive no-flights — likely parked/stored`);
         } else {
           info(`No upcoming flights for ${plane.tail_number}, skipping`);
         }


### PR DESCRIPTION
~100 UA tails are parked/stored (20+ consecutive no-flight checks) but still hit the 24h error-backoff cap, burning ~90 FR24 lookups/day and re-warning "likely grounded" on every check.

- Once a tail reaches 20 consecutive failures, the error backoff jumps to 7 days; a successful check still resets it to the normal cadence
- The grounded warning fires once at the threshold instead of on every recheck