### PR TITLE
Shadow-track flight assignments with ADS-B and log deltas

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -4,6 +4,7 @@ import "dotenv/config";
 
 import { checkNewPlanes, startFlightUpdater } from "./src/api/flight-updater";
 import { archivePastDepartures, initializeDatabase, pruneCrashRows } from "./src/database/database";
+import { startAdsbSweepJob } from "./src/scripts/adsb-sweep";
 import { startAlaskaVerifier } from "./src/scripts/alaska-verifier";
 import { startFreshnessEmitter } from "./src/scripts/data-freshness";
 import { startFaaRegistryJob } from "./src/scripts/faa-registry";
@@ -117,6 +118,10 @@ if (JOBS_ENABLED) {
   // Daily SEC filings watcher: keeps the officially-reported anchors seeded and
   // flags new UAL/SkyWest/Republic filings for review.
   track(startSecAnchorsJob(db));
+
+  // ADS-B shadow sweep: compares live callsigns against FR24-derived
+  // assignments, metrics-only — FR24 stays the serving source.
+  track(startAdsbSweepJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -20,6 +20,8 @@ import {
   normalizeWifiProvider,
 } from "../observability/metrics";
 import type {
+  AdsbObservationRecord,
+  AdsbSweepRecord,
   Aircraft,
   AirportDepartures,
   BodyClass,
@@ -377,6 +379,49 @@ export function setupTables(db: Database) {
         last_refreshed INTEGER NOT NULL
       );
     `).run();
+  }
+
+  // ADS-B shadow sweep audit trail: one aggregate row per sweep plus the
+  // per-aircraft observations it classified against upcoming_flights.
+  if (!tableExists(db, "adsb_sweeps")) {
+    db.exec(`
+      CREATE TABLE adsb_sweeps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        swept_at INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        requests INTEGER NOT NULL,
+        latency_ms INTEGER NOT NULL,
+        tails_queried INTEGER NOT NULL,
+        observed INTEGER NOT NULL,
+        airborne INTEGER NOT NULL,
+        matched INTEGER NOT NULL,
+        mismatched INTEGER NOT NULL,
+        no_assignment INTEGER NOT NULL,
+        no_callsign INTEGER NOT NULL
+      );
+      CREATE INDEX idx_adsb_sweeps_at ON adsb_sweeps(swept_at);
+    `);
+  }
+  if (!tableExists(db, "adsb_observations")) {
+    db.exec(`
+      CREATE TABLE adsb_observations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        observed_at INTEGER NOT NULL,
+        tail_number TEXT NOT NULL,
+        callsign TEXT,
+        hex TEXT,
+        airborne INTEGER NOT NULL,
+        ground_speed REAL,
+        lat REAL,
+        lon REAL,
+        aircraft_type TEXT,
+        provider TEXT NOT NULL,
+        shadow_result TEXT,
+        assigned_flight TEXT
+      );
+      CREATE INDEX idx_adsb_obs_tail ON adsb_observations(tail_number, observed_at);
+      CREATE INDEX idx_adsb_obs_at ON adsb_observations(observed_at);
+    `);
   }
 
   if (tableExists(db, "starlink_planes")) {
@@ -3202,6 +3247,62 @@ export function getFaaRegistryByTail(db: Database, tail: string): FaaRegistryRow
       .query("SELECT * FROM faa_registry WHERE tail_number = ?")
       .get(tail) as FaaRegistryRow | null) ?? null
   );
+}
+
+const ADSB_OBSERVATION_RETENTION_DAYS = 7;
+const ADSB_SWEEP_RETENTION_DAYS = 90;
+
+/** Persist one shadow sweep + its observations and prune old audit rows. */
+export function recordAdsbSweep(
+  db: Database,
+  sweep: AdsbSweepRecord,
+  observations: Array<Omit<AdsbObservationRecord, "id">>
+): void {
+  const obsCutoff = sweep.swept_at - ADSB_OBSERVATION_RETENTION_DAYS * 86400;
+  const sweepCutoff = sweep.swept_at - ADSB_SWEEP_RETENTION_DAYS * 86400;
+  db.transaction(() => {
+    db.query(`
+      INSERT INTO adsb_sweeps
+        (swept_at, provider, requests, latency_ms, tails_queried, observed, airborne,
+         matched, mismatched, no_assignment, no_callsign)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      sweep.swept_at,
+      sweep.provider,
+      sweep.requests,
+      sweep.latency_ms,
+      sweep.tails_queried,
+      sweep.observed,
+      sweep.airborne,
+      sweep.matched,
+      sweep.mismatched,
+      sweep.no_assignment,
+      sweep.no_callsign
+    );
+    for (const o of observations) {
+      db.query(`
+        INSERT INTO adsb_observations
+          (observed_at, tail_number, callsign, hex, airborne, ground_speed, lat, lon,
+           aircraft_type, provider, shadow_result, assigned_flight)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        o.observed_at,
+        o.tail_number,
+        o.callsign,
+        o.hex,
+        o.airborne,
+        o.ground_speed,
+        o.lat,
+        o.lon,
+        o.aircraft_type,
+        o.provider,
+        o.shadow_result,
+        o.assigned_flight
+      );
+    }
+    db.query("DELETE FROM adsb_observations WHERE observed_at < ?").run(obsCutoff);
+    db.query("DELETE FROM adsb_sweeps WHERE swept_at < ?").run(sweepCutoff);
+  })();
 }
 
 // One definition of "departure on a Starlink-equipped aircraft, next 48h":

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -17,7 +17,7 @@
  *   aircraft_type:   normalized families (B737-800, E175, etc)      (~25)
  *   wifi_provider:   starlink | viasat | panasonic | thales | none | other | unknown  (7)
  *   starlink_status: confirmed | negative | unknown                  (3)
- *   vendor:          fr24 | flightaware | united | qatar | alaska    (5)
+ *   vendor:          fr24 | flightaware | united | qatar | alaska | adsb    (6)
  *   status:          success | error | rate_limited | timeout | killed |
  *                    exit_error | parse_error | spawn_error | partial |
  *                    aborted | scrape_error                          (~11)
@@ -141,9 +141,9 @@ export const COUNTERS = {
   VERIFICATION_CHECK: "verification.check",
 
   // External API calls
-  // tags: vendor (fr24|flightaware|united|qatar|alaska), type, status
+  // tags: vendor (fr24|flightaware|united|qatar|alaska|adsb), type, status
   // united status values: success | timeout | killed | exit_error | parse_error | spawn_error
-  // fr24/flightaware status values: success | error | rate_limited
+  // fr24/flightaware/adsb status values: success | error | rate_limited
   // qatar status values: success | error | partial
   VENDOR_REQUEST: "vendor.request",
 
@@ -215,6 +215,10 @@ export const GAUGES = {
 
   // FAA registry sync results. tags: state (resolved|not_in_master|starlink_flagged), airline
   FAA_REGISTRY_TAILS: "faa_registry.tails",
+
+  // ADS-B shadow sweep vs upcoming_flights assignments.
+  // tags: result (match|mismatch|no_assignment|no_callsign|airborne_total), airline
+  ADSB_SHADOW_OBSERVATIONS: "adsb_shadow.observations",
 } as const;
 
 /**

--- a/src/scripts/adsb-sweep.ts
+++ b/src/scripts/adsb-sweep.ts
@@ -1,0 +1,368 @@
+/**
+ * ADS-B shadow sweep: every few minutes, ask the community ADS-B aggregators
+ * which Starlink-equipped tails are airborne and what callsign they're flying,
+ * then compare against the FR24-derived upcoming_flights assignments. Shadow
+ * only — nothing here feeds the serving path; the point is delta metrics in
+ * Datadog (and rows in adsb_observations) so we can audit agreement before
+ * ever leaning on this source.
+ */
+
+import type { Database } from "bun:sqlite";
+import { looksLikeValidTailNumber } from "../airlines/registry";
+import { getAllStarlinkPlanes, recordAdsbSweep } from "../database/database";
+import {
+  COUNTERS,
+  DISTRIBUTIONS,
+  GAUGES,
+  metrics,
+  normalizeAirlineTag,
+  withSpan,
+} from "../observability";
+import type { AdsbObservationRecord } from "../types";
+import { BROWSER_USER_AGENT } from "../utils/constants";
+import { type JobHandle, createOutageBreaker, startJob } from "../utils/job-runner";
+import { info, error as logError, warn } from "../utils/logger";
+
+interface AdsbProvider {
+  name: string;
+  buildUrl: (regs: string[]) => string;
+  /** Measured: airplanes.live takes the whole fleet in one URL; the others 414 past ~100 regs. */
+  maxRegsPerRequest: number;
+}
+
+const PROVIDERS: AdsbProvider[] = [
+  {
+    name: "airplanes.live",
+    buildUrl: (regs) => `https://api.airplanes.live/v2/reg/${regs.join(",")}`,
+    maxRegsPerRequest: 500,
+  },
+  {
+    name: "adsb.lol",
+    buildUrl: (regs) => `https://api.adsb.lol/v2/reg/${regs.join(",")}`,
+    maxRegsPerRequest: 100,
+  },
+  {
+    name: "adsb.fi",
+    buildUrl: (regs) => `https://opendata.adsb.fi/api/v2/registration/${regs.join(",")}`,
+    maxRegsPerRequest: 100,
+  },
+];
+
+const PROVIDER_RATE_GAP_MS = 1100;
+
+export interface AdsbAircraft {
+  tail: string;
+  hex: string | null;
+  callsign: string | null;
+  airborne: boolean;
+  gs: number | null;
+  lat: number | null;
+  lon: number | null;
+  aircraftType: string | null;
+}
+
+export interface AdsbSweepStats {
+  provider: string;
+  requests: number;
+  latencyMs: number;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function queryProvider(
+  provider: AdsbProvider,
+  tails: string[],
+  fetcher: typeof fetch
+): Promise<{ aircraft: AdsbAircraft[]; requests: number }> {
+  const aircraft: AdsbAircraft[] = [];
+  let requests = 0;
+  for (let i = 0; i < tails.length; i += provider.maxRegsPerRequest) {
+    if (i > 0) await sleep(PROVIDER_RATE_GAP_MS);
+    const chunk = tails.slice(i, i + provider.maxRegsPerRequest);
+    const res = await fetcher(provider.buildUrl(chunk), {
+      headers: { "User-Agent": BROWSER_USER_AGENT, Accept: "application/json" },
+    });
+    requests++;
+    if (!res.ok) throw new Error(`${provider.name} HTTP ${res.status}`);
+    const json = (await res.json()) as { ac?: any[] };
+    for (const ac of json.ac ?? []) {
+      const tail = typeof ac.r === "string" ? ac.r.trim().toUpperCase() : "";
+      if (!tail) continue;
+      aircraft.push({
+        tail,
+        hex: ac.hex ?? null,
+        callsign: typeof ac.flight === "string" && ac.flight.trim() ? ac.flight.trim() : null,
+        // alt_geom fallback: MLAT/degraded targets can be airborne without alt_baro.
+        airborne: ac.alt_baro === "ground" ? false : ac.alt_baro != null || ac.alt_geom != null,
+        gs: typeof ac.gs === "number" ? ac.gs : null,
+        lat: typeof ac.lat === "number" ? ac.lat : null,
+        lon: typeof ac.lon === "number" ? ac.lon : null,
+        aircraftType: typeof ac.t === "string" ? ac.t : null,
+      });
+    }
+  }
+  return { aircraft, requests };
+}
+
+/** One full sweep with provider failover. */
+export async function sweepAdsbProviders(
+  tails: string[],
+  fetcher: typeof fetch = fetch
+): Promise<{ aircraft: AdsbAircraft[]; stats: AdsbSweepStats }> {
+  let lastErr: unknown = null;
+  for (const provider of PROVIDERS) {
+    const started = Date.now();
+    try {
+      const { aircraft, requests } = await queryProvider(provider, tails, fetcher);
+      return {
+        aircraft,
+        stats: { provider: provider.name, requests, latencyMs: Date.now() - started },
+      };
+    } catch (err) {
+      lastErr = err;
+      warn(`adsb-sweep: ${provider.name} failed, trying next provider`, err);
+    }
+  }
+  throw new Error(`all ADS-B providers failed: ${lastErr}`);
+}
+
+// Callsign ICAO prefix → how upcoming_flights codes that operator's rows. The
+// pairing matters: SKW#### must never match a marketing UA#### that shares the number.
+const OPERATOR_DB_PREFIXES: Record<string, string[]> = {
+  UAL: ["UAL", "UA"],
+  SKW: ["SKW", "OO"],
+  GJS: ["GJS", "G7"],
+  RPA: ["RPA", "YX"],
+  ASH: ["ASH", "YV"],
+  UCA: ["UCA", "C5"],
+  AWI: ["AWI", "ZW"],
+};
+const UA_CALLSIGN_RE = new RegExp(`^(${Object.keys(OPERATOR_DB_PREFIXES).join("|")})(\\d+)$`);
+
+export function deriveCallsignFlight(
+  callsign: string | null
+): { prefix: string; num: number } | null {
+  const m = callsign?.match(UA_CALLSIGN_RE);
+  return m ? { prefix: m[1], num: Number(m[2]) } : null;
+}
+
+export function callsignMatchesAssignment(
+  callsign: string | null,
+  assignedFlight: string
+): boolean {
+  const derived = deriveCallsignFlight(callsign);
+  if (!derived) return false;
+  const assigned = assignedFlight.toUpperCase();
+  // Prefix-by-prefix instead of a letters/digits regex split: IATA codes with a
+  // digit (G7, C5) would otherwise be unsplittable from the flight number.
+  return (OPERATOR_DB_PREFIXES[derived.prefix] ?? []).some((prefix) => {
+    if (!assigned.startsWith(prefix)) return false;
+    const rest = assigned.slice(prefix.length);
+    return /^\d+$/.test(rest) && Number(rest) === derived.num;
+  });
+}
+
+export type ShadowResult = "match" | "mismatch" | "no_assignment" | "no_callsign";
+
+export function classifyObservation(
+  aircraft: AdsbAircraft,
+  assignedFlights: string[]
+): { result: ShadowResult; assignedFlight: string | null } {
+  if (!aircraft.callsign || !deriveCallsignFlight(aircraft.callsign)) {
+    return { result: "no_callsign", assignedFlight: assignedFlights[0] ?? null };
+  }
+  if (assignedFlights.length === 0) {
+    return { result: "no_assignment", assignedFlight: null };
+  }
+  const hit = assignedFlights.find((f) => callsignMatchesAssignment(aircraft.callsign, f));
+  return hit
+    ? { result: "match", assignedFlight: hit }
+    : { result: "mismatch", assignedFlight: assignedFlights[0] };
+}
+
+// A flight covers the observation if it's in progress (departed but not yet
+// arrived, with grace) or departs soon — long sectors must stay matchable.
+const ASSIGNMENT_LOOKAHEAD_SEC = 4 * 3600;
+const ASSIGNMENT_ARRIVAL_GRACE_SEC = 3600;
+
+export interface AdsbShadowResult {
+  outcome: "success" | "error";
+  observed: number;
+  airborne: number;
+  counts: Record<ShadowResult, number>;
+}
+
+export async function runAdsbSweepShadow(
+  db: Database,
+  fetcher: typeof fetch = fetch
+): Promise<AdsbShadowResult> {
+  return withSpan(
+    "scraper.adsb_sweep",
+    async (span): Promise<AdsbShadowResult> => {
+      span.setTag("job.type", "background");
+      const airlineTag = normalizeAirlineTag("UA");
+      const counts: Record<ShadowResult, number> = {
+        match: 0,
+        mismatch: 0,
+        no_assignment: 0,
+        no_callsign: 0,
+      };
+      const tails = getAllStarlinkPlanes(db, "UA")
+        .map((p) => p.TailNumber)
+        .filter((t) => looksLikeValidTailNumber(t));
+      if (tails.length === 0) {
+        return { outcome: "success", observed: 0, airborne: 0, counts };
+      }
+
+      // The vendor call gets its own try/catch so a later DB failure can't be
+      // double-counted as a vendor error.
+      let swept: Awaited<ReturnType<typeof sweepAdsbProviders>>;
+      try {
+        swept = await sweepAdsbProviders(tails, fetcher);
+      } catch (err) {
+        logError("adsb-shadow sweep failed", err);
+        metrics.increment(COUNTERS.VENDOR_REQUEST, {
+          vendor: "adsb",
+          type: "sweep",
+          status: "error",
+          airline: airlineTag,
+        });
+        span.setTag("error", true);
+        return { outcome: "error", observed: 0, airborne: 0, counts };
+      }
+
+      try {
+        const { aircraft, stats } = swept;
+        metrics.increment(COUNTERS.VENDOR_REQUEST, {
+          vendor: "adsb",
+          type: "sweep",
+          status: "success",
+          airline: airlineTag,
+        });
+        metrics.distribution(DISTRIBUTIONS.VENDOR_DURATION_MS, stats.latencyMs, {
+          vendor: "adsb",
+          type: "sweep",
+          status: "success",
+          airline: airlineTag,
+        });
+
+        const now = Math.floor(Date.now() / 1000);
+        // One window query for the whole sweep, keyed by tail (closest departure first).
+        const assignmentsByTail = new Map<string, string[]>();
+        const assignmentRows = db
+          .query(
+            `SELECT tail_number, flight_number FROM upcoming_flights
+             WHERE departure_time <= ? AND arrival_time >= ?
+             ORDER BY ABS(departure_time - ?) ASC`
+          )
+          .all(now + ASSIGNMENT_LOOKAHEAD_SEC, now - ASSIGNMENT_ARRIVAL_GRACE_SEC, now) as Array<{
+          tail_number: string;
+          flight_number: string;
+        }>;
+        for (const row of assignmentRows) {
+          const list = assignmentsByTail.get(row.tail_number) ?? [];
+          list.push(row.flight_number);
+          assignmentsByTail.set(row.tail_number, list);
+        }
+
+        const observations: Array<Omit<AdsbObservationRecord, "id">> = [];
+        for (const ac of aircraft) {
+          // Only airborne aircraft are comparable to a flight assignment.
+          let result: ShadowResult | null = null;
+          let assignedFlight: string | null = null;
+          if (ac.airborne) {
+            const assigned = assignmentsByTail.get(ac.tail) ?? [];
+            const classified = classifyObservation(ac, assigned);
+            result = classified.result;
+            assignedFlight = classified.assignedFlight;
+            counts[result]++;
+            if (result === "mismatch") {
+              warn(
+                `adsb-shadow: ${ac.tail} flying ${ac.callsign} but upcoming_flights says ${assignedFlight}`
+              );
+            }
+          }
+          observations.push({
+            observed_at: now,
+            tail_number: ac.tail,
+            callsign: ac.callsign,
+            hex: ac.hex,
+            airborne: ac.airborne ? 1 : 0,
+            ground_speed: ac.gs,
+            lat: ac.lat,
+            lon: ac.lon,
+            aircraft_type: ac.aircraftType,
+            provider: stats.provider,
+            shadow_result: result,
+            assigned_flight: assignedFlight,
+          });
+        }
+
+        const airborne = aircraft.filter((a) => a.airborne).length;
+        recordAdsbSweep(
+          db,
+          {
+            swept_at: now,
+            provider: stats.provider,
+            requests: stats.requests,
+            latency_ms: stats.latencyMs,
+            tails_queried: tails.length,
+            observed: aircraft.length,
+            airborne,
+            matched: counts.match,
+            mismatched: counts.mismatch,
+            no_assignment: counts.no_assignment,
+            no_callsign: counts.no_callsign,
+          },
+          observations
+        );
+
+        for (const [result, value] of Object.entries(counts)) {
+          metrics.gauge(GAUGES.ADSB_SHADOW_OBSERVATIONS, value, { result, airline: airlineTag });
+        }
+        metrics.gauge(GAUGES.ADSB_SHADOW_OBSERVATIONS, airborne, {
+          result: "airborne_total",
+          airline: airlineTag,
+        });
+
+        span.setTag("observed", aircraft.length);
+        span.setTag("airborne", airborne);
+        span.setTag("mismatches", counts.mismatch);
+        if (airborne > 0) {
+          info(
+            `adsb-shadow sweep: ${airborne} airborne of ${aircraft.length} seen — ` +
+              `${counts.match} match, ${counts.mismatch} mismatch, ${counts.no_assignment} no assignment`
+          );
+        }
+        return { outcome: "success", observed: aircraft.length, airborne, counts };
+      } catch (err) {
+        // Classification/DB-side failure — the vendor call already succeeded.
+        logError("adsb-shadow classification/write failed", err);
+        span.setTag("error", true);
+        return { outcome: "error", observed: swept.aircraft.length, airborne: 0, counts };
+      }
+    },
+    { "job.type": "background" }
+  );
+}
+
+// Pause for 30 minutes after three consecutive failures so a provider outage
+// doesn't get hammered every 5 minutes.
+const ADSB_OUTAGE_FAILURES = 3;
+const ADSB_OUTAGE_SKIP_TICKS = 6;
+
+export function startAdsbSweepJob(db: Database): JobHandle {
+  const breaker = createOutageBreaker(ADSB_OUTAGE_FAILURES, ADSB_OUTAGE_SKIP_TICKS);
+  return startJob({
+    name: "adsb_sweep",
+    intervalMs: 5 * 60 * 1000,
+    initialDelayMs: 2 * 60 * 1000,
+    run: async () => {
+      if (breaker.shouldSkip()) return;
+      const result = await runAdsbSweepShadow(db);
+      if (breaker.record(result.outcome === "error" ? "failure" : "success")) {
+        warn("adsb-sweep: repeated failures — pausing sweeps for 30 minutes");
+      }
+    },
+  });
+}

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -41,6 +41,9 @@ export function buildFreshnessQueries(qrEnabled = AIRLINES.QR.enabled): Record<s
     faa_registry: `
     SELECT 'UA' AS airline, MAX(last_refreshed) AS ts
     FROM faa_registry`,
+    adsb_sweep: `
+    SELECT 'UA' AS airline, MAX(swept_at) AS ts
+    FROM adsb_sweeps`,
   };
   // QR writes none of the airline-column tables — only qatar_schedule, whose
   // last_updated is touched solely on successful upserts. Without this gauge
