### PR TITLE
Verify wifi via united's flight-status API and fast-track disputed tails

### DIFF
--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -80,10 +80,10 @@ INSERT OR IGNORE INTO starlink_planes (aircraft, wifi, sheet_gid, sheet_type, Da
   ('Airbus A321-271N','Starlink','ha_seed','HA-mainline','2024-09-24','N205HA','Hawaiian Airlines','mainline','Starlink','HA'),
   ('Airbus A321-271N','Starlink','ha_seed','HA-mainline','2024-09-24','N215HA','Hawaiian Airlines','mainline','Starlink','HA');
 
--- Seed flight_routes cache for UA100 so predict_flight_starlink test never
--- falls through to live FR24 (the one network-dependent flake).
+-- Seed flight_routes for UA100 so the predict test never needs live FR24;
+-- far-future last_seen_at keeps it inside the lookup's 7-day freshness window.
 INSERT OR REPLACE INTO flight_routes (flight_number, origin, destination, duration_sec, first_seen_at, last_seen_at, seen_count)
-  VALUES ('UA100', 'EWR', 'TLV', 39600, strftime('%s','now'), strftime('%s','now'), 1);
+  VALUES ('UA100', 'EWR', 'TLV', 39600, strftime('%s','now'), strftime('%s','now','+10 years'), 1);
 
 -- Real AS fleet sample — mid-rollout: Horizon E175s confirmed (first to ship),
 -- mainline 737s mostly unknown.

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -9,6 +9,7 @@ import {
   getAllStarlinkPlanes,
   getUpcomingFlights,
   getVerificationStats,
+  getWifiMismatches,
   initializeDatabase,
   logVerification,
   needsVerification,
@@ -87,6 +88,10 @@ interface Plane {
   fleet: string;
 }
 
+// Tails where the sheet and the united.com consensus disagree are usually fresh
+// retrofits united's feed hasn't caught up on — re-check daily instead of ~72h.
+const DISPUTED_RECHECK_HOURS = 24;
+
 /**
  * Get planes that need United verification.
  * Queries the local DB directly (including mismatched planes with
@@ -100,13 +105,18 @@ function getPlanesNeedingVerification(
   db: Database,
   limit: number,
   forceAll = false
-): Array<{ plane: Plane; flight: Flight }> {
-  const result: Array<{ plane: Plane; flight: Flight }> = [];
+): Array<{ plane: Plane; flight: Flight; recheckHours?: number }> {
+  const result: Array<{ plane: Plane; flight: Flight; recheckHours?: number }> = [];
   const now = Math.floor(Date.now() / 1000);
 
   // Pull ALL planes from starlink_planes (including mismatches) — UA only;
   // HA is type-deterministic and AS uses alaska-json, neither needs united.com checks.
-  const planes = getAllStarlinkPlanes(db, "UA") as Plane[];
+  // Disputed tails (sheet vs verified_wifi mismatch) go first so they self-heal
+  // ahead of routine re-checks.
+  const disputed = new Set(getWifiMismatches(db, "UA").map((m) => m.TailNumber));
+  const planes = (getAllStarlinkPlanes(db, "UA") as Plane[]).sort(
+    (a, b) => Number(disputed.has(b.TailNumber)) - Number(disputed.has(a.TailNumber))
+  );
   const allFlights = getUpcomingFlights(db, undefined, "UA");
 
   // Group flights by tail number
@@ -130,11 +140,12 @@ function getPlanesNeedingVerification(
     );
     if (!candidate) continue;
 
-    if (!forceAll && !needsVerification(db, plane.TailNumber, UNITED_SOURCE)) {
+    const recheckHours = disputed.has(plane.TailNumber) ? DISPUTED_RECHECK_HOURS : undefined;
+    if (!forceAll && !needsVerification(db, plane.TailNumber, UNITED_SOURCE, recheckHours)) {
       continue;
     }
 
-    result.push({ plane, flight: candidate });
+    result.push({ plane, flight: candidate, recheckHours });
   }
 
   return result;
@@ -148,11 +159,11 @@ export async function verifyPlaneStarlink(
   tailNumber: string,
   flight: Flight,
   forceCheck = false,
-  context?: { aircraftType?: string | null; fleet?: string | null },
+  context?: { aircraftType?: string | null; fleet?: string | null; recheckHours?: number },
   deps: VerifyPlaneStarlinkDeps = {}
 ): Promise<StarlinkCheckResult | null> {
   const checker = deps.checker ?? checkStarlinkStatusSubprocess;
-  if (!forceCheck && !needsVerification(db, tailNumber, UNITED_SOURCE)) {
+  if (!forceCheck && !needsVerification(db, tailNumber, UNITED_SOURCE, context?.recheckHours)) {
     return null;
   }
 
@@ -218,7 +229,9 @@ export async function verifyPlaneStarlink(
             `Flight ${flightNumber} aircraft: ${resolvedTail} (${result.wifiProvider || "unknown"})`
           );
         } else if (result.hasStarlink) {
-          verifierLog.info(`✓ ${tailNumber} confirmed Starlink (${result.wifiProvider})`);
+          verifierLog.info(
+            `✓ ${tailNumber} confirmed Starlink (${result.wifiProvider} via ${result.providerSource})`
+          );
         } else if (result.error) {
           verifierLog.warn(
             `✗ ${tailNumber} error: ${result.error}`,
@@ -226,7 +239,11 @@ export async function verifyPlaneStarlink(
           );
         } else {
           verifierLog.info(
-            `✗ ${tailNumber} no Starlink (${result.wifiProvider || "unknown provider"})`,
+            `✗ ${tailNumber} no Starlink (${
+              result.wifiProvider
+                ? `${result.wifiProvider} via ${result.providerSource}`
+                : "unknown provider"
+            })`,
             result.debugFile ? { debugFile: result.debugFile } : undefined
           );
         }
@@ -299,10 +316,11 @@ export async function runVerificationBatch(
     verifierLog.info(`${toVerify.length} plane(s) need verification`);
 
     for (let i = 0; i < toVerify.length; i++) {
-      const { plane, flight } = toVerify[i];
+      const { plane, flight, recheckHours } = toVerify[i];
       const result = await verifyPlaneStarlink(db, plane.TailNumber, flight, forceAll, {
         aircraftType: plane.Aircraft,
         fleet: plane.fleet,
+        recheckHours,
       });
 
       if (result === null) {

--- a/src/scripts/united-starlink-checker.ts
+++ b/src/scripts/united-starlink-checker.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { Browser, Page } from "playwright";
 import { chromium } from "playwright-extra";
 import StealthPlugin from "puppeteer-extra-plugin-stealth";
+import { looksLikeValidTailNumber } from "../airlines/registry";
 import { BROWSER_USER_AGENT } from "../utils/constants";
 import { LOG_DIR, info, warn } from "../utils/logger";
 
@@ -19,12 +20,75 @@ export interface StarlinkCheckResult {
   shipNumber: string | null;
   aircraftType: string | null;
   wifiProvider: string | null;
+  // Where the provider came from: united's flight-status XHR or scraped page text
+  providerSource?: "status_api" | "page";
   flightNumber: string;
   date: string;
   origin: string;
   destination: string;
   error?: string;
   debugFile?: string;
+}
+
+export interface StatusApiEquipment {
+  wifiProvider: string | null;
+  tailNumber: string | null;
+  shipNumber: string | null;
+  aircraftType: string | null;
+}
+
+// Same bounded vocabulary the page scrape produces, so downstream string
+// matching (consensus, mismatch exclusion) never sees raw vendor spellings.
+const PROVIDER_PATTERNS: Array<[RegExp, string]> = [
+  [/starlink/i, "Starlink"],
+  [/panasonic/i, "Panasonic"],
+  [/viasat/i, "Viasat"],
+  [/thales/i, "Thales"],
+  [/gogo/i, "Gogo"],
+  [/^(none|not offered|no ?wi-?fi)$/i, "None"],
+];
+
+function canonicalProvider(raw: string): string | null {
+  if (!raw) return null;
+  for (const [pattern, name] of PROVIDER_PATTERNS) {
+    if (pattern.test(raw)) return name;
+  }
+  return raw;
+}
+
+/**
+ * Extract the Equipment block from united's /api/flightstatus/status response.
+ * WifiPrvdr there drives the page's Starlink banner; the "Inflight amenities"
+ * text comes from a separate aircraft-amenities feed that lags retrofits.
+ */
+export function parseStatusApiResponse(
+  json: unknown,
+  origin: string,
+  destination: string
+): StatusApiEquipment | null {
+  const legs = (json as any)?.data?.flightLegs;
+  if (!Array.isArray(legs)) return null;
+  const segments: any[] = legs.flatMap((leg) => leg?.OperationalFlightSegments ?? []);
+  // Require a leg match when the payload has several segments — falling back to
+  // an arbitrary leg would attribute another aircraft's provider to this one.
+  const segment =
+    segments.find(
+      (s) => s?.DepartureAirport?.IATACode === origin && s?.ArrivalAirport?.IATACode === destination
+    ) ?? (segments.length === 1 ? segments[0] : undefined);
+  const equipment = segment?.Equipment;
+  if (!equipment) return null;
+
+  const rawProvider =
+    typeof equipment.Amenities?.WifiPrvdr === "string" ? equipment.Amenities.WifiPrvdr.trim() : "";
+  const tail = typeof equipment.TailNumber === "string" ? equipment.TailNumber.toUpperCase() : "";
+  const ship = equipment.NoseNumber ?? equipment.ShipNumber;
+  return {
+    wifiProvider: canonicalProvider(rawProvider),
+    tailNumber: looksLikeValidTailNumber(tail) ? tail : null,
+    shipNumber: ship != null && /^\d{3,4}$/.test(String(ship)) ? String(ship) : null,
+    aircraftType:
+      typeof equipment.Model?.Description === "string" ? equipment.Model.Description : null,
+  };
 }
 
 /**
@@ -124,6 +188,14 @@ export async function checkStarlinkStatus(
     if (process.env.SUBPROCESS_MODE !== "1") {
       info(`Fetching: ${url}`);
     }
+
+    // Capture the flight-status XHR the page makes for itself; registered
+    // before goto so the response can't be missed.
+    const statusApiPromise: Promise<StatusApiEquipment | null> = page
+      .waitForResponse((r) => r.url().includes("/api/flightstatus/status/"), { timeout: 25000 })
+      .then((r) => r.json())
+      .then((json) => parseStatusApiResponse(json, origin, destination))
+      .catch(() => null);
 
     // Navigate with a longer timeout
     await page.goto(url, {
@@ -267,9 +339,24 @@ export async function checkStarlinkStatus(
     result.aircraftType = data.aircraftType;
     result.wifiProvider = data.wifiProvider;
 
-    if (!data.wifiProvider || (!data.hasStarlink && !data.wifiProvider)) {
+    // The status XHR drives the page's own banner — prefer it over scraped text.
+    const statusApi = await statusApiPromise;
+    if (statusApi) {
+      if (statusApi.wifiProvider) {
+        result.hasStarlink = statusApi.wifiProvider === "Starlink";
+        result.wifiProvider = statusApi.wifiProvider;
+      }
+      result.tailNumber = statusApi.tailNumber || result.tailNumber;
+      result.shipNumber = statusApi.shipNumber || result.shipNumber;
+      result.aircraftType = statusApi.aircraftType || result.aircraftType;
+    }
+    if (result.wifiProvider) {
+      result.providerSource = statusApi?.wifiProvider ? "status_api" : "page";
+    }
+
+    if (!result.wifiProvider) {
       result.debugFile = saveDebugHtml(
-        data.tailNumber || "unknown",
+        result.tailNumber || "unknown",
         flightNumber,
         pageContent,
         data.bodyText

--- a/tests/united-status-api.test.ts
+++ b/tests/united-status-api.test.ts
@@ -1,0 +1,101 @@
+// Pins the slice of united's flight-status payload the checker relies on.
+// If united renames fields the parser must degrade to null (DOM scrape is the fallback).
+
+import { describe, expect, test } from "bun:test";
+import { parseStatusApiResponse } from "../src/scripts/united-starlink-checker";
+
+function segment(over: Record<string, unknown> = {}) {
+  return {
+    DepartureAirport: { IATACode: "LAX" },
+    ArrivalAirport: { IATACode: "SFO" },
+    Equipment: {
+      TailNumber: "N73275",
+      NoseNumber: "3275",
+      ShipNumber: "3275",
+      Model: { Description: "Boeing 737-800" },
+      Amenities: { WifiPrvdr: "Starlink" },
+    },
+    ...over,
+  };
+}
+
+function payload(...segments: Array<Record<string, unknown>>) {
+  return { data: { flightLegs: [{ OperationalFlightSegments: segments }] } };
+}
+
+describe("parseStatusApiResponse", () => {
+  test("extracts provider, tail, ship, and model from the equipment block", () => {
+    const parsed = parseStatusApiResponse(payload(segment()), "LAX", "SFO");
+    expect(parsed).toEqual({
+      wifiProvider: "Starlink",
+      tailNumber: "N73275",
+      shipNumber: "3275",
+      aircraftType: "Boeing 737-800",
+    });
+  });
+
+  test("picks the segment matching the requested leg, not the first one", () => {
+    const otherLeg = segment({
+      DepartureAirport: { IATACode: "SFO" },
+      ArrivalAirport: { IATACode: "DEN" },
+      Equipment: { TailNumber: "N77590", Amenities: { WifiPrvdr: "Viasat" } },
+    });
+    const parsed = parseStatusApiResponse(payload(otherLeg, segment()), "LAX", "SFO");
+    expect(parsed?.wifiProvider).toBe("Starlink");
+    expect(parsed?.tailNumber).toBe("N73275");
+  });
+
+  test("falls back to the only segment when no leg matches", () => {
+    const parsed = parseStatusApiResponse(payload(segment()), "EWR", "ORD");
+    expect(parsed?.tailNumber).toBe("N73275");
+  });
+
+  test("returns null when several segments exist and none match the leg", () => {
+    const otherLeg = segment({ ArrivalAirport: { IATACode: "DEN" } });
+    expect(parseStatusApiResponse(payload(segment(), otherLeg), "EWR", "ORD")).toBeNull();
+  });
+
+  test.each([
+    ["STARLINK Wi-Fi", "Starlink"],
+    ["Panasonic Avionics", "Panasonic"],
+    ["VIASAT", "Viasat"],
+    ["Not offered", "None"],
+    ["SomeFutureVendor", "SomeFutureVendor"],
+  ])("canonicalizes provider %s to %s", (raw, expected) => {
+    const variant = segment({
+      Equipment: { TailNumber: "N73275", Amenities: { WifiPrvdr: raw } },
+    });
+    expect(parseStatusApiResponse(payload(variant), "LAX", "SFO")?.wifiProvider).toBe(expected);
+  });
+
+  test.each([
+    ["null payload", null],
+    ["missing flightLegs", { data: {} }],
+    ["missing equipment", payload({ DepartureAirport: { IATACode: "LAX" } })],
+  ])("returns null for %s", (_label, input) => {
+    expect(parseStatusApiResponse(input, "LAX", "SFO")).toBeNull();
+  });
+
+  test("nulls fields that fail validation instead of passing junk through", () => {
+    const parsed = parseStatusApiResponse(
+      payload(
+        segment({
+          Equipment: {
+            TailNumber: "Boeing 737-800W",
+            NoseNumber: "not-a-ship",
+            Model: {},
+            Amenities: { WifiPrvdr: "  " },
+          },
+        })
+      ),
+      "LAX",
+      "SFO"
+    );
+    expect(parsed).toEqual({
+      wifiProvider: null,
+      tailNumber: null,
+      shipNumber: null,
+      aircraftType: null,
+    });
+  });
+});


### PR DESCRIPTION
united.com has two wifi sources for a flight: the aircraft-amenities feed (lags retrofits — still says Viasat for freshly converted 737s) and the flight-status API that the page's own Starlink banner renders from. The verifier scraped page text, so freshly retrofitted tails sat in a disputed/negative state for weeks — 19 tails right now, including N73275 which flew UA2019 on 2026-06-13 with working Starlink while the API answered no.

- the checker now captures the page's `/api/flightstatus/status` XHR and prefers its `WifiPrvdr`/`TailNumber`/`ShipNumber` over scraped text; the source is logged as `providerSource`
- API provider strings are normalized to the existing vocabulary and tails validated with `looksLikeValidTailNumber`, so consensus and the mismatch list never see raw vendor spellings
- the verifier re-checks `getWifiMismatches` tails on a 24h cadence and checks them first; deliberate tradeoff: a genuinely wrong sheet entry stays on daily rechecks (~19 tails today ≈ 19 extra checks/day)
- new unit tests pin the slice of the status-API payload the parser relies on
- the UA100 route seed in test-setup is now far-future, so the suite no longer fails once the local snapshot is older than the route lookup's 7-day freshness window