### PR TITLE
Show officially reported fleet and Starlink figures from SEC filings

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -11,6 +11,7 @@ import { startFleetDiscovery } from "./src/scripts/fleet-discovery";
 import { startFleetProgressJob } from "./src/scripts/fleet-progress";
 import { startFleetSync } from "./src/scripts/fleet-sync";
 import { startQatarScheduleIngester } from "./src/scripts/qatar-schedule-ingester";
+import { startSecAnchorsJob } from "./src/scripts/sec-anchors";
 import { runSheetScrape } from "./src/scripts/sheet-scrape";
 import { startStarlinkVerifier } from "./src/scripts/starlink-verifier";
 import { syncShipNumbers } from "./src/scripts/sync-ship-numbers";
@@ -112,6 +113,10 @@ if (JOBS_ENABLED) {
 
   // Daily FAA registry slice: existence/dereg hygiene + Mode-S hex per tail.
   track(startFaaRegistryJob(db));
+
+  // Daily SEC filings watcher: keeps the officially-reported anchors seeded and
+  // flags new UAL/SkyWest/Republic filings for review.
+  track(startSecAnchorsJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/components/fleet-page.tsx
+++ b/src/components/fleet-page.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AIRLINES, type SiteConfig } from "../airlines/registry";
 import type {
+  FleetAnchorRow,
   FleetFamily,
   FleetPageData,
   FleetProgressRow,
@@ -577,6 +578,45 @@ function InstallPipelineSection({ progress }: { progress: FleetProgressRow[] }) 
   );
 }
 
