### PR TITLE
Ingest fleet-site Starlink progress sheets and show the install pipeline

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -7,6 +7,7 @@ import { archivePastDepartures, initializeDatabase, pruneCrashRows } from "./src
 import { startAlaskaVerifier } from "./src/scripts/alaska-verifier";
 import { startFreshnessEmitter } from "./src/scripts/data-freshness";
 import { startFleetDiscovery } from "./src/scripts/fleet-discovery";
+import { startFleetProgressJob } from "./src/scripts/fleet-progress";
 import { startFleetSync } from "./src/scripts/fleet-sync";
 import { startQatarScheduleIngester } from "./src/scripts/qatar-schedule-ingester";
 import { runSheetScrape } from "./src/scripts/sheet-scrape";
@@ -104,6 +105,9 @@ if (JOBS_ENABLED) {
       run: () => syncShipNumbers(),
     })
   );
+
+  // Daily UA install-pipeline counts from the fleet-site progress workbooks.
+  track(startFleetProgressJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/components/fleet-page.tsx
+++ b/src/components/fleet-page.tsx
@@ -1,6 +1,12 @@
 import React from "react";
 import { AIRLINES, type SiteConfig } from "../airlines/registry";
-import type { FleetFamily, FleetPageData, FleetTail, WifiProvider } from "../types";
+import type {
+  FleetFamily,
+  FleetPageData,
+  FleetProgressRow,
+  FleetTail,
+  WifiProvider,
+} from "../types";
 import { AIRCRAFT_SPECS, type AircraftSpec } from "../utils/aircraft-specs";
 
 const PROVIDER_LABEL: Record<WifiProvider, string> = {
@@ -504,6 +510,73 @@ function TailMonument({ allTails, totalFleet }: { allTails: FleetTail[]; totalFl
   );
 }
 
+const PROGRESS_SEGMENT_LABELS: Record<string, string> = {
+  mainline_nb: "Mainline narrowbody",
+  mainline_wb: "Mainline widebody",
+  express: "Express & regional",
+};
+
+// Forward-looking install pipeline (in mod / awaiting verification) — the
+// historical counterpart is InstallPaceSection.
+function InstallPipelineSection({ progress }: { progress: FleetProgressRow[] }) {
+  const totals = progress.filter((r) => r.type_code === "Totals");
+  if (totals.length === 0) return null;
+  const updated = totals.find((r) => r.sheet_updated)?.sheet_updated;
+  const inModTypes = progress.filter(
+    (r) => r.type_code !== "Totals" && ((r.in_mod ?? 0) > 0 || (r.verification_needed ?? 0) > 0)
+  );
+
+  return (
+    <section className={SECTION}>
+      <div className="mb-4">
+        <h2 className="font-display text-xl font-semibold text-primary mb-1">Install Pipeline</h2>
+        <p className="text-xs text-muted">
+          Per the community fleet-site progress sheets{updated ? ` (updated ${updated} ET)` : ""} —
+          aircraft currently in a mod line show up here before they appear as equipped.
+        </p>
+      </div>
+      <div className="grid md:grid-cols-3 gap-4">
+        {totals.map((seg) => {
+          const pct =
+            seg.total && seg.starlink_complete !== null
+              ? Math.round((seg.starlink_complete / seg.total) * 100)
+              : null;
+          return (
+            <div key={seg.segment} className={PANEL}>
+              <div className={EYEBROW}>{PROGRESS_SEGMENT_LABELS[seg.segment] ?? seg.segment}</div>
+              <div className="font-display text-2xl font-bold text-primary">
+                {seg.starlink_complete ?? 0}
+                <span className="text-sm font-normal text-muted">
+                  {" "}
+                  of {seg.total ?? "?"} complete
+                </span>
+              </div>
+              <div className="font-mono text-[11px] text-secondary mt-2 space-y-1">
+                <div>{seg.in_mod ?? 0} in mod line now</div>
+                <div>{seg.verification_needed ?? 0} awaiting verification</div>
+                {pct !== null && <div className="text-muted">{pct}% of segment</div>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {inModTypes.length > 0 && (
+        <div className={`${PANEL} mt-4`}>
+          <div className={EYEBROW}>Active mod lines by type</div>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 font-mono text-[11px] text-secondary">
+            {inModTypes.map((r) => (
+              <div key={`${r.segment}-${r.type_code}`}>
+                {r.type_code}: {r.in_mod ?? 0} in mod
+                {(r.verification_needed ?? 0) > 0 ? `, ${r.verification_needed} verifying` : ""}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
 interface FleetPageProps {
   data: FleetPageData;
   site: SiteConfig;
@@ -586,6 +659,7 @@ export default function FleetPage({ data, site }: FleetPageProps) {
 
       <LivePulse pulse={data.pulse} />
       <InstallPaceSection pace={data.installPace} />
+      <InstallPipelineSection progress={data.progress} />
       <HangarFloor
         families={data.families}
         totalFleet={data.totalFleet}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -28,6 +28,7 @@ import type {
   FleetDiscoveryStats,
   FleetFamily,
   FleetPageData,
+  FleetProgressRow,
   FleetSource,
   FleetStats,
   FleetTail,
@@ -299,6 +300,26 @@ function setupTables(db: Database) {
       CREATE INDEX idx_qs_dep_time ON qatar_schedule(departure_time);
       CREATE INDEX idx_qs_route ON qatar_schedule(departure_airport, arrival_airport, departure_time);
       CREATE INDEX idx_qs_flight ON qatar_schedule(flight_number, scheduled_date);
+    `).run();
+  }
+
+  // Per-type Starlink install pipeline from the United Fleet Site progress
+  // workbooks (Complete / In Mod / Verification needed), refreshed daily.
+  if (!tableExists(db, "fleet_progress")) {
+    db.query(`
+      CREATE TABLE fleet_progress (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        airline TEXT NOT NULL,
+        segment TEXT NOT NULL,
+        type_code TEXT NOT NULL,
+        total INTEGER,
+        starlink_complete INTEGER,
+        in_mod INTEGER,
+        verification_needed INTEGER,
+        sheet_updated TEXT,
+        fetched_at INTEGER NOT NULL,
+        UNIQUE(airline, segment, type_code)
+      );
     `).run();
   }
 
@@ -2989,6 +3010,52 @@ export function getFleetPageData(db: Database, airline?: AirlineFilter): FleetPa
   return data;
 }
 
+/** Replace an airline's install-pipeline rows, per segment, so types dropped
+ * from the sheet don't linger as stale rows. */
+export function replaceFleetProgress(
+  db: Database,
+  airline: string,
+  rows: Array<Omit<FleetProgressRow, "airline" | "fetched_at">>
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.transaction(() => {
+    for (const segment of new Set(rows.map((r) => r.segment))) {
+      db.query("DELETE FROM fleet_progress WHERE airline = ? AND segment = ?").run(
+        airline,
+        segment
+      );
+    }
+    for (const r of rows) {
+      db.query(`
+        INSERT INTO fleet_progress
+          (airline, segment, type_code, total, starlink_complete, in_mod, verification_needed,
+           sheet_updated, fetched_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        airline,
+        r.segment,
+        r.type_code,
+        r.total,
+        r.starlink_complete,
+        r.in_mod,
+        r.verification_needed,
+        r.sheet_updated,
+        now
+      );
+    }
+  })();
+}
+
+export function getFleetProgress(db: Database, airline?: AirlineFilter): FleetProgressRow[] {
+  const q = withAirline(
+    `SELECT airline, segment, type_code, total, starlink_complete, in_mod, verification_needed,
+            sheet_updated, fetched_at
+     FROM fleet_progress WHERE 1=1`,
+    airline
+  );
+  return db.query(`${q.sql} ORDER BY segment, type_code`).all(...q.params) as FleetProgressRow[];
+}
+
 // One definition of "departure on a Starlink-equipped aircraft, next 48h":
 // the same equipped predicate /api/check-flight uses, with a real upper bound.
 // The homepage airports panel and /routes both render from this base, so the
@@ -3244,6 +3311,9 @@ function computeFleetPageData(db: Database, airline?: AirlineFilter): FleetPageD
     totalFleet: rows.length,
     totalStarlink,
     installPace,
+    // Single-airline narrative like installPace — the hub page must not show
+    // one airline's pipeline as if it covered every tracked fleet.
+    progress: soleAirline ? getFleetProgress(db, airline) : [],
   };
 }
 

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -205,6 +205,10 @@ export const GAUGES = {
   // Row counts for key tables, sampled with the 5-min freshness sweep.
   // tags: table, airline (or "all" if the table has no airline column)
   DB_TABLE_ROWS: "db.table_rows",
+
+  // Install-pipeline rollup from the fleet-progress sheets.
+  // tags: segment (mainline_nb|mainline_wb|express), state (total|complete|in_mod|verification_needed), airline
+  FLEET_PROGRESS_COUNT: "fleet_progress.count",
 } as const;
 
 /**

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -30,6 +30,13 @@ export function buildFreshnessQueries(qrEnabled = AIRLINES.QR.enabled): Record<s
     SELECT airline, MAX(departed_at) AS ts
     FROM departure_log
     GROUP BY airline`,
+    // MIN over per-segment maxima: one segment failing to refresh must age the
+    // gauge even while the other segments keep writing.
+    fleet_progress: `
+    SELECT airline, MIN(seg_ts) AS ts FROM (
+      SELECT airline, MAX(fetched_at) AS seg_ts
+      FROM fleet_progress GROUP BY airline, segment
+    ) GROUP BY airline`,
   };
   // QR writes none of the airline-column tables — only qatar_schedule, whose
   // last_updated is touched solely on successful upserts. Without this gauge
@@ -55,6 +62,7 @@ export function buildFreshnessCoverage(
     flight_updater: ["UA", "HA", "AS"],
     verifier: ["UA", "HA", "AS"],
     departures: ["UA", "HA", "AS"],
+    fleet_progress: ["UA"],
   };
   if (qrEnabled) coverage.qatar_ingester = ["QR"];
   return coverage;

--- a/src/scripts/fleet-progress.ts
+++ b/src/scripts/fleet-progress.ts
@@ -1,0 +1,273 @@
+/**
+ * Daily ingest of the United Fleet Site "Starlink Progress" workbooks — the
+ * per-type install pipeline (Complete / In Mod / Verification needed) that the
+ * roster sheets we already scrape don't carry. Counts only: per-tail install
+ * state lives in cell colors, which the CSV export strips.
+ */
+
+import type { Database } from "bun:sqlite";
+import { looksLikeValidTailNumber } from "../airlines/registry";
+import { replaceFleetProgress } from "../database/database";
+import { COUNTERS, GAUGES, metrics, normalizeAirlineTag, withSpan } from "../observability";
+import { type JobHandle, startJob } from "../utils/job-runner";
+import { info, error as logError, warn } from "../utils/logger";
+import { fetchSheetCsv } from "../utils/utils";
+
+export type ProgressSegment = "mainline_nb" | "mainline_wb" | "express";
+
+const MAINLINE_PROGRESS_DOC = "1QQyca_aIbxrV7uXuYfNdHuTygHwsaTFC9uf_dZbKWnI";
+const EXPRESS_PROGRESS_DOC = "1rADs3NACwfFOgqQATmj9CXWkwFH00yGUwmN1zrrT4u8";
+
+const PROGRESS_SHEETS: Array<{ segment: ProgressSegment; docId: string; gid: number }> = [
+  { segment: "mainline_nb", docId: MAINLINE_PROGRESS_DOC, gid: 96918390 },
+  { segment: "mainline_wb", docId: MAINLINE_PROGRESS_DOC, gid: 1396514988 },
+  { segment: "express", docId: EXPRESS_PROGRESS_DOC, gid: 0 },
+];
+
+// Summary-row labels as they appear in column A, normalized to our fields.
+// Mainline uses "Starlink Complete"/"% Completed"/"Updated ET"; express uses
+// "Starlink"/"% Starlink"/"Updated EST"/"Total (no Exit/Fltr)".
+const LABEL_FIELDS: Array<[RegExp, keyof ParsedSummary]> = [
+  [/^total \(no exit/i, "total"],
+  [/^total$/i, "total"],
+  [/^starlink complete$/i, "complete"],
+  [/^completed$/i, "complete"],
+  [/^starlink$/i, "complete"],
+  [/^in mod$/i, "inMod"],
+  [/^verification needed$/i, "verificationNeeded"],
+  [/^updated/i, "updated"],
+];
+
+interface ParsedSummary {
+  total?: string;
+  complete?: string;
+  inMod?: string;
+  verificationNeeded?: string;
+  updated?: string;
+}
+
+// Single pass over the whole export so newlines inside quoted cells stay part
+// of the cell instead of shearing the row.
+function parseCsvGrid(csvText: string): string[][] {
+  const rows: string[][] = [];
+  let cells: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  const endRow = () => {
+    cells.push(field.replace(/\r$/, ""));
+    if (cells.some((c) => c.trim() !== "")) rows.push(cells);
+    cells = [];
+    field = "";
+  };
+  for (let i = 0; i < csvText.length; i++) {
+    const ch = csvText[i];
+    if (ch === '"') {
+      if (inQuotes && csvText[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      cells.push(field);
+      field = "";
+    } else if (ch === "\n" && !inQuotes) {
+      endRow();
+    } else {
+      field += ch;
+    }
+  }
+  if (field !== "" || cells.length > 0) endRow();
+  return rows;
+}
+
+function toCount(raw: string | undefined): number | null {
+  if (raw === undefined) return null;
+  const cleaned = raw.replace(/[,%\s]/g, "");
+  if (cleaned === "") return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) ? Math.round(n) : null;
+}
+
+// Sheet column headers carry positional junk ("Tab#2 E175", "Wide E175",
+// "Bottom CRJ2") — the real type code is the last token.
+function cleanTypeCode(header: string): string {
+  const trimmed = header.trim();
+  const last = trimmed.split(/\s+/).at(-1) ?? "";
+  return last.length >= 2 ? last : trimmed;
+}
+
+export interface ProgressTypeRow {
+  segment: ProgressSegment;
+  type_code: string;
+  total: number | null;
+  starlink_complete: number | null;
+  in_mod: number | null;
+  verification_needed: number | null;
+  sheet_updated: string | null;
+}
+
+/** Parse one progress tab's CSV into per-type rows plus the "Totals" rollup. */
+export function parseProgressCsv(csvText: string, segment: ProgressSegment): ProgressTypeRow[] {
+  const grid = parseCsvGrid(csvText);
+  const headerIdx = grid.findIndex((row) => row.some((c) => c.trim() === "Totals"));
+  if (headerIdx === -1) return [];
+  const header = grid[headerIdx];
+
+  const columns: Array<{ col: number; type: string }> = [];
+  for (let col = 1; col < header.length; col++) {
+    const name = cleanTypeCode(header[col] ?? "");
+    if (name) columns.push({ col, type: name });
+  }
+  if (columns.length === 0) return [];
+
+  const summaries = new Map<number, ParsedSummary>();
+  for (const { col } of columns) summaries.set(col, {});
+  let sheetUpdated: string | null = null;
+
+  for (let r = headerIdx + 1; r < grid.length; r++) {
+    const row = grid[r];
+    // The summary block ends where the per-tail listing starts.
+    if (row.slice(1).some((c) => looksLikeValidTailNumber(c.trim()))) break;
+    const label = (row[0] ?? "").trim();
+    if (!label) continue;
+    const field = LABEL_FIELDS.find(([re]) => re.test(label))?.[1];
+    if (!field) continue;
+    // First matching row wins, except "Total (no Exit/Fltr)" which beats a
+    // plain "Total" — the no-exit figure is the operating denominator.
+    const preferredTotal = field === "total" && /no exit/i.test(label);
+    for (const { col } of columns) {
+      const summary = summaries.get(col);
+      if (!summary || (summary[field] !== undefined && !preferredTotal)) continue;
+      const value = (row[col] ?? "").trim();
+      if (value === "") continue;
+      summary[field] = value;
+      if (field === "updated" && !sheetUpdated) sheetUpdated = value;
+    }
+  }
+
+  const byType = new Map<string, ProgressTypeRow>();
+  for (const { col, type } of columns) {
+    const s = summaries.get(col) ?? {};
+    const parsed: ProgressTypeRow = {
+      segment,
+      type_code: type,
+      total: toCount(s.total),
+      starlink_complete: toCount(s.complete),
+      in_mod: toCount(s.inMod),
+      verification_needed: toCount(s.verificationNeeded),
+      sheet_updated: s.updated?.trim() || sheetUpdated,
+    };
+    if (
+      parsed.total === null &&
+      parsed.starlink_complete === null &&
+      parsed.in_mod === null &&
+      parsed.verification_needed === null
+    ) {
+      continue;
+    }
+    const existing = byType.get(type);
+    if (!existing) {
+      byType.set(type, parsed);
+      continue;
+    }
+    // The sheet splits some types across two columns — fold them into one row.
+    const add = (a: number | null, b: number | null) =>
+      a === null && b === null ? null : (a ?? 0) + (b ?? 0);
+    existing.total = add(existing.total, parsed.total);
+    existing.starlink_complete = add(existing.starlink_complete, parsed.starlink_complete);
+    existing.in_mod = add(existing.in_mod, parsed.in_mod);
+    existing.verification_needed = add(existing.verification_needed, parsed.verification_needed);
+  }
+
+  return [...byType.values()];
+}
+
+export interface FleetProgressSyncResult {
+  outcome: "success" | "partial" | "error";
+  segments: number;
+  rows: number;
+}
+
+export async function runFleetProgressSync(
+  db: Database,
+  fetchCsv: typeof fetchSheetCsv = fetchSheetCsv
+): Promise<FleetProgressSyncResult> {
+  return withSpan(
+    "scraper.fleet_progress",
+    async (span): Promise<FleetProgressSyncResult> => {
+      span.setTag("job.type", "background");
+      const airlineTag = normalizeAirlineTag("UA");
+      const allRows: ProgressTypeRow[] = [];
+      let failed = 0;
+
+      for (const sheet of PROGRESS_SHEETS) {
+        try {
+          const rows = parseProgressCsv(await fetchCsv(sheet.docId, sheet.gid), sheet.segment);
+          if (rows.length === 0) throw new Error("no progress rows parsed");
+          allRows.push(...rows);
+        } catch (err) {
+          failed++;
+          warn(`fleet-progress: ${sheet.segment} fetch/parse failed`, err);
+        }
+      }
+
+      const outcome: FleetProgressSyncResult["outcome"] =
+        failed === PROGRESS_SHEETS.length ? "error" : failed > 0 ? "partial" : "success";
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "fleet_progress",
+        airline: airlineTag,
+        status: outcome,
+      });
+      span.setTag("result", outcome);
+
+      if (outcome === "error") {
+        logError("fleet-progress: all progress sheets failed; nothing written");
+        return { outcome, segments: 0, rows: 0 };
+      }
+
+      replaceFleetProgress(db, "UA", allRows);
+
+      // One gauge per segment rollup so dashboards/monitors can watch the
+      // pipeline (and catch a parse regression as a sudden drop to zero).
+      const totalsRows = allRows.filter((r) => r.type_code === "Totals");
+      for (const rollup of totalsRows) {
+        const states: Array<[string, number | null]> = [
+          ["total", rollup.total],
+          ["complete", rollup.starlink_complete],
+          ["in_mod", rollup.in_mod],
+          ["verification_needed", rollup.verification_needed],
+        ];
+        for (const [state, value] of states) {
+          if (value !== null) {
+            metrics.gauge(GAUGES.FLEET_PROGRESS_COUNT, value, {
+              segment: rollup.segment,
+              state,
+              airline: airlineTag,
+            });
+          }
+        }
+      }
+
+      const summary = totalsRows
+        .map(
+          (r) => `${r.segment}: ${r.starlink_complete}/${r.total} complete, ${r.in_mod ?? 0} in mod`
+        )
+        .join("; ");
+      info(`fleet-progress sync ${outcome}: ${allRows.length} rows (${summary})`);
+      return { outcome, segments: PROGRESS_SHEETS.length - failed, rows: allRows.length };
+    },
+    { "job.type": "background" }
+  );
+}
+
+export function startFleetProgressJob(db: Database): JobHandle {
+  return startJob({
+    name: "fleet_progress",
+    intervalMs: 24 * 3600 * 1000,
+    initialDelayMs: 5 * 60 * 1000,
+    run: async () => {
+      await runFleetProgressSync(db);
+    },
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,6 +173,21 @@ export interface FleetPageData {
   totalStarlink: number;
   /** null on the hub site — install pace is a single-airline narrative. */
   installPace: InstallPace | null;
+  /** Per-type install pipeline rows (empty until the fleet-progress job has run). */
+  progress: FleetProgressRow[];
+}
+
+/** One per-type row of the install pipeline (United Fleet Site progress workbooks). */
+export interface FleetProgressRow {
+  airline: string;
+  segment: string;
+  type_code: string;
+  total: number | null;
+  starlink_complete: number | null;
+  in_mod: number | null;
+  verification_needed: number | null;
+  sheet_updated: string | null;
+  fetched_at: number;
 }
 
 export interface RouteScheduleRow {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -95,6 +95,27 @@ function parseCSV(csvText: string) {
   return { headers, rows };
 }
 
+/** Fetch one Google Sheets tab as CSV via the export endpoint, with the same
+ * browser-imitating headers the roster scrape uses. */
+export async function fetchSheetCsv(docId: string, gid: number): Promise<string> {
+  const response = await fetch(
+    `https://docs.google.com/spreadsheets/d/${docId}/export?format=csv&gid=${gid}`,
+    {
+      redirect: "follow",
+      headers: {
+        "User-Agent": BROWSER_USER_AGENT,
+        Accept: "text/html,application/xhtml+xml,application/xml;q=0.9",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Cache-Control": "no-cache",
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP error! Status: ${response.status}`);
+  }
+  return response.text();
+}
+
 // Function to fetch all CSV data and filter for Starlink WiFi
 export async function fetchAllSheets() {
   const exportUrls = createCsvExportUrls();

--- a/tests/fleet-progress.test.ts
+++ b/tests/fleet-progress.test.ts
@@ -1,0 +1,111 @@
+// Pins the fleet-site progress workbook parsing (summary rows only — per-tail
+// state is color-encoded and deliberately out of scope) and the replace/read path.
+
+import { describe, expect, test } from "bun:test";
+import { getFleetProgress, replaceFleetProgress } from "../src/database/database";
+import { parseProgressCsv, runFleetProgressSync } from "../src/scripts/fleet-progress";
+import { makeSyntheticDb } from "./helpers";
+
+const MAINLINE_NB_CSV = [
+  '"Type","73G","738","738","Totals",""',
+  '"Total","40","67","74","181","100.0%"',
+  '"Starlink Complete","0","16","21","37","20.4%"',
+  '"W/O Starlink","40","51","53","144","79.6%"',
+  '"Verification needed ","0","0","5","5","2.8%"',
+  '"In Mod","1","6","3","10","5.5%"',
+  '"% Completed","0.0%","23.9%","28.4%","20.4%",""',
+  '"Updated ET","6/14 1am","6/14 1am","6/14 1am"," ",""',
+  '"","N16701","N37263","N76265","",""',
+  '"STARLINK MOD","N24702","N76265","N33266","",""',
+  '"MLB (DG3)","N16703","N33264","N37267","",""',
+].join("\n");
+
+const EXPRESS_CSV = [
+  '"Junk header text Type","Wide E175","Tab#2 E175","Bottom CRJ2","Totals",""',
+  '"Total (no Exit/Fltr)","59","66","41","166",""',
+  '"Starlink","59","66","0","125",""',
+  '"In Mod","0","0","0","0",""',
+  '"In Operation","59","66","41","166",""',
+  '"% Starlink","100.0%","100.0%","0.0%","75.3%",""',
+  '"Updated EST","6/14 1am","6/14 1am","6/14 1am","",""',
+  '"","OO/SkyWst","RW/Republic","OO/SkyWst","",""',
+  '"Starlink","N106SY","N721YX","N920EV","",""',
+].join("\n");
+
+describe("parseProgressCsv", () => {
+  test("extracts the Totals rollup and per-type counts from a mainline tab", () => {
+    const rows = parseProgressCsv(MAINLINE_NB_CSV, "mainline_nb");
+    const totals = rows.find((r) => r.type_code === "Totals");
+    expect(totals).toMatchObject({
+      segment: "mainline_nb",
+      total: 181,
+      starlink_complete: 37,
+      in_mod: 10,
+      verification_needed: 5,
+    });
+    expect(totals?.sheet_updated).toContain("6/14");
+  });
+
+  test("sums duplicate type columns into one row", () => {
+    const rows = parseProgressCsv(MAINLINE_NB_CSV, "mainline_nb");
+    const b738 = rows.find((r) => r.type_code === "738");
+    expect(b738).toMatchObject({ total: 141, starlink_complete: 37, in_mod: 9 });
+  });
+
+  test("handles the express tab labels and ignores the tail-listing rows", () => {
+    const rows = parseProgressCsv(EXPRESS_CSV, "express");
+    const totals = rows.find((r) => r.type_code === "Totals");
+    expect(totals).toMatchObject({ total: 166, starlink_complete: 125, in_mod: 0 });
+    // Aggregated across the two E175 columns (59 + 66); the second "Starlink"
+    // row (tail listing) must not overwrite the summary value.
+    const e175 = rows.find((r) => r.type_code === "E175");
+    expect(e175?.starlink_complete).toBe(125);
+  });
+
+  test("returns no rows for content without a Totals header", () => {
+    expect(parseProgressCsv("not,a,progress,sheet\n1,2,3,4", "express")).toEqual([]);
+  });
+});
+
+describe("fleet_progress storage", () => {
+  test("replace drops rows for types no longer on the sheet and scopes reads by airline", () => {
+    const db = makeSyntheticDb();
+    const rows = parseProgressCsv(MAINLINE_NB_CSV, "mainline_nb");
+    replaceFleetProgress(db, "UA", rows);
+    replaceFleetProgress(db, "UA", rows); // idempotent re-run, no duplicate rows
+    expect(getFleetProgress(db, "UA").length).toBe(rows.length);
+
+    const without738 = rows.filter((r) => r.type_code !== "738");
+    replaceFleetProgress(db, "UA", without738);
+    const stored = getFleetProgress(db, "UA");
+    expect(stored.length).toBe(without738.length);
+    expect(stored.some((r) => r.type_code === "738")).toBe(false);
+    expect(stored.every((r) => r.airline === "UA" && r.fetched_at > 0)).toBe(true);
+    expect(getFleetProgress(db, "HA")).toEqual([]);
+  });
+});
+
+describe("runFleetProgressSync", () => {
+  test("writes rows from all sheets with an injected fetcher", async () => {
+    const db = makeSyntheticDb();
+    const fetchCsv = async (docId: string) =>
+      docId.includes("1rADs3NACw") ? EXPRESS_CSV : MAINLINE_NB_CSV;
+    const result = await runFleetProgressSync(db, fetchCsv);
+    expect(result.outcome).toBe("success");
+    const stored = getFleetProgress(db, "UA");
+    expect(stored.length).toBeGreaterThan(0);
+    expect(new Set(stored.map((r) => r.segment))).toEqual(
+      new Set(["mainline_nb", "mainline_wb", "express"])
+    );
+  });
+
+  test("reports error and writes nothing when every sheet fails", async () => {
+    const db = makeSyntheticDb();
+    const fetchCsv = async () => {
+      throw new Error("HTTP 500");
+    };
+    const result = await runFleetProgressSync(db, fetchCsv);
+    expect(result.outcome).toBe("error");
+    expect(getFleetProgress(db, "UA")).toEqual([]);
+  });
+});

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -604,6 +604,11 @@ describe("data-freshness coverage", () => {
           "INSERT INTO qatar_schedule (flight_number, scheduled_date, last_updated) VALUES ('QR701', '2026-06-03', ?)"
         ).run(ts);
         break;
+      case "fleet_progress":
+        db.query(
+          "INSERT INTO fleet_progress (airline, segment, type_code, total, starlink_complete, fetched_at) VALUES (?, 'mainline_nb', 'Totals', 878, 67, ?)"
+        ).run(airline, ts);
+        break;
       default:
         throw new Error(`no seeder for freshness job ${job} — add one with the query`);
     }


### PR DESCRIPTION
The United Fleet Site maintains separate "Starlink Progress" workbooks (different doc IDs from the roster sheets we scrape) with per-type Complete / In Mod / Verification-needed counts updated daily — a forward-looking install pipeline we have nowhere else. This adds a daily ingest of those counts and surfaces them on /fleet, with metrics so a parse regression or stale segment is visible in Datadog.

- new daily `fleet_progress` job fetches the three progress tabs (mainline NB/WB + express) as CSV and parses the per-type summary rows; per-tail color-coded state is deliberately out of scope for now
- rows land in a new `fleet_progress` table (replace-per-segment so removed types don't linger) and ride FleetPageData into a new "Install Pipeline" panel on /fleet (single-airline pages only, hidden on the hub)
- `fleet_progress.count` gauges per segment/state plus a freshness anchor that uses the oldest segment, so one frozen tab ages the gauge even while the others keep writing
- shared `fetchSheetCsv` helper in utils so the new fetch can't drift from the roster scrape's headers
- unit tests pin the parser against both sheet shapes (junk headers, duplicate type columns, tail-listing cutoff) and the replace semantics

Verified against the live workbooks: 33 rows, totals matching the prototype (express 332/484, mainline NB 67/878 + 22 in mod, WB 0/235), panel rendering on the UA tenant and suppressed on the hub.