@@ -68,6 +71,7 @@ export function buildFreshnessCoverage(
     departures: ["UA", "HA", "AS"],
     fleet_progress: ["UA"],
     faa_registry: ["UA"],
+    adsb_sweep: ["UA"],
   };
   if (qrEnabled) coverage.qatar_ingester = ["QR"];
   return coverage;
@@ -131,7 +135,7 @@ export function emitDataFreshness(db: Database, queries = FRESHNESS_QUERIES): vo
           // return a null MAX on an empty table — the maximally stale state must
           // still emit so the monitor can fire (epoch 0 / meta-stamp fallback).
           if (job === "qatar_ingester") ts = metaLastUpdatedEpoch(db, row.airline) ?? 0;
-          else if (job === "faa_registry") ts = 0;
+          else if (job === "faa_registry" || job === "adsb_sweep") ts = 0;
           else continue;
         }
         const ageSec = Math.max(0, now - ts);

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,39 @@ export interface SecFilingRow {
   seen_at: number;
 }
 
+/** One ADS-B shadow sweep (aggregate row; observations carry the per-aircraft detail). */
+export interface AdsbSweepRecord {
+  swept_at: number;
+  provider: string;
+  requests: number;
+  latency_ms: number;
+  tails_queried: number;
+  observed: number;
+  airborne: number;
+  matched: number;
+  mismatched: number;
+  no_assignment: number;
+  no_callsign: number;
+}
+
+/** One aircraft seen during an ADS-B shadow sweep. */
+export interface AdsbObservationRecord {
+  id?: number;
+  observed_at: number;
+  tail_number: string;
+  callsign: string | null;
+  hex: string | null;
+  airborne: number;
+  ground_speed: number | null;
+  lat: number | null;
+  lon: number | null;
+  aircraft_type: string | null;
+  provider: string;
+  /** match | mismatch | no_assignment | no_callsign; null for on-ground observations. */
+  shadow_result: string | null;
+  assigned_flight: string | null;
+}
+
 /** One tracked tail's slice of the FAA Releasable Aircraft Registry. */
 export interface FaaRegistryRow {
   tail_number: string;

--- a/tests/adsb-sweep.test.ts
+++ b/tests/adsb-sweep.test.ts
@@ -1,0 +1,127 @@
+// Pins the callsign↔assignment matching rules and the shadow sweep's write path.
+// Shadow only: nothing here may touch the serving tables.
+
+import { describe, expect, test } from "bun:test";
+import {
+  callsignMatchesAssignment,
+  classifyObservation,
+  deriveCallsignFlight,
+  runAdsbSweepShadow,
+} from "../src/scripts/adsb-sweep";
+import { addFlight, addPlane, makeSyntheticDb } from "./helpers";
+
+describe("callsign matching", () => {
+  test.each([
+    ["UAL1710", "UA1710", true],
+    ["UAL1710", "UAL1710", true],
+    ["SKW5753", "SKW5753", true],
+    ["SKW5753", "OO5753", true],
+    ["GJS4520", "G74520", true],
+    ["RPA3640", "YX3640", true],
+    ["UAL1710", "UA1711", false],
+    ["SKW5753", "UA5753", false],
+    ["DAL123", "UA123", false],
+  ])("%s vs assigned %s -> %p", (callsign, assigned, expected) => {
+    expect(callsignMatchesAssignment(callsign, assigned)).toBe(expected);
+  });
+
+  test("deriveCallsignFlight ignores non-UA-network callsigns", () => {
+    expect(deriveCallsignFlight("DAL123")).toBeNull();
+    expect(deriveCallsignFlight(null)).toBeNull();
+    expect(deriveCallsignFlight("UAL204")).toEqual({ prefix: "UAL", num: 204 });
+  });
+});
+
+describe("classifyObservation", () => {
+  const aircraft = (callsign: string | null) => ({
+    tail: "N73275",
+    hex: "a98d0c",
+    callsign,
+    airborne: true,
+    gs: 450,
+    lat: 40,
+    lon: -100,
+    aircraftType: "B738",
+  });
+
+  test("classifies match, mismatch, no_assignment, and no_callsign", () => {
+    expect(classifyObservation(aircraft("UAL1326"), ["UAL1326"]).result).toBe("match");
+    expect(classifyObservation(aircraft("UAL1326"), ["UAL2436"]).result).toBe("mismatch");
+    expect(classifyObservation(aircraft("UAL1326"), []).result).toBe("no_assignment");
+    expect(classifyObservation(aircraft(null), ["UAL1326"]).result).toBe("no_callsign");
+  });
+});
+
+describe("runAdsbSweepShadow", () => {
+  function seedDb() {
+    const db = makeSyntheticDb();
+    const now = Math.floor(Date.now() / 1000);
+    addPlane(db, "N73275", "Starlink", { aircraft: "Boeing 737-824" });
+    addPlane(db, "N106SY", "Starlink", { aircraft: "E175" });
+    // One in-progress long sector (departed 5h ago, lands in 1h) and one about to depart.
+    addFlight(db, "N73275", "UAL1326", "AUS", now - 5 * 3600, { arrivalAirport: "IAH" });
+    db.query("UPDATE upcoming_flights SET arrival_time = ? WHERE tail_number = 'N73275'").run(
+      now + 3600
+    );
+    addFlight(db, "N106SY", "SKW6027", "SFO", now + 900, { arrivalAirport: "SLC" });
+    return db;
+  }
+
+  const providerResponse = JSON.stringify({
+    ac: [
+      {
+        r: "N73275",
+        hex: "a98d0c",
+        flight: "UAL1326 ",
+        alt_baro: 35000,
+        gs: 450,
+        lat: 30,
+        lon: -97,
+        t: "B738",
+      },
+      {
+        r: "N106SY",
+        hex: "abc123",
+        flight: "SKW9999",
+        alt_baro: 20000,
+        gs: 380,
+        lat: 37,
+        lon: -121,
+        t: "E75L",
+      },
+    ],
+  });
+
+  test("records observations, classifies against assignments, and prunes nothing fresh", async () => {
+    const db = seedDb();
+    const fetcher = (async () => new Response(providerResponse, { status: 200 })) as typeof fetch;
+    const result = await runAdsbSweepShadow(db, fetcher);
+    expect(result.outcome).toBe("success");
+    expect(result.airborne).toBe(2);
+    expect(result.counts.match).toBe(1);
+    expect(result.counts.mismatch).toBe(1);
+
+    const sweeps = db.query("SELECT * FROM adsb_sweeps").all() as Array<Record<string, unknown>>;
+    expect(sweeps.length).toBe(1);
+    expect(sweeps[0].matched).toBe(1);
+    expect(sweeps[0].mismatched).toBe(1);
+
+    const obs = db
+      .query(
+        "SELECT tail_number, shadow_result, assigned_flight FROM adsb_observations ORDER BY tail_number"
+      )
+      .all() as Array<{ tail_number: string; shadow_result: string; assigned_flight: string }>;
+    expect(obs.length).toBe(2);
+    expect(obs.find((o) => o.tail_number === "N73275")?.shadow_result).toBe("match");
+    expect(obs.find((o) => o.tail_number === "N106SY")?.shadow_result).toBe("mismatch");
+    expect(obs.find((o) => o.tail_number === "N106SY")?.assigned_flight).toBe("SKW6027");
+  });
+
+  test("reports error without writing when every provider fails", async () => {
+    const db = seedDb();
+    const fetcher = (async () => new Response("nope", { status: 500 })) as typeof fetch;
+    const result = await runAdsbSweepShadow(db, fetcher);
+    expect(result.outcome).toBe("error");
+    expect(db.query("SELECT COUNT(*) AS n FROM adsb_sweeps").get()).toEqual({ n: 0 });
+  });
+});

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -614,6 +614,11 @@ describe("data-freshness coverage", () => {
           "INSERT INTO faa_registry (tail_number, faa_status, last_refreshed) VALUES ('N73275', 'V', ?)"
         ).run(ts);
         break;
+      case "adsb_sweep":
+        db.query(
+          "INSERT INTO adsb_sweeps (swept_at, provider, requests, latency_ms, tails_queried, observed, airborne, matched, mismatched, no_assignment, no_callsign) VALUES (?, 'airplanes.live', 1, 250, 425, 40, 36, 11, 0, 25, 0)"
+        ).run(ts);
+        break;
       default:
         throw new Error(`no seeder for freshness job ${job} — add one with the query`);
     }


### PR DESCRIPTION
Before we ever lean on ADS-B (or retire FR24), we need measured agreement data. This adds a shadow sweep that observes which Starlink tails are actually airborne and what callsign they're flying, compares that against the FR24-derived assignment, and records the deltas — in Datadog for monitoring and in the DB for auditing. Nothing in the serving path changes.

- every 5 minutes, one batched airplanes.live request (adsb.lol / adsb.fi failover, outage breaker after repeated failures) covers all Starlink tails
- each airborne aircraft is classified against `upcoming_flights` as match / mismatch / no_assignment / no_callsign, using operator-coded callsign pairing (SKW↔OO etc.) and an in-progress-or-departing-soon window so long sectors stay matchable
- audit trail in `adsb_sweeps` (per-sweep stats, 90-day retention) and `adsb_observations` (per-aircraft rows incl. position, 7-day retention); mismatches are also warn-logged
- Datadog: `adsb_shadow.observations{result}` gauges per sweep, `vendor.request{vendor:adsb}` health, and a freshness anchor that reads maximally stale if the job never succeeds
- a live run saw 153 airborne Starlink tails in one ~600 ms request

Once a few weeks of agreement data is in, we can decide whether ADS-B becomes a fallback or primary for tail-to-flight assignment — that decision is explicitly out of scope here.