### PR TITLE
Sync the FAA aircraft registry daily for tail hygiene and Mode-S hex

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM oven/bun:1.3.13-slim
 WORKDIR /app
 
 # Install Chromium runtime dependencies (required for Playwright's browser)
+# plus curl + unzip (FAA registry job downloads and streams the daily bulk zip)
 RUN apt-get update && apt-get install -y \
+    curl \
     libnss3 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \
@@ -19,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     libpango-1.0-0 \
     libcairo2 \
     libxshmfence1 \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY package.json .

--- a/server.ts
+++ b/server.ts
@@ -6,6 +6,7 @@ import { checkNewPlanes, startFlightUpdater } from "./src/api/flight-updater";
 import { archivePastDepartures, initializeDatabase, pruneCrashRows } from "./src/database/database";
 import { startAlaskaVerifier } from "./src/scripts/alaska-verifier";
 import { startFreshnessEmitter } from "./src/scripts/data-freshness";
+import { startFaaRegistryJob } from "./src/scripts/faa-registry";
 import { startFleetDiscovery } from "./src/scripts/fleet-discovery";
 import { startFleetProgressJob } from "./src/scripts/fleet-progress";
 import { startFleetSync } from "./src/scripts/fleet-sync";
@@ -108,6 +109,9 @@ if (JOBS_ENABLED) {
 
   // Daily UA install-pipeline counts from the fleet-site progress workbooks.
   track(startFleetProgressJob(db));
+
+  // Daily FAA registry slice: existence/dereg hygiene + Mode-S hex per tail.
+  track(startFaaRegistryJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -23,6 +23,7 @@ import type {
   Aircraft,
   AirportDepartures,
   BodyClass,
+  FaaRegistryRow,
   FleetAircraft,
   FleetCarrier,
   FleetDiscoveryStats,
@@ -103,7 +104,9 @@ export interface VerificationLogEntry {
   airline: string;
 }
 
-function setupTables(db: Database) {
+// Exported so tests' synthetic in-memory DBs pick up tables added after the
+// last `test:setup` snapshot, instead of failing on a stale schema.
+export function setupTables(db: Database) {
   // Create starlink_verification_log table
   if (!tableExists(db, "starlink_verification_log")) {
     db.query(`
@@ -319,6 +322,25 @@ function setupTables(db: Database) {
         sheet_updated TEXT,
         fetched_at INTEGER NOT NULL,
         UNIQUE(airline, segment, type_code)
+      );
+    `).run();
+  }
+
+  // FAA Releasable Aircraft Registry slice for tracked tails (no airline column —
+  // the registry is national; tails are globally unique).
+  if (!tableExists(db, "faa_registry")) {
+    db.query(`
+      CREATE TABLE faa_registry (
+        tail_number TEXT PRIMARY KEY,
+        mode_s_hex TEXT,
+        serial TEXT,
+        year_mfr TEXT,
+        faa_status TEXT NOT NULL,
+        registrant TEXT,
+        faa_model TEXT,
+        expiration_date TEXT,
+        dereg_date TEXT,
+        last_refreshed INTEGER NOT NULL
       );
     `).run();
   }
@@ -3054,6 +3076,44 @@ export function getFleetProgress(db: Database, airline?: AirlineFilter): FleetPr
     airline
   );
   return db.query(`${q.sql} ORDER BY segment, type_code`).all(...q.params) as FleetProgressRow[];
+}
+
+/** Replace the FAA registry slice with the latest pull (full refresh, one transaction). */
+export function replaceFaaRegistry(
+  db: Database,
+  rows: Array<Omit<FaaRegistryRow, "last_refreshed">>
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.transaction(() => {
+    db.query("DELETE FROM faa_registry").run();
+    for (const r of rows) {
+      db.query(`
+        INSERT INTO faa_registry
+          (tail_number, mode_s_hex, serial, year_mfr, faa_status, registrant, faa_model,
+           expiration_date, dereg_date, last_refreshed)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        r.tail_number,
+        r.mode_s_hex,
+        r.serial,
+        r.year_mfr,
+        r.faa_status,
+        r.registrant,
+        r.faa_model,
+        r.expiration_date,
+        r.dereg_date,
+        now
+      );
+    }
+  })();
+}
+
+export function getFaaRegistryByTail(db: Database, tail: string): FaaRegistryRow | null {
+  return (
+    (db
+      .query("SELECT * FROM faa_registry WHERE tail_number = ?")
+      .get(tail) as FaaRegistryRow | null) ?? null
+  );
 }
 
 // One definition of "departure on a Starlink-equipped aircraft, next 48h":

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -209,6 +209,9 @@ export const GAUGES = {
   // Install-pipeline rollup from the fleet-progress sheets.
   // tags: segment (mainline_nb|mainline_wb|express), state (total|complete|in_mod|verification_needed), airline
   FLEET_PROGRESS_COUNT: "fleet_progress.count",
+
+  // FAA registry sync results. tags: state (resolved|not_in_master|starlink_flagged), airline
+  FAA_REGISTRY_TAILS: "faa_registry.tails",
 } as const;
 
 /**

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -37,6 +37,10 @@ export function buildFreshnessQueries(qrEnabled = AIRLINES.QR.enabled): Record<s
       SELECT airline, MAX(fetched_at) AS seg_ts
       FROM fleet_progress GROUP BY airline, segment
     ) GROUP BY airline`,
+    // faa_registry has no airline column (national registry); attribute to UA.
+    faa_registry: `
+    SELECT 'UA' AS airline, MAX(last_refreshed) AS ts
+    FROM faa_registry`,
   };
   // QR writes none of the airline-column tables — only qatar_schedule, whose
   // last_updated is touched solely on successful upserts. Without this gauge
@@ -63,6 +67,7 @@ export function buildFreshnessCoverage(
     verifier: ["UA", "HA", "AS"],
     departures: ["UA", "HA", "AS"],
     fleet_progress: ["UA"],
+    faa_registry: ["UA"],
   };
   if (qrEnabled) coverage.qatar_ingester = ["QR"];
   return coverage;
@@ -122,12 +127,12 @@ export function emitDataFreshness(db: Database, queries = FRESHNESS_QUERIES): vo
       for (const row of rows) {
         let ts = row.ts;
         if (ts == null) {
-          // GROUP BY queries skip airlines with no rows. The fixed-airline QR
-          // query instead returns a null MAX on an empty table — the maximally
-          // stale state must still emit: fall back to the meta stamp, else
-          // epoch 0 so the monitor definitely fires.
-          if (job !== "qatar_ingester") continue;
-          ts = metaLastUpdatedEpoch(db, row.airline) ?? 0;
+          // GROUP BY queries skip airlines with no rows. Fixed-airline queries
+          // return a null MAX on an empty table — the maximally stale state must
+          // still emit so the monitor can fire (epoch 0 / meta-stamp fallback).
+          if (job === "qatar_ingester") ts = metaLastUpdatedEpoch(db, row.airline) ?? 0;
+          else if (job === "faa_registry") ts = 0;
+          else continue;
         }
         const ageSec = Math.max(0, now - ts);
         metrics.gauge(GAUGES.DATA_FRESHNESS_SECONDS, ageSec, {

--- a/src/scripts/faa-registry.ts
+++ b/src/scripts/faa-registry.ts
@@ -1,0 +1,355 @@
+/**
+ * Daily FAA Releasable Aircraft Registry sync: canonical existence/deregistration
+ * status and Mode-S hex for every tracked tail. The three files are streamed out
+ * of the bulk zip with `unzip -p`, so the ~480 MB extract never lands in memory —
+ * only rows for tails we track are kept.
+ */
+
+import type { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { replaceFaaRegistry } from "../database/database";
+import { COUNTERS, GAUGES, metrics, normalizeAirlineTag, withSpan } from "../observability";
+import type { FaaRegistryRow } from "../types";
+import { BROWSER_USER_AGENT } from "../utils/constants";
+import { type JobHandle, startJob } from "../utils/job-runner";
+import { info, error as logError, warn } from "../utils/logger";
+
+const REGISTRY_ZIP_URL = "https://registry.faa.gov/database/ReleasableAircraft.zip";
+
+export type RegistryFile = "MASTER.txt" | "ACFTREF.txt" | "DEREG.txt";
+export type LineSource = (file: RegistryFile) => AsyncIterable<string> | Iterable<string>;
+
+export interface FaaSyncDeps {
+  loadLines?: LineSource;
+}
+
+export interface FaaSyncResult {
+  outcome: "success" | "error";
+  tracked: number;
+  resolved: number;
+  flagged: number;
+}
+
+// FAA N-NUMBER columns carry no leading N.
+const stripN = (tail: string) => tail.trim().toUpperCase().replace(/^N/, "");
+
+interface MasterRow {
+  serial: string;
+  mfrMdlCode: string;
+  yearMfr: string;
+  registrant: string;
+  statusCode: string;
+  modeSHex: string;
+  expirationDate: string;
+}
+
+function headerIndex(headerLine: string): Record<string, number> {
+  const idx: Record<string, number> = {};
+  headerLine
+    .replace(/^﻿/, "")
+    .split(",")
+    .forEach((name, i) => {
+      idx[name.trim()] = i;
+    });
+  return idx;
+}
+
+export async function collectMasterRows(
+  lines: AsyncIterable<string> | Iterable<string>,
+  wanted: ReadonlySet<string>
+): Promise<Map<string, MasterRow>> {
+  const out = new Map<string, MasterRow>();
+  let idx: Record<string, number> | null = null;
+  for await (const line of lines) {
+    if (!idx) {
+      idx = headerIndex(line);
+      continue;
+    }
+    const cols = line.split(",");
+    const n = (cols[idx["N-NUMBER"]] ?? "").trim();
+    if (!wanted.has(n)) continue;
+    out.set(n, {
+      serial: (cols[idx["SERIAL NUMBER"]] ?? "").trim(),
+      mfrMdlCode: (cols[idx["MFR MDL CODE"]] ?? "").trim(),
+      yearMfr: (cols[idx["YEAR MFR"]] ?? "").trim(),
+      registrant: (cols[idx.NAME] ?? "").trim(),
+      statusCode: (cols[idx["STATUS CODE"]] ?? "").trim(),
+      modeSHex: (cols[idx["MODE S CODE HEX"]] ?? "").trim(),
+      expirationDate: (cols[idx["EXPIRATION DATE"]] ?? "").trim(),
+    });
+  }
+  return out;
+}
+
+export async function collectAcftref(
+  lines: AsyncIterable<string> | Iterable<string>,
+  wantedCodes: ReadonlySet<string>
+): Promise<Map<string, string>> {
+  const out = new Map<string, string>();
+  let idx: Record<string, number> | null = null;
+  for await (const line of lines) {
+    if (!idx) {
+      idx = headerIndex(line);
+      continue;
+    }
+    const cols = line.split(",");
+    const code = (cols[idx.CODE] ?? "").trim();
+    if (!wantedCodes.has(code)) continue;
+    const mfr = (cols[idx.MFR] ?? "").trim();
+    const model = (cols[idx.MODEL] ?? "").trim();
+    out.set(code, `${mfr} ${model}`.trim());
+  }
+  return out;
+}
+
+export async function collectDereg(
+  lines: AsyncIterable<string> | Iterable<string>,
+  wanted: ReadonlySet<string>
+): Promise<Map<string, Array<{ serial: string; cancelDate: string }>>> {
+  const out = new Map<string, Array<{ serial: string; cancelDate: string }>>();
+  let idx: Record<string, number> | null = null;
+  for await (const line of lines) {
+    if (!idx) {
+      idx = headerIndex(line);
+      continue;
+    }
+    const cols = line.split(",");
+    const n = (cols[idx["N-NUMBER"]] ?? "").trim();
+    if (!wanted.has(n)) continue;
+    const records = out.get(n) ?? [];
+    records.push({
+      serial: (cols[idx["SERIAL-NUMBER"]] ?? "").trim(),
+      cancelDate: (cols[idx["CANCEL-DATE"]] ?? "").trim(),
+    });
+    out.set(n, records);
+  }
+  return out;
+}
+
+export interface FaaFlags {
+  missingFromMaster: string[];
+  /** Tails we mark as Starlink-equipped that the FAA says don't validly exist.
+   * Deliberately a log+gauge tripwire (expected ~0), not a mismatch-list entry. */
+  wrongYes: Array<{ tail: string; reason: string }>;
+}
+
+export function buildFaaRecords(opts: {
+  tails: readonly string[];
+  starlinkTails: ReadonlySet<string>;
+  master: ReadonlyMap<string, MasterRow>;
+  acftref: ReadonlyMap<string, string>;
+  dereg: ReadonlyMap<string, Array<{ serial: string; cancelDate: string }>>;
+}): { rows: Array<Omit<FaaRegistryRow, "last_refreshed">>; flags: FaaFlags } {
+  const rows: Array<Omit<FaaRegistryRow, "last_refreshed">> = [];
+  const flags: FaaFlags = { missingFromMaster: [], wrongYes: [] };
+
+  for (const tail of [...opts.tails].sort()) {
+    const n = stripN(tail);
+    const m = opts.master.get(n);
+    // Raw N-number dereg matches are dominated by historical N-number reuse —
+    // a record only counts when the tail is gone from MASTER or the serial matches.
+    const relevantDereg = (opts.dereg.get(n) ?? []).filter((d) => !m || d.serial === m.serial);
+    const deregDate =
+      relevantDereg
+        .map((d) => d.cancelDate)
+        .sort()
+        .at(-1) ?? null;
+
+    if (!m) flags.missingFromMaster.push(tail);
+    if (opts.starlinkTails.has(tail) && (!m || m.statusCode !== "V")) {
+      flags.wrongYes.push({
+        tail,
+        reason: m ? `FAA status ${m.statusCode}` : "not in FAA registry",
+      });
+    }
+
+    rows.push({
+      tail_number: tail,
+      mode_s_hex: m?.modeSHex || null,
+      serial: m?.serial || null,
+      year_mfr: m?.yearMfr || null,
+      faa_status: m ? m.statusCode || "?" : "NOT_IN_MASTER",
+      registrant: m?.registrant || null,
+      faa_model: (m && opts.acftref.get(m.mfrMdlCode)) || null,
+      expiration_date: m?.expirationDate || null,
+      dereg_date: deregDate,
+    });
+  }
+  return { rows, flags };
+}
+
+async function* spawnLines(cmd: string[]): AsyncGenerator<string> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "ignore" });
+  try {
+    const decoder = new TextDecoder();
+    let buf = "";
+    for await (const chunk of proc.stdout) {
+      buf += decoder.decode(chunk, { stream: true });
+      let nl = buf.indexOf("\n");
+      while (nl !== -1) {
+        yield buf.slice(0, nl).replace(/\r$/, "");
+        buf = buf.slice(nl + 1);
+        nl = buf.indexOf("\n");
+      }
+    }
+    if (buf.trim() !== "") yield buf;
+    const code = await proc.exited;
+    if (code !== 0) throw new Error(`${cmd.join(" ")} exited with ${code}`);
+  } finally {
+    // Covers consumers that stop iterating early — never leave unzip blocked
+    // on an undrained pipe.
+    proc.kill();
+    await proc.exited;
+  }
+}
+
+async function downloadRegistryZip(): Promise<{ dir: string; zipPath: string }> {
+  const dir = mkdtempSync(path.join(tmpdir(), "faa-registry-"));
+  const zipPath = path.join(dir, "ReleasableAircraft.zip");
+  // curl, not fetch: the FAA host needs a browser User-Agent (503s otherwise)
+  // and Bun's fetch stalls indefinitely streaming this particular 73 MB body.
+  const proc = Bun.spawn(
+    [
+      "curl",
+      "-sSL",
+      "--fail",
+      "--max-time",
+      "600",
+      "-A",
+      BROWSER_USER_AGENT,
+      "-o",
+      zipPath,
+      REGISTRY_ZIP_URL,
+    ],
+    { stdout: "ignore", stderr: "pipe" }
+  );
+  const code = await proc.exited;
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error(`registry download failed (curl exit ${code}): ${stderr.slice(0, 200)}`);
+  }
+  return { dir, zipPath };
+}
+
+function trackedTails(db: Database): { tails: string[]; starlinkTails: Set<string> } {
+  const fleet = db.query("SELECT tail_number, starlink_status FROM united_fleet").all() as Array<{
+    tail_number: string;
+    starlink_status: string | null;
+  }>;
+  const sheet = db.query("SELECT TailNumber, wifi FROM starlink_planes").all() as Array<{
+    TailNumber: string;
+    wifi: string | null;
+  }>;
+
+  const isUsReg = (t: string) => /^N/i.test(t);
+  const tails = new Set<string>();
+  const starlinkTails = new Set<string>();
+  for (const r of fleet) {
+    if (!isUsReg(r.tail_number)) continue;
+    tails.add(r.tail_number);
+    if (r.starlink_status === "confirmed") starlinkTails.add(r.tail_number);
+  }
+  for (const r of sheet) {
+    if (!isUsReg(r.TailNumber)) continue;
+    tails.add(r.TailNumber);
+    if (r.wifi === "Starlink" || r.wifi === "StrLnk") starlinkTails.add(r.TailNumber);
+  }
+  return { tails: [...tails], starlinkTails };
+}
+
+export async function runFaaRegistrySync(
+  db: Database,
+  deps: FaaSyncDeps = {}
+): Promise<FaaSyncResult> {
+  return withSpan(
+    "scraper.faa_registry",
+    async (span): Promise<FaaSyncResult> => {
+      span.setTag("job.type", "background");
+      let cleanup = () => {};
+      try {
+        let loadLines = deps.loadLines;
+        if (!loadLines) {
+          const { dir, zipPath } = await downloadRegistryZip();
+          cleanup = () => rmSync(dir, { recursive: true, force: true });
+          loadLines = (file) => spawnLines(["unzip", "-p", zipPath, file]);
+        }
+
+        const { tails, starlinkTails } = trackedTails(db);
+        const wanted = new Set(tails.map(stripN));
+        // ACFTREF needs MASTER's model codes; DEREG doesn't, so scan it concurrently.
+        const [master, dereg] = await Promise.all([
+          collectMasterRows(loadLines("MASTER.txt"), wanted),
+          collectDereg(loadLines("DEREG.txt"), wanted),
+        ]);
+        const acftref = await collectAcftref(
+          loadLines("ACFTREF.txt"),
+          new Set([...master.values()].map((m) => m.mfrMdlCode))
+        );
+
+        const { rows, flags } = buildFaaRecords({ tails, starlinkTails, master, acftref, dereg });
+        replaceFaaRegistry(db, rows);
+
+        const resolved = rows.filter((r) => r.faa_status !== "NOT_IN_MASTER").length;
+        metrics.gauge(GAUGES.FAA_REGISTRY_TAILS, resolved, {
+          state: "resolved",
+          airline: normalizeAirlineTag("UA"),
+        });
+        metrics.gauge(GAUGES.FAA_REGISTRY_TAILS, flags.missingFromMaster.length, {
+          state: "not_in_master",
+          airline: normalizeAirlineTag("UA"),
+        });
+        metrics.gauge(GAUGES.FAA_REGISTRY_TAILS, flags.wrongYes.length, {
+          state: "starlink_flagged",
+          airline: normalizeAirlineTag("UA"),
+        });
+        metrics.increment(COUNTERS.SCRAPER_SYNC, {
+          source: "faa_registry",
+          airline: normalizeAirlineTag("UA"),
+          status: "success",
+        });
+
+        for (const f of flags.wrongYes) {
+          warn(`faa-registry: ${f.tail} is marked Starlink but ${f.reason}`);
+        }
+        span.setTag("resolved", resolved);
+        span.setTag("flagged", flags.wrongYes.length);
+        info(
+          `faa-registry sync: ${resolved}/${rows.length} tails resolved, ` +
+            `${flags.missingFromMaster.length} not in registry, ${flags.wrongYes.length} starlink-flagged`
+        );
+        return {
+          outcome: "success",
+          tracked: rows.length,
+          resolved,
+          flagged: flags.wrongYes.length,
+        };
+      } catch (err) {
+        logError("faa-registry sync failed", err);
+        metrics.increment(COUNTERS.SCRAPER_SYNC, {
+          source: "faa_registry",
+          airline: normalizeAirlineTag("UA"),
+          status: "error",
+        });
+        span.setTag("error", true);
+        return { outcome: "error", tracked: 0, resolved: 0, flagged: 0 };
+      } finally {
+        cleanup();
+      }
+    },
+    { "job.type": "background" }
+  );
+}
+
+export function startFaaRegistryJob(db: Database): JobHandle {
+  return startJob({
+    name: "faa_registry",
+    intervalMs: 24 * 3600 * 1000,
+    initialDelayMs: 20 * 60 * 1000,
+    run: async () => {
+      await runFaaRegistrySync(db);
+    },
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,21 @@ export interface FleetProgressRow {
   fetched_at: number;
 }
 
+/** One tracked tail's slice of the FAA Releasable Aircraft Registry. */
+export interface FaaRegistryRow {
+  tail_number: string;
+  mode_s_hex: string | null;
+  serial: string | null;
+  year_mfr: string | null;
+  /** MASTER status code ("V" = valid) or "NOT_IN_MASTER". */
+  faa_status: string;
+  registrant: string | null;
+  faa_model: string | null;
+  expiration_date: string | null;
+  dereg_date: string | null;
+  last_refreshed: number;
+}
+
 export interface RouteScheduleRow {
   origin: string;
   destination: string;

--- a/tests/faa-registry.test.ts
+++ b/tests/faa-registry.test.ts
@@ -1,0 +1,130 @@
+// Pins the FAA registry parsing/flagging rules: serial-filtered dereg matches,
+// NOT_IN_MASTER handling, and the wrong-yes flag for Starlink-marked tails.
+
+import { describe, expect, test } from "bun:test";
+import { getFaaRegistryByTail, replaceFaaRegistry } from "../src/database/database";
+import {
+  buildFaaRecords,
+  collectAcftref,
+  collectDereg,
+  collectMasterRows,
+  runFaaRegistrySync,
+} from "../src/scripts/faa-registry";
+import { makeSyntheticDb } from "./helpers";
+
+const MASTER_LINES = [
+  "N-NUMBER,SERIAL NUMBER,MFR MDL CODE,ENG MFR MDL,YEAR MFR,TYPE REGISTRANT,NAME,STREET,STREET2,CITY,STATE,ZIP CODE,REGION,COUNTY,COUNTRY,LAST ACTION DATE,CERT ISSUE DATE,CERTIFICATION,TYPE AIRCRAFT,TYPE ENGINE,STATUS CODE,MODE S CODE,FRACT OWNER,AIR WORTH DATE,OTHER NAMES(1),OTHER NAMES(2),OTHER NAMES(3),OTHER NAMES(4),OTHER NAMES(5),EXPIRATION DATE,UNIQUE ID,KIT MFR, KIT MODEL,MODE S CODE HEX",
+  "73275,30581,1387815,30030,2001,3,UNITED AIRLINES INC,233 S WACKER DR,,CHICAGO,IL,60606,3,031,US,20240105,20011019,,5,5,V,52624414,,20011102,,,,,,20310131,01089105,,,A98D0C",
+  "868AS,7474,3160009,52021,2001,3,SKYWEST AIRLINES INC,444 S RIVER RD,,ST GEORGE,UT,84790,4,053,US,20231002,20011207,,5,5,9,52764363,,20011219,,,,,,20261231,00569204,,,ABC123",
+  "99999,1234,9999999,11111,1990,1,SOMEONE ELSE,1 MAIN ST,,AUSTIN,TX,78701,2,453,US,20200101,19900101,,4,1,V,50000001,,19900201,,,,,,20270101,00000001,,,A00001",
+].join("\n");
+
+const ACFTREF_LINES = [
+  "CODE,MFR,MODEL,TYPE-ACFT,TYPE-ENG,AC-CAT,BUILD-CERT-IND,NO-ENG,NO-SEATS,AC-WEIGHT,SPEED,TC-DATA-SHEET,TC-DATA-HOLDER",
+  "1387815,BOEING,737-824,5,5,1,0,2,166,CLASS 3,0,A16WE,THE BOEING COMPANY",
+  "3160009,BOMBARDIER INC,CL-600-2B19,5,5,1,0,2,50,CLASS 3,0,A21EA,BOMBARDIER INC",
+].join("\n");
+
+const DEREG_LINES = [
+  "N-NUMBER,SERIAL-NUMBER,MFR MDL CODE,STATUS-CODE,NAME,STREET-MAIL,STREET2-MAIL,CITY-MAIL,STATE-ABBREV-MAIL,ZIP-CODE-MAIL,ENG MFR MDL,YEAR MFR,CERTIFICATION,REGION,COUNTY-MAIL,COUNTRY-MAIL,AIR-WORTH-DATE,CANCEL-DATE,MODE-S-CODE,INDICATOR-GROUP,EXP-COUNTRY,LAST-ACT-DATE,CERT-ISSUE-DATE,STREET-PHYSICAL,STREET2-PHYSICAL,CITY-PHYSICAL,STATE-ABBREV-PHYSICAL,ZIP-CODE-PHYSICAL,COUNTY-PHYSICAL,COUNTRY-PHYSICAL,OTHER-NAMES(1),OTHER-NAMES(2),OTHER-NAMES(3),OTHER-NAMES(4),OTHER-NAMES(5)",
+  // Historical N-number reuse on a different airframe — must be ignored
+  "73275,OLD-CESSNA-1,2072702,A,OLD OWNER,1 RD,,TULSA,OK,74100,,1965,,2,143,US,,19890301,,,,19890301,19650101,,,,,,,,,,,,",
+  // Same airframe (serial matches) — must be flagged
+  "868AS,7474,3160009,A,SKYWEST AIRLINES INC,444 S RIVER RD,,ST GEORGE,UT,84790,,2001,,4,053,US,,20231002,,,,20231002,20011207,,,,,,,,,,,,",
+  // Tail not in MASTER at all — dereg counts
+  "652BR,7429,3160009,A,SKYWEST AIRLINES INC,444 S RIVER RD,,ST GEORGE,UT,84790,,2001,,4,053,US,,20231103,,,,20231103,20011207,,,,,,,,,,,,",
+].join("\n");
+
+async function fixtures() {
+  const wanted = new Set(["73275", "868AS", "652BR", "7943SK"]);
+  const master = await collectMasterRows(MASTER_LINES.split("\n"), wanted);
+  const acftref = await collectAcftref(
+    ACFTREF_LINES.split("\n"),
+    new Set([...master.values()].map((m) => m.mfrMdlCode))
+  );
+  const dereg = await collectDereg(DEREG_LINES.split("\n"), wanted);
+  return { master, acftref, dereg };
+}
+
+describe("FAA registry parsing", () => {
+  test("collects only wanted tails and resolves model names via ACFTREF", async () => {
+    const { master, acftref } = await fixtures();
+    expect([...master.keys()].sort()).toEqual(["73275", "868AS"]);
+    expect(acftref.get("1387815")).toBe("BOEING 737-824");
+  });
+
+  test("buildFaaRecords applies serial-filtered dereg and flags Starlink-marked problem tails", async () => {
+    const { master, acftref, dereg } = await fixtures();
+    const { rows, flags } = buildFaaRecords({
+      tails: ["N73275", "N868AS", "N652BR", "N7943SK"],
+      starlinkTails: new Set(["N73275", "N7943SK", "N868AS"]),
+      master,
+      acftref,
+      dereg,
+    });
+
+    const byTail = new Map(rows.map((r) => [r.tail_number, r]));
+    // Valid registration with a historical-reuse dereg record: no dereg date.
+    expect(byTail.get("N73275")).toMatchObject({
+      faa_status: "V",
+      mode_s_hex: "A98D0C",
+      faa_model: "BOEING 737-824",
+      dereg_date: null,
+    });
+    // Same-airframe dereg (serial match) carries the cancel date.
+    expect(byTail.get("N868AS")?.dereg_date).toBe("20231002");
+    // Tail absent from MASTER entirely.
+    expect(byTail.get("N7943SK")?.faa_status).toBe("NOT_IN_MASTER");
+    expect(byTail.get("N652BR")?.dereg_date).toBe("20231103");
+
+    expect(flags.missingFromMaster.sort()).toEqual(["N652BR", "N7943SK"]);
+    // Starlink-marked tails that aren't validly registered: the fabricated tail
+    // and the deregistered one; the valid N73275 must NOT be flagged.
+    expect(flags.wrongYes.map((f) => f.tail).sort()).toEqual(["N7943SK", "N868AS"]);
+  });
+});
+
+describe("faa_registry storage and sync", () => {
+  test("runFaaRegistrySync writes rows for tracked tails using injected line sources", async () => {
+    const db = makeSyntheticDb();
+    db.query(
+      "INSERT INTO united_fleet (tail_number, fleet, starlink_status, first_seen_source, first_seen_at, last_seen_at, airline) VALUES ('N73275', 'mainline', 'confirmed', 'test', 1, 1, 'UA')"
+    ).run();
+    db.query(
+      "INSERT INTO starlink_planes (aircraft, wifi, sheet_gid, sheet_type, DateFound, TailNumber, OperatedBy, fleet, airline) VALUES ('Boeing 737-824', 'Starlink', '4', '', '2026-06-04', 'N73275', 'United Airlines', 'mainline', 'UA')"
+    ).run();
+
+    const loadLines = (file: string) =>
+      (file === "MASTER.txt"
+        ? MASTER_LINES
+        : file === "ACFTREF.txt"
+          ? ACFTREF_LINES
+          : DEREG_LINES
+      ).split("\n");
+    const result = await runFaaRegistrySync(db, { loadLines });
+    expect(result).toMatchObject({ outcome: "success", tracked: 1, resolved: 1, flagged: 0 });
+
+    const row = getFaaRegistryByTail(db, "N73275");
+    expect(row).toMatchObject({ faa_status: "V", mode_s_hex: "A98D0C" });
+    expect(row?.last_refreshed).toBeGreaterThan(0);
+  });
+
+  test("replaceFaaRegistry fully replaces the previous pull", () => {
+    const db = makeSyntheticDb();
+    const bareRow = (tail_number: string) => ({
+      tail_number,
+      mode_s_hex: null,
+      serial: null,
+      year_mfr: null,
+      faa_status: "V",
+      registrant: null,
+      faa_model: null,
+      expiration_date: null,
+      dereg_date: null,
+    });
+    replaceFaaRegistry(db, [bareRow("N1")]);
+    replaceFaaRegistry(db, [bareRow("N2")]);
+    expect(getFaaRegistryByTail(db, "N1")).toBeNull();
+    expect(getFaaRegistryByTail(db, "N2")).not.toBeNull();
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -7,6 +7,7 @@
 import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { setupTables } from "../src/database/database";
 import type { predictFlight } from "../src/scripts/starlink-predictor";
 
 // Snapshot lives inside the checkout (gitignored) so parallel worktrees never
@@ -39,6 +40,9 @@ export function makeSyntheticDb(): Database {
   snapshotDdl ??= loadSnapshotDdl();
   const db = new Database(":memory:");
   for (const sql of snapshotDdl) db.exec(sql);
+  // Tables added since the snapshot was generated (setupTables is idempotent),
+  // so a stale .test-snapshot.sqlite doesn't fail write-path tests.
+  setupTables(db);
   return db;
 }
 

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -609,6 +609,11 @@ describe("data-freshness coverage", () => {
           "INSERT INTO fleet_progress (airline, segment, type_code, total, starlink_complete, fetched_at) VALUES (?, 'mainline_nb', 'Totals', 878, 67, ?)"
         ).run(airline, ts);
         break;
+      case "faa_registry":
+        db.query(
+          "INSERT INTO faa_registry (tail_number, faa_status, last_refreshed) VALUES ('N73275', 'V', ?)"
+        ).run(ts);
+        break;
       default:
         throw new Error(`no seeder for freshness job ${job} — add one with the query`);
     }


### PR DESCRIPTION
The FAA Releasable Aircraft Registry is the canonical answer to "does this tail exist, is it deregistered, and what is its Mode-S hex" — it would have auto-flagged the fabricated N7943SK and the two retired CRJ-200s without any united.com scraping, and the hex column unlocks ADS-B sources keyed by hex (next integration). This adds a daily sync of the registry slice for every tracked tail.

Stacked on #52 (retarget to main once that merges).

- daily `faa_registry` job downloads the FAA bulk zip with curl and streams MASTER/ACFTREF/DEREG through `unzip -p`, keeping only tracked tails (~480 MB extract never lands in memory); curl + unzip added to the image
- new `faa_registry` table (full replace per run): status, Mode-S hex, serial, year, registrant, model, serial-filtered dereg date
- any Starlink-marked tail that isn't validly registered is warn-logged and gauged (`faa_registry.tails`, state=starlink_flagged) — a tripwire, expected to stay at zero
- freshness anchor included, and an empty table now emits a maximally-stale gauge so a never-succeeding sync still pages
- synthetic test DBs now run `setupTables`, so a stale `.test-snapshot.sqlite` no longer fails tests that touch newly added tables

Verified with a live end-to-end run against a fresh prod snapshot: 2,012 of 2,016 tracked tails resolved with hex, the 4 known-bad tails flagged NOT_IN_MASTER (two with dereg dates), zero Starlink-marked tails invalid.