+// The handful of figures the airline itself has put in SEC filings — the
+// citable cross-check next to our scraped counts.
+function OfficialAnchorsSection({ anchors }: { anchors: FleetAnchorRow[] }) {
+  // Latest figure per metric (rows arrive ordered by as_of_date DESC), so a
+  // freshly seeded quarter replaces the old one without touching this list.
+  const latestByMetric = new Map<string, FleetAnchorRow>();
+  for (const a of anchors) {
+    if (!latestByMetric.has(a.metric)) latestByMetric.set(a.metric, a);
+  }
+  const shown = [...latestByMetric.values()].slice(0, 6);
+  if (shown.length === 0) return null;
+
+  return (
+    <section className={SECTION}>
+      <div className={PANEL}>
+        <div className={EYEBROW}>Officially reported (SEC filings)</div>
+        <div className="font-mono text-[11px] text-secondary space-y-1">
+          {shown.map((a) => (
+            <div key={a.metric}>
+              {a.scope}:{" "}
+              <a
+                href={a.source_url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent hover:underline"
+              >
+                {a.value}
+              </a>{" "}
+              <span className="text-muted">
+                ({a.source_form}, as of {a.as_of_date})
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 interface FleetPageProps {
   data: FleetPageData;
   site: SiteConfig;
@@ -660,6 +700,7 @@ export default function FleetPage({ data, site }: FleetPageProps) {
       <LivePulse pulse={data.pulse} />
       <InstallPaceSection pace={data.installPace} />
       <InstallPipelineSection progress={data.progress} />
+      <OfficialAnchorsSection anchors={data.anchors} />
       <HangarFloor
         families={data.families}
         totalFleet={data.totalFleet}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -25,6 +25,7 @@ import type {
   BodyClass,
   FaaRegistryRow,
   FleetAircraft,
+  FleetAnchorRow,
   FleetCarrier,
   FleetDiscoveryStats,
   FleetFamily,
@@ -39,6 +40,7 @@ import type {
   RecentInstall,
   RouteSchedule,
   RouteScheduleRow,
+  SecFilingRow,
   StarlinkStatus,
   WifiProvider,
 } from "../types";
@@ -322,6 +324,38 @@ export function setupTables(db: Database) {
         sheet_updated TEXT,
         fetched_at INTEGER NOT NULL,
         UNIQUE(airline, segment, type_code)
+      );
+    `).run();
+  }
+
+  // Officially-reported fleet/Starlink figures from SEC filings, plus the
+  // watcher's record of which filings have already been seen.
+  if (!tableExists(db, "fleet_anchors")) {
+    db.query(`
+      CREATE TABLE fleet_anchors (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        airline TEXT NOT NULL,
+        as_of_date TEXT NOT NULL,
+        scope TEXT NOT NULL,
+        metric TEXT NOT NULL,
+        value TEXT NOT NULL,
+        source_form TEXT NOT NULL,
+        source_url TEXT NOT NULL,
+        added_at INTEGER NOT NULL,
+        UNIQUE(airline, metric, as_of_date)
+      );
+    `).run();
+  }
+  if (!tableExists(db, "sec_filings_seen")) {
+    db.query(`
+      CREATE TABLE sec_filings_seen (
+        accession TEXT PRIMARY KEY,
+        cik TEXT NOT NULL,
+        company TEXT NOT NULL,
+        form TEXT NOT NULL,
+        filed_date TEXT NOT NULL,
+        primary_doc_url TEXT NOT NULL,
+        seen_at INTEGER NOT NULL
       );
     `).run();
   }
@@ -3108,6 +3142,60 @@ export function replaceFaaRegistry(
   })();
 }
 
+/** Upsert anchors keyed by (airline, metric, as-of date) — editing SEED_ANCHORS
+ * and redeploying is the whole correction story, no manual SQL. */
+export function seedFleetAnchors(
+  db: Database,
+  rows: Array<Omit<FleetAnchorRow, "added_at">>
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.transaction(() => {
+    for (const r of rows) {
+      db.query(`
+        INSERT INTO fleet_anchors
+          (airline, as_of_date, scope, metric, value, source_form, source_url, added_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(airline, metric, as_of_date) DO UPDATE SET
+          scope = excluded.scope,
+          value = excluded.value,
+          source_form = excluded.source_form,
+          source_url = excluded.source_url
+      `).run(r.airline, r.as_of_date, r.scope, r.metric, r.value, r.source_form, r.source_url, now);
+    }
+  })();
+}
+
+export function getFleetAnchors(db: Database, airline?: AirlineFilter): FleetAnchorRow[] {
+  const q = withAirline(
+    `SELECT airline, as_of_date, scope, metric, value, source_form, source_url, added_at
+     FROM fleet_anchors WHERE 1=1`,
+    airline
+  );
+  return db.query(`${q.sql} ORDER BY as_of_date DESC, metric`).all(...q.params) as FleetAnchorRow[];
+}
+
+/** Record filings not seen before; returns only the newly inserted ones. */
+export function recordSecFilings(
+  db: Database,
+  filings: Array<Omit<SecFilingRow, "seen_at">>
+): Array<Omit<SecFilingRow, "seen_at">> {
+  const now = Math.floor(Date.now() / 1000);
+  const fresh: Array<Omit<SecFilingRow, "seen_at">> = [];
+  db.transaction(() => {
+    for (const f of filings) {
+      const result = db
+        .query(`
+          INSERT OR IGNORE INTO sec_filings_seen
+            (accession, cik, company, form, filed_date, primary_doc_url, seen_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+        `)
+        .run(f.accession, f.cik, f.company, f.form, f.filed_date, f.primary_doc_url, now);
+      if (result.changes > 0) fresh.push(f);
+    }
+  })();
+  return fresh;
+}
+
 export function getFaaRegistryByTail(db: Database, tail: string): FaaRegistryRow | null {
   return (
     (db
@@ -3374,6 +3462,7 @@ function computeFleetPageData(db: Database, airline?: AirlineFilter): FleetPageD
     // Single-airline narrative like installPace — the hub page must not show
     // one airline's pipeline as if it covered every tracked fleet.
     progress: soleAirline ? getFleetProgress(db, airline) : [],
+    anchors: soleAirline ? getFleetAnchors(db, airline) : [],
   };
 }
 

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -151,6 +151,9 @@ export const COUNTERS = {
   // tags: method, route (allowlisted), status_code, tenant, client_class
   HTTP_REQUEST: "http.request",
 
+  // A new SEC filing surfaced for anchor review — tags: company, form, airline
+  SEC_FILING_SEEN: "sec.filing_seen",
+
   // Per-IP rate limit triggered on /api/* — tags: route, tenant
   HTTP_RATE_LIMITED: "http.rate_limited",
 

--- a/src/scripts/sec-anchors.ts
+++ b/src/scripts/sec-anchors.ts
@@ -1,0 +1,212 @@
+/**
+ * Daily SEC EDGAR watcher: keeps the officially-reported fleet/Starlink anchors
+ * (10-K fleet tables, earnings 8-K Starlink counts) seeded for display, and
+ * flags newly filed 10-K/10-Q/8-Ks from UAL, SkyWest, and Republic so the
+ * handful of numbers they contain can be reviewed and added each quarter.
+ * Anchor extraction is deliberately manual — the figures change at most
+ * quarterly and live in prose/tables that don't parse robustly. To add a new
+ * figure, append it to SEED_ANCHORS below.
+ */
+
+import type { Database } from "bun:sqlite";
+import { getFleetAnchors, recordSecFilings, seedFleetAnchors } from "../database/database";
+import { COUNTERS, metrics, normalizeAirlineTag, withSpan } from "../observability";
+import type { FleetAnchorRow, SecFilingRow } from "../types";
+import { type JobHandle, startJob } from "../utils/job-runner";
+import { info, error as logError } from "../utils/logger";
+
+// SEC fair-access policy requires "company-name contact-email" — other formats get 403.
+const SEC_USER_AGENT = "ua-starlink-tracker admin@unitedstarlinktracker.com";
+
+const SEC_COMPANIES = [
+  { cik: "0000100517", company: "United Airlines Holdings", tag: "united_airlines_holdings" },
+  { cik: "0000793733", company: "SkyWest", tag: "skywest" },
+  { cik: "0000810332", company: "Republic Airways", tag: "republic_airways" },
+] as const;
+
+const WATCHED_FORMS = new Set(["10-K", "10-Q", "8-K"]);
+// Only earnings 8-Ks (Item 2.02) carry fleet/Starlink figures; the rest are
+// financings/governance noise that would train reviewers to ignore the alert.
+const EARNINGS_8K_ITEM = "2.02";
+const WATCH_WINDOW_DAYS = 450;
+
+// Verified against the filings on 2026-06-13.
+export const SEED_ANCHORS: Array<Omit<FleetAnchorRow, "added_at">> = [
+  {
+    airline: "UA",
+    as_of_date: "2025-12-31",
+    scope: "Mainline fleet in service",
+    metric: "mainline_fleet_total",
+    value: "1066",
+    source_form: "UAL 10-K FY2025",
+    source_url:
+      "https://www.sec.gov/Archives/edgar/data/100517/000010051726000023/ual-20251231.htm",
+  },
+  {
+    airline: "UA",
+    as_of_date: "2025-12-31",
+    scope: "Regional fleet in service",
+    metric: "regional_fleet_total",
+    value: "424",
+    source_form: "UAL 10-K FY2025",
+    source_url:
+      "https://www.sec.gov/Archives/edgar/data/100517/000010051726000023/ual-20251231.htm",
+  },
+  {
+    airline: "UA",
+    as_of_date: "2026-03-31",
+    scope: "Starlink installed, dual-class United Express",
+    metric: "starlink_installed_dual_class_uax",
+    value: "327",
+    source_form: "UAL Q1 2026 earnings 8-K",
+    source_url:
+      "https://www.sec.gov/Archives/edgar/data/100517/000010051726000089/ual_erx03312026xex991.htm",
+  },
+  {
+    airline: "UA",
+    as_of_date: "2026-03-31",
+    scope: "SkyWest aircraft under United Express agreements",
+    metric: "skywest_united_express_total",
+    value: "226",
+    source_form: "SkyWest Q1 2026 10-Q",
+    source_url:
+      "https://www.sec.gov/Archives/edgar/data/793733/000110465926048542/skyw-20260331x10q.htm",
+  },
+  {
+    airline: "UA",
+    as_of_date: "2025-12-31",
+    scope: "Republic aircraft operated for United",
+    metric: "republic_united_total",
+    value: "126",
+    source_form: "Republic 10-K FY2025",
+    source_url:
+      "https://www.sec.gov/Archives/edgar/data/810332/000162828026019614/rjet-20251231.htm",
+  },
+];
+
+interface SubmissionsJson {
+  filings?: {
+    recent?: {
+      accessionNumber?: string[];
+      form?: string[];
+      filingDate?: string[];
+      primaryDocument?: string[];
+      items?: string[];
+    };
+  };
+}
+
+/** Pull the watched forms out of a data.sec.gov submissions document. */
+export function extractRecentFilings(
+  cik: string,
+  company: string,
+  submissions: SubmissionsJson,
+  nowMs: number
+): Array<Omit<SecFilingRow, "seen_at">> {
+  const recent = submissions.filings?.recent;
+  if (!recent?.accessionNumber) return [];
+  const cutoff = nowMs - WATCH_WINDOW_DAYS * 86400 * 1000;
+  const out: Array<Omit<SecFilingRow, "seen_at">> = [];
+  for (let i = 0; i < recent.accessionNumber.length; i++) {
+    const form = recent.form?.[i] ?? "";
+    if (!WATCHED_FORMS.has(form)) continue;
+    if (form === "8-K" && !(recent.items?.[i] ?? "").includes(EARNINGS_8K_ITEM)) continue;
+    const filedDate = recent.filingDate?.[i] ?? "";
+    if (!filedDate || Date.parse(filedDate) < cutoff) continue;
+    const accession = recent.accessionNumber[i];
+    const doc = recent.primaryDocument?.[i] ?? "";
+    out.push({
+      accession,
+      cik,
+      company,
+      form,
+      filed_date: filedDate,
+      primary_doc_url: `https://www.sec.gov/Archives/edgar/data/${Number(cik)}/${accession.replace(/-/g, "")}/${doc}`,
+    });
+  }
+  return out;
+}
+
+export interface SecAnchorsSyncResult {
+  outcome: "success" | "partial" | "error";
+  newFilings: number;
+  anchors: number;
+}
+
+export async function runSecAnchorsSync(
+  db: Database,
+  fetcher: typeof fetch = fetch
+): Promise<SecAnchorsSyncResult> {
+  return withSpan(
+    "scraper.sec_anchors",
+    async (span): Promise<SecAnchorsSyncResult> => {
+      span.setTag("job.type", "background");
+      const airlineTag = normalizeAirlineTag("UA");
+      seedFleetAnchors(db, SEED_ANCHORS);
+
+      let newFilings = 0;
+      let failed = 0;
+      for (const { cik, company, tag } of SEC_COMPANIES) {
+        try {
+          // A company's first successful run records its whole back-catalog —
+          // only per-filing log/alert once that company has a baseline.
+          const hasBaseline =
+            (
+              db.query("SELECT COUNT(*) AS n FROM sec_filings_seen WHERE cik = ?").get(cik) as {
+                n: number;
+              }
+            ).n > 0;
+          const res = await fetcher(`https://data.sec.gov/submissions/CIK${cik}.json`, {
+            headers: { "User-Agent": SEC_USER_AGENT, Accept: "application/json" },
+          });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          const filings = extractRecentFilings(cik, company, await res.json(), Date.now());
+          const fresh = recordSecFilings(db, filings);
+          newFilings += fresh.length;
+          if (!hasBaseline) continue;
+          for (const f of fresh) {
+            info(
+              `sec-anchors: new ${company} ${f.form} filed ${f.filed_date} — review for updated fleet/Starlink anchors (append to SEED_ANCHORS): ${f.primary_doc_url}`
+            );
+            metrics.increment(COUNTERS.SEC_FILING_SEEN, {
+              company: tag,
+              form: f.form.toLowerCase(),
+              airline: airlineTag,
+            });
+          }
+        } catch (err) {
+          failed++;
+          logError(`sec-anchors: ${company} submissions fetch failed`, err);
+        }
+      }
+
+      const outcome: SecAnchorsSyncResult["outcome"] =
+        failed === SEC_COMPANIES.length ? "error" : failed > 0 ? "partial" : "success";
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "sec_anchors",
+        airline: airlineTag,
+        status: outcome,
+      });
+      span.setTag("result", outcome);
+      span.setTag("new_filings", newFilings);
+
+      const anchors = getFleetAnchors(db, "UA").length;
+      if (newFilings > 0 || outcome !== "success") {
+        info(`sec-anchors sync ${outcome}: ${newFilings} new filings, ${anchors} anchors stored`);
+      }
+      return { outcome, newFilings, anchors };
+    },
+    { "job.type": "background" }
+  );
+}
+
+export function startSecAnchorsJob(db: Database): JobHandle {
+  return startJob({
+    name: "sec_anchors",
+    intervalMs: 24 * 3600 * 1000,
+    initialDelayMs: 30 * 60 * 1000,
+    run: async () => {
+      await runSecAnchorsSync(db);
+    },
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,8 @@ export interface FleetPageData {
   installPace: InstallPace | null;
   /** Per-type install pipeline rows (empty until the fleet-progress job has run). */
   progress: FleetProgressRow[];
+  /** Officially-reported fleet/Starlink figures (single-airline pages only). */
+  anchors: FleetAnchorRow[];
 }
 
 /** One per-type row of the install pipeline (United Fleet Site progress workbooks). */
@@ -188,6 +190,29 @@ export interface FleetProgressRow {
   verification_needed: number | null;
   sheet_updated: string | null;
   fetched_at: number;
+}
+
+/** An officially-reported fleet/Starlink figure from an SEC filing. */
+export interface FleetAnchorRow {
+  airline: string;
+  as_of_date: string;
+  scope: string;
+  metric: string;
+  value: string;
+  source_form: string;
+  source_url: string;
+  added_at: number;
+}
+
+/** A filing the SEC watcher has already surfaced for review. */
+export interface SecFilingRow {
+  accession: string;
+  cik: string;
+  company: string;
+  form: string;
+  filed_date: string;
+  primary_doc_url: string;
+  seen_at: number;
 }
 
 /** One tracked tail's slice of the FAA Releasable Aircraft Registry. */

--- a/tests/sec-anchors.test.ts
+++ b/tests/sec-anchors.test.ts
@@ -1,0 +1,89 @@
+// Pins the SEC submissions parsing, the seed/record idempotency, and that the
+// watcher only surfaces filings it hasn't seen before.
+
+import { describe, expect, test } from "bun:test";
+import { getFleetAnchors, recordSecFilings } from "../src/database/database";
+import { SEED_ANCHORS, extractRecentFilings, runSecAnchorsSync } from "../src/scripts/sec-anchors";
+import { makeSyntheticDb } from "./helpers";
+
+const NOW = Date.parse("2026-06-14");
+
+const SUBMISSIONS_FIXTURE = {
+  filings: {
+    recent: {
+      accessionNumber: [
+        "0000100517-26-000089",
+        "0000100517-26-000050",
+        "0000100517-26-000023",
+        "0000100517-20-000001",
+      ],
+      form: ["8-K", "8-K", "10-K", "10-K"],
+      filingDate: ["2026-04-21", "2026-03-10", "2026-02-26", "2020-02-26"],
+      primaryDocument: [
+        "ual_erx03312026xex991.htm",
+        "financing.htm",
+        "ual-20251231.htm",
+        "old.htm",
+      ],
+      // Earnings 8-K (Item 2.02) vs a financing 8-K that must be ignored.
+      items: ["2.02,9.01", "8.01,9.01", "", ""],
+    },
+  },
+};
+
+describe("extractRecentFilings", () => {
+  test("keeps watched forms inside the window and builds archive URLs", () => {
+    const filings = extractRecentFilings(
+      "0000100517",
+      "United Airlines Holdings",
+      SUBMISSIONS_FIXTURE,
+      NOW
+    );
+    expect(filings.map((f) => f.accession)).toEqual([
+      "0000100517-26-000089",
+      "0000100517-26-000023",
+    ]);
+    expect(filings[0].primary_doc_url).toBe(
+      "https://www.sec.gov/Archives/edgar/data/100517/000010051726000089/ual_erx03312026xex991.htm"
+    );
+  });
+
+  test("returns nothing for malformed submissions documents", () => {
+    expect(extractRecentFilings("0000100517", "UAL", {}, NOW)).toEqual([]);
+  });
+});
+
+describe("sec anchors storage and sync", () => {
+  test("recordSecFilings returns only filings not seen before", () => {
+    const db = makeSyntheticDb();
+    const filings = extractRecentFilings("0000100517", "UAL", SUBMISSIONS_FIXTURE, NOW);
+    expect(recordSecFilings(db, filings).length).toBe(2);
+    expect(recordSecFilings(db, filings).length).toBe(0);
+  });
+
+  test("runSecAnchorsSync seeds anchors, records filings, and is idempotent", async () => {
+    const db = makeSyntheticDb();
+    const fetcher = (async () =>
+      new Response(JSON.stringify(SUBMISSIONS_FIXTURE), { status: 200 })) as typeof fetch;
+
+    const first = await runSecAnchorsSync(db, fetcher);
+    expect(first.outcome).toBe("success");
+    expect(first.newFilings).toBeGreaterThan(0);
+    expect(first.anchors).toBe(SEED_ANCHORS.length);
+    expect(getFleetAnchors(db, "UA").some((a) => a.metric === "mainline_fleet_total")).toBe(true);
+    expect(getFleetAnchors(db, "HA")).toEqual([]);
+
+    const second = await runSecAnchorsSync(db, fetcher);
+    expect(second.newFilings).toBe(0);
+    expect(second.anchors).toBe(SEED_ANCHORS.length);
+  });
+
+  test("reports error when every submissions fetch fails", async () => {
+    const db = makeSyntheticDb();
+    const fetcher = (async () => new Response("denied", { status: 403 })) as typeof fetch;
+    const result = await runSecAnchorsSync(db, fetcher);
+    expect(result.outcome).toBe("error");
+    // Anchors are still seeded — they don't depend on the network.
+    expect(result.anchors).toBe(SEED_ANCHORS.length);
+  });
+});


### PR DESCRIPTION
Our scraped counts have no citable cross-check, and the figures United, SkyWest, and Republic put in SEC filings are the strongest possible anchors (10-K fleet tables, earnings 8-K Starlink counts). This stores those anchors, shows them on /fleet, and watches EDGAR daily so the handful of new numbers each quarter get reviewed.

Stacked on #53 (retarget once it merges).

- `fleet_anchors` seeded from verified citations (mainline 1,066 / regional 424 in service, 327 dual-class UAX Starlink installs, SkyWest 226, Republic 126), upserted so correcting a value is just an edit + deploy
- "Officially reported (SEC filings)" panel on /fleet with source links; single-airline pages only
- daily watcher polls data.sec.gov submissions for UAL/SkyWest/Republic and logs new 10-K/10-Q/earnings-8-K filings for manual anchor review (anchor extraction stays manual — the figures change at most quarterly and live in prose)
- per-company first-run baseline so deploy day doesn't flood the log with the back-catalog; `sec.filing_seen` counter + `scraper.sync` status for monitoring
- SEC fair-access User-Agent format verified (other formats get 403)

Verified live: 5 anchors seeded, 36 filings baselined across the three companies, idempotent re-runs, panel rendering on the UA tenant and hidden on the hub.