### PR TITLE
Add BTS monthly shadow ingest with fleet delta metrics

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -6,6 +6,7 @@ import { checkNewPlanes, startFlightUpdater } from "./src/api/flight-updater";
 import { archivePastDepartures, initializeDatabase, pruneCrashRows } from "./src/database/database";
 import { startAdsbSweepJob } from "./src/scripts/adsb-sweep";
 import { startAlaskaVerifier } from "./src/scripts/alaska-verifier";
+import { startBtsSyncJob } from "./src/scripts/bts-sync";
 import { startFreshnessEmitter } from "./src/scripts/data-freshness";
 import { startFaaRegistryJob } from "./src/scripts/faa-registry";
 import { startFleetDiscovery } from "./src/scripts/fleet-discovery";
@@ -122,6 +123,9 @@ if (JOBS_ENABLED) {
   // ADS-B shadow sweep: compares live callsigns against FR24-derived
   // assignments, metrics-only — FR24 stays the serving source.
   track(startAdsbSweepJob(db));
+
+  // BTS FGK monthly shadow ingest (daily check; ingests when a new month posts).
+  track(startBtsSyncJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -25,6 +25,7 @@ import type {
   Aircraft,
   AirportDepartures,
   BodyClass,
+  BtsMonthAggregates,
   FaaRegistryRow,
   FleetAircraft,
   FleetAnchorRow,
@@ -379,6 +380,37 @@ export function setupTables(db: Database) {
         last_refreshed INTEGER NOT NULL
       );
     `).run();
+  }
+
+  // BTS FGK monthly shadow aggregates (per-operator, per-tail, per-route).
+  if (!tableExists(db, "bts_monthly_operators")) {
+    db.exec(`
+      CREATE TABLE bts_monthly_operators (
+        month TEXT NOT NULL,
+        op_carrier TEXT NOT NULL,
+        flights INTEGER NOT NULL,
+        performed INTEGER NOT NULL,
+        distinct_tails INTEGER NOT NULL,
+        ingested_at INTEGER NOT NULL,
+        UNIQUE(month, op_carrier)
+      );
+      CREATE TABLE bts_monthly_tails (
+        month TEXT NOT NULL,
+        tail_number TEXT NOT NULL,
+        op_carrier TEXT NOT NULL,
+        departures INTEGER NOT NULL,
+        UNIQUE(month, tail_number)
+      );
+      CREATE TABLE bts_monthly_routes (
+        month TEXT NOT NULL,
+        origin TEXT NOT NULL,
+        dest TEXT NOT NULL,
+        performed INTEGER NOT NULL,
+        UNIQUE(month, origin, dest)
+      );
+      CREATE INDEX idx_bts_tails_month ON bts_monthly_tails(month);
+      CREATE INDEX idx_bts_routes_month ON bts_monthly_routes(month);
+    `);
   }
 
   // ADS-B shadow sweep audit trail: one aggregate row per sweep plus the
@@ -3083,7 +3115,7 @@ function normalizeCarrier(op: string | null): string | null {
   return null;
 }
 
-function bodyClassOf(family: string): BodyClass {
+export function bodyClassOf(family: string): BodyClass {
   if (/^(B767|B777|B787|A350)/.test(family)) return "widebody";
   if (/^(B737|B757|A319|A320|A321)/.test(family)) return "narrowbody";
   if (/^(E175|ERJ|CRJ)/.test(family)) return "regional";
@@ -3247,6 +3279,42 @@ export function getFaaRegistryByTail(db: Database, tail: string): FaaRegistryRow
       .query("SELECT * FROM faa_registry WHERE tail_number = ?")
       .get(tail) as FaaRegistryRow | null) ?? null
   );
+}
+
+/** Replace one month's BTS aggregates in a single transaction. */
+export function replaceBtsMonth(db: Database, month: string, agg: BtsMonthAggregates): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.transaction(() => {
+    db.query("DELETE FROM bts_monthly_operators WHERE month = ?").run(month);
+    db.query("DELETE FROM bts_monthly_tails WHERE month = ?").run(month);
+    db.query("DELETE FROM bts_monthly_routes WHERE month = ?").run(month);
+    for (const o of agg.operators) {
+      db.query(`
+        INSERT INTO bts_monthly_operators (month, op_carrier, flights, performed, distinct_tails, ingested_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+      `).run(month, o.op_carrier, o.flights, o.performed, o.distinct_tails, now);
+    }
+    for (const t of agg.tails) {
+      db.query(`
+        INSERT INTO bts_monthly_tails (month, tail_number, op_carrier, departures)
+        VALUES (?, ?, ?, ?)
+      `).run(month, t.tail_number, t.op_carrier, t.departures);
+    }
+    for (const r of agg.routes) {
+      db.query(`
+        INSERT INTO bts_monthly_routes (month, origin, dest, performed)
+        VALUES (?, ?, ?, ?)
+      `).run(month, r.origin, r.dest, r.performed);
+    }
+  })();
+}
+
+export function getBtsIngestedMonths(db: Database): string[] {
+  return (
+    db
+      .query("SELECT DISTINCT month FROM bts_monthly_operators ORDER BY month DESC")
+      .all() as Array<{ month: string }>
+  ).map((r) => r.month);
 }
 
 const ADSB_OBSERVATION_RETENTION_DAYS = 7;

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -16,6 +16,7 @@ export {
   normalizeWifiProvider,
   normalizeFleet,
   normalizeAirlineTag,
+  normalizeOpCarrier,
   normalizeStarlinkStatus,
   classifyUserAgent,
   bucketDaysOut,

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -18,6 +18,8 @@
  *   wifi_provider:   starlink | viasat | panasonic | thales | none | other | unknown  (7)
  *   starlink_status: confirmed | negative | unknown                  (3)
  *   vendor:          fr24 | flightaware | united | qatar | alaska | adsb    (6)
+ *   op_carrier:      ua | oo | yx | g7 | c5 | yv | zw | other | unknown      (9)
+ *   kind:            missing_from_fleet | inactive_in_fleet                 (2)
  *   status:          success | error | rate_limited | timeout | killed |
  *                    exit_error | parse_error | spawn_error | partial |
  *                    aborted | scrape_error                          (~11)
@@ -86,6 +88,14 @@ export function normalizeFleet(raw: string | null | undefined): string {
 export function normalizeStarlinkStatus(raw: string | null | undefined): string {
   if (raw === "confirmed" || raw === "negative") return raw;
   return "unknown";
+}
+
+// UA mainline plus its Express operators; anything else buckets to "other".
+const UA_OPERATING_CARRIERS = new Set(["UA", "OO", "YX", "G7", "C5", "YV", "ZW"]);
+export function normalizeOpCarrier(raw: string | null | undefined): string {
+  if (!raw || raw.trim() === "") return "unknown";
+  const code = raw.trim().toUpperCase();
+  return UA_OPERATING_CARRIERS.has(code) ? code.toLowerCase() : "other";
 }
 
 // Bounded user-agent classification (≤6 buckets, never the raw UA).
@@ -219,6 +229,10 @@ export const GAUGES = {
   // ADS-B shadow sweep vs upcoming_flights assignments.
   // tags: result (match|mismatch|no_assignment|no_callsign|airborne_total), airline
   ADSB_SHADOW_OBSERVATIONS: "adsb_shadow.observations",
+
+  // BTS monthly shadow ingest. tags: op_carrier, airline / kind (missing_from_fleet|inactive_in_fleet), airline
+  BTS_ACTIVE_TAILS: "bts.active_tails",
+  BTS_FLEET_DELTA: "bts.fleet_delta",
 } as const;
 
 /**

--- a/src/scripts/bts-sync.ts
+++ b/src/scripts/bts-sync.ts
@@ -1,0 +1,275 @@
+/**
+ * BTS Marketing Carrier On-Time (table FGK) shadow ingest. Once a month BTS
+ * publishes carrier-reported per-flight data (~2-month lag) with the tail that
+ * actually flew every UA-marketed domestic flight, including the regionals
+ * that don't report anywhere else. We keep aggregates only — per-operator
+ * active-tail counts, per-tail departure counts, per-route departures — and
+ * emit fleet-delta metrics vs united_fleet. Shadow only: nothing here feeds
+ * the serving path. Domestic-only caveat: widebodies barely appear. The tail
+ * and route tables have no readers yet — they back the planned route-share
+ * denominator and parked-tail audits.
+ */
+
+import type { Database } from "bun:sqlite";
+import { rmSync } from "node:fs";
+import { bodyClassOf, getBtsIngestedMonths, replaceBtsMonth } from "../database/database";
+import {
+  COUNTERS,
+  GAUGES,
+  metrics,
+  normalizeAircraftType,
+  normalizeAirlineTag,
+  normalizeOpCarrier,
+  withSpan,
+} from "../observability";
+import type { BtsMonthAggregates } from "../types";
+import { downloadZipToTemp, spawnLines, splitCsvLine } from "../utils/bulk-data";
+import { type JobHandle, startJob } from "../utils/job-runner";
+import { info, error as logError, warn } from "../utils/logger";
+
+const PREZIP_BASE = "https://transtats.bts.gov/PREZIP";
+const FILE_PREFIX = "On_Time_Marketing_Carrier_On_Time_Performance_Beginning_January_2018";
+
+// Publication runs ~2 months behind; look back a little further to catch up
+// after outages without walking the whole archive.
+const PUBLICATION_LAG_MONTHS = 2;
+const CATCHUP_MONTHS = 4;
+
+export type LineSource = AsyncIterable<string> | Iterable<string>;
+
+export interface BtsSyncDeps {
+  /** Returns CSV lines for a month's file, or null when BTS hasn't published it yet. */
+  loadMonth?: (year: number, month: number) => Promise<LineSource | null>;
+}
+
+export interface BtsSyncResult {
+  outcome: "ingested" | "noop" | "error";
+  month: string | null;
+  rows: number;
+}
+
+export const monthKey = (year: number, month: number) =>
+  `${year}-${String(month).padStart(2, "0")}`;
+
+/** Months worth probing, newest first, given the publication lag. */
+export function candidateMonths(now: Date): Array<{ year: number; month: number }> {
+  const out: Array<{ year: number; month: number }> = [];
+  for (let back = PUBLICATION_LAG_MONTHS; back <= CATCHUP_MONTHS; back++) {
+    const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - back, 1));
+    out.push({ year: d.getUTCFullYear(), month: d.getUTCMonth() + 1 });
+  }
+  return out;
+}
+
+/** Aggregate the UA-marketed rows of one month's CSV without keeping raw rows. */
+export async function aggregateBtsCsv(lines: LineSource): Promise<BtsMonthAggregates> {
+  let header: Record<string, number> | null = null;
+  const operators = new Map<string, { flights: number; performed: number; tails: Set<string> }>();
+  const tails = new Map<string, { op_carrier: string; departures: number }>();
+  const routes = new Map<string, number>();
+  let rows = 0;
+
+  for await (const line of lines) {
+    if (line.trim() === "") continue;
+    const cells = splitCsvLine(line);
+    if (!header) {
+      header = {};
+      // The export pads some header names with spaces ("Operating_Airline ").
+      cells.forEach((name, i) => {
+        header![name.trim()] = i;
+      });
+      continue;
+    }
+    const get = (name: string) => (cells[header![name] ?? -1] ?? "").trim();
+    if (get("Marketing_Airline_Network") !== "UA") continue;
+    rows++;
+
+    const opCarrier = get("Operating_Airline") || "unknown";
+    const tail = get("Tail_Number").toUpperCase();
+    const cancelled = Number(get("Cancelled") || "0") > 0;
+    const diverted = Number(get("Diverted") || "0") > 0;
+    const origin = get("Origin");
+    const dest = get("Dest");
+
+    const op = operators.get(opCarrier) ?? { flights: 0, performed: 0, tails: new Set<string>() };
+    op.flights++;
+    if (!cancelled) op.performed++;
+    if (tail) op.tails.add(tail);
+    operators.set(opCarrier, op);
+
+    if (tail && !cancelled) {
+      // First-seen operator wins for tails transferred between operators mid-month.
+      const t = tails.get(tail) ?? { op_carrier: opCarrier, departures: 0 };
+      t.departures++;
+      tails.set(tail, t);
+    }
+    // Diverted flights departed but didn't complete the scheduled route.
+    if (!cancelled && !diverted && origin && dest) {
+      const key = `${origin}-${dest}`;
+      routes.set(key, (routes.get(key) ?? 0) + 1);
+    }
+  }
+
+  return {
+    rows,
+    operators: [...operators.entries()].map(([op_carrier, v]) => ({
+      op_carrier,
+      flights: v.flights,
+      performed: v.performed,
+      distinct_tails: v.tails.size,
+    })),
+    tails: [...tails.entries()].map(([tail_number, v]) => ({ tail_number, ...v })),
+    routes: [...routes.entries()].map(([key, performed]) => {
+      const [origin, dest] = key.split("-");
+      return { origin, dest, performed };
+    }),
+  };
+}
+
+/** Compare a month's active tails against united_fleet; widebodies are excluded
+ * from the inactive list because this dataset is domestic-only. */
+export function computeFleetDeltas(
+  db: Database,
+  aggregates: BtsMonthAggregates
+): { missingFromFleet: string[]; inactiveInFleet: string[] } {
+  const fleet = db
+    .query("SELECT tail_number, aircraft_type FROM united_fleet WHERE airline = 'UA'")
+    .all() as Array<{ tail_number: string; aircraft_type: string | null }>;
+  const fleetTails = new Set(fleet.map((r) => r.tail_number));
+  const btsTails = new Set(aggregates.tails.map((t) => t.tail_number));
+
+  const missingFromFleet = [...btsTails].filter((t) => !fleetTails.has(t)).sort();
+  const inactiveInFleet = fleet
+    .filter(
+      (r) =>
+        !btsTails.has(r.tail_number) &&
+        bodyClassOf(normalizeAircraftType(r.aircraft_type)) !== "widebody"
+    )
+    .map((r) => r.tail_number)
+    .sort();
+  return { missingFromFleet, inactiveInFleet };
+}
+
+async function downloadMonth(year: number, month: number): Promise<LineSource | null> {
+  const url = `${PREZIP_BASE}/${FILE_PREFIX}_${year}_${month}.zip`;
+  const downloaded = await downloadZipToTemp(url, {
+    prefix: "bts-fgk-",
+    maxTimeSec: 900,
+    notFoundOk: true,
+  });
+  if (!downloaded) return null;
+  const { dir, zipPath } = downloaded;
+
+  const list = Bun.spawnSync(["unzip", "-Z1", zipPath]);
+  const csvName = list.stdout
+    .toString()
+    .split("\n")
+    .find((n) => n.trim().toLowerCase().endsWith(".csv"))
+    ?.trim();
+  if (!csvName) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error("BTS zip contained no CSV");
+  }
+
+  const lines = spawnLines(["unzip", "-p", zipPath, csvName]);
+  // Wrap so the temp dir is removed when the stream is fully consumed or abandoned.
+  async function* withCleanup(): AsyncGenerator<string> {
+    try {
+      yield* lines;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  return withCleanup();
+}
+
+export async function runBtsSync(db: Database, deps: BtsSyncDeps = {}): Promise<BtsSyncResult> {
+  return withSpan(
+    "scraper.bts_sync",
+    async (span): Promise<BtsSyncResult> => {
+      span.setTag("job.type", "background");
+      const airlineTag = normalizeAirlineTag("UA");
+      const loadMonth = deps.loadMonth ?? downloadMonth;
+      const ingested = new Set(getBtsIngestedMonths(db));
+
+      let failedMonths = 0;
+      for (const { year, month } of candidateMonths(new Date())) {
+        const key = monthKey(year, month);
+        if (ingested.has(key)) continue; // already have it — older gaps can still backfill
+        try {
+          const lines = await loadMonth(year, month);
+          if (!lines) continue; // not published yet — try the previous month
+
+          const aggregates = await aggregateBtsCsv(lines);
+          if (aggregates.rows === 0) throw new Error(`BTS ${key} parsed to zero UA rows`);
+          replaceBtsMonth(db, key, aggregates);
+
+          const deltas = computeFleetDeltas(db, aggregates);
+          for (const op of aggregates.operators) {
+            metrics.gauge(GAUGES.BTS_ACTIVE_TAILS, op.distinct_tails, {
+              op_carrier: normalizeOpCarrier(op.op_carrier),
+              airline: airlineTag,
+            });
+          }
+          metrics.gauge(GAUGES.BTS_FLEET_DELTA, deltas.missingFromFleet.length, {
+            kind: "missing_from_fleet",
+            airline: airlineTag,
+          });
+          metrics.gauge(GAUGES.BTS_FLEET_DELTA, deltas.inactiveInFleet.length, {
+            kind: "inactive_in_fleet",
+            airline: airlineTag,
+          });
+          metrics.increment(COUNTERS.SCRAPER_SYNC, {
+            source: "bts",
+            airline: airlineTag,
+            status: "success",
+          });
+
+          if (deltas.missingFromFleet.length > 0) {
+            const sample = deltas.missingFromFleet.slice(0, 20).join(", ");
+            warn(
+              `bts-sync ${key}: ${deltas.missingFromFleet.length} active tails missing from united_fleet: ${sample}`
+            );
+          }
+          const totalTails = aggregates.tails.length;
+          info(
+            `bts-sync ingested ${key}: ${aggregates.rows} UA-marketed rows, ${totalTails} active tails, ` +
+              `${deltas.missingFromFleet.length} missing from fleet, ${deltas.inactiveInFleet.length} fleet tails inactive (narrowbody/regional)`
+          );
+          span.setTag("result", "ingested");
+          span.setTag("month", key);
+          return { outcome: "ingested", month: key, rows: aggregates.rows };
+        } catch (err) {
+          // A bad newer file (download failure, renamed column) must not block
+          // backfilling an older month still in the catch-up window.
+          failedMonths++;
+          logError(`bts-sync ${key} failed`, err);
+          metrics.increment(COUNTERS.SCRAPER_SYNC, {
+            source: "bts",
+            airline: airlineTag,
+            status: "error",
+          });
+        }
+      }
+
+      if (failedMonths > 0) {
+        span.setTag("error", true);
+        return { outcome: "error", month: null, rows: 0 };
+      }
+      span.setTag("result", "noop");
+      return { outcome: "noop", month: null, rows: 0 };
+    },
+    { "job.type": "background" }
+  );
+}
+
+export function startBtsSyncJob(db: Database): JobHandle {
+  return startJob({
+    name: "bts_sync",
+    intervalMs: 24 * 3600 * 1000,
+    initialDelayMs: 45 * 60 * 1000,
+    run: async () => {
+      await runBtsSync(db);
+    },
+  });
+}

--- a/src/scripts/faa-registry.ts
+++ b/src/scripts/faa-registry.ts
@@ -6,13 +6,11 @@
  */
 
 import type { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import path from "node:path";
+import { rmSync } from "node:fs";
 import { replaceFaaRegistry } from "../database/database";
 import { COUNTERS, GAUGES, metrics, normalizeAirlineTag, withSpan } from "../observability";
 import type { FaaRegistryRow } from "../types";
-import { BROWSER_USER_AGENT } from "../utils/constants";
+import { downloadZipToTemp, spawnLines } from "../utils/bulk-data";
 import { type JobHandle, startJob } from "../utils/job-runner";
 import { info, error as logError, warn } from "../utils/logger";
 
@@ -180,60 +178,6 @@ export function buildFaaRecords(opts: {
   return { rows, flags };
 }
 
-async function* spawnLines(cmd: string[]): AsyncGenerator<string> {
-  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "ignore" });
-  try {
-    const decoder = new TextDecoder();
-    let buf = "";
-    for await (const chunk of proc.stdout) {
-      buf += decoder.decode(chunk, { stream: true });
-      let nl = buf.indexOf("\n");
-      while (nl !== -1) {
-        yield buf.slice(0, nl).replace(/\r$/, "");
-        buf = buf.slice(nl + 1);
-        nl = buf.indexOf("\n");
-      }
-    }
-    if (buf.trim() !== "") yield buf;
-    const code = await proc.exited;
-    if (code !== 0) throw new Error(`${cmd.join(" ")} exited with ${code}`);
-  } finally {
-    // Covers consumers that stop iterating early — never leave unzip blocked
-    // on an undrained pipe.
-    proc.kill();
-    await proc.exited;
-  }
-}
-
-async function downloadRegistryZip(): Promise<{ dir: string; zipPath: string }> {
-  const dir = mkdtempSync(path.join(tmpdir(), "faa-registry-"));
-  const zipPath = path.join(dir, "ReleasableAircraft.zip");
-  // curl, not fetch: the FAA host needs a browser User-Agent (503s otherwise)
-  // and Bun's fetch stalls indefinitely streaming this particular 73 MB body.
-  const proc = Bun.spawn(
-    [
-      "curl",
-      "-sSL",
-      "--fail",
-      "--max-time",
-      "600",
-      "-A",
-      BROWSER_USER_AGENT,
-      "-o",
-      zipPath,
-      REGISTRY_ZIP_URL,
-    ],
-    { stdout: "ignore", stderr: "pipe" }
-  );
-  const code = await proc.exited;
-  if (code !== 0) {
-    const stderr = await new Response(proc.stderr).text();
-    rmSync(dir, { recursive: true, force: true });
-    throw new Error(`registry download failed (curl exit ${code}): ${stderr.slice(0, 200)}`);
-  }
-  return { dir, zipPath };
-}
-
 function trackedTails(db: Database): { tails: string[]; starlinkTails: Set<string> } {
   const fleet = db.query("SELECT tail_number, starlink_status FROM united_fleet").all() as Array<{
     tail_number: string;
@@ -272,7 +216,9 @@ export async function runFaaRegistrySync(
       try {
         let loadLines = deps.loadLines;
         if (!loadLines) {
-          const { dir, zipPath } = await downloadRegistryZip();
+          const downloaded = await downloadZipToTemp(REGISTRY_ZIP_URL, { prefix: "faa-registry-" });
+          if (!downloaded) throw new Error("registry download returned no file");
+          const { dir, zipPath } = downloaded;
           cleanup = () => rmSync(dir, { recursive: true, force: true });
           loadLines = (file) => spawnLines(["unzip", "-p", zipPath, file]);
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,19 @@ export interface SecFilingRow {
   seen_at: number;
 }
 
+/** Aggregates kept from one month of BTS FGK data (raw per-flight rows are not stored). */
+export interface BtsMonthAggregates {
+  rows: number;
+  operators: Array<{
+    op_carrier: string;
+    flights: number;
+    performed: number;
+    distinct_tails: number;
+  }>;
+  tails: Array<{ tail_number: string; op_carrier: string; departures: number }>;
+  routes: Array<{ origin: string; dest: string; performed: number }>;
+}
+
 /** One ADS-B shadow sweep (aggregate row; observations carry the per-aircraft detail). */
 export interface AdsbSweepRecord {
   swept_at: number;

--- a/src/utils/bulk-data.ts
+++ b/src/utils/bulk-data.ts
@@ -1,0 +1,99 @@
+/**
+ * Helpers for bulk public data files (FAA registry, BTS on-time): download a
+ * zip to a temp dir with curl, stream a member's lines without holding the
+ * extract in memory, and split CSV lines. curl rather than fetch — the FAA
+ * host 503s default user agents and Bun's fetch stalls on its large bodies.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { BROWSER_USER_AGENT } from "./constants";
+
+export async function downloadZipToTemp(
+  url: string,
+  opts: { prefix: string; maxTimeSec?: number; notFoundOk?: boolean }
+): Promise<{ dir: string; zipPath: string } | null> {
+  const dir = mkdtempSync(path.join(tmpdir(), opts.prefix));
+  const zipPath = path.join(dir, "download.zip");
+  const proc = Bun.spawn(
+    [
+      "curl",
+      "-sSL",
+      "--fail",
+      "--max-time",
+      String(opts.maxTimeSec ?? 600),
+      "-A",
+      BROWSER_USER_AGENT,
+      "-w",
+      "%{http_code}",
+      "-o",
+      zipPath,
+      url,
+    ],
+    { stdout: "pipe", stderr: "pipe" }
+  );
+  const code = await proc.exited;
+  if (code !== 0) {
+    rmSync(dir, { recursive: true, force: true });
+    const httpCode = (await new Response(proc.stdout).text()).trim();
+    // notFoundOk only swallows a true 404 (file not published yet); 403/429/5xx
+    // must surface so an outage doesn't masquerade as "nothing new".
+    if (opts.notFoundOk && code === 22 && httpCode === "404") return null;
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(
+      `download failed (curl exit ${code}, http ${httpCode || "?"}): ${stderr.slice(0, 200)}`
+    );
+  }
+  return { dir, zipPath };
+}
+
+export async function* spawnLines(cmd: string[]): AsyncGenerator<string> {
+  const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "ignore" });
+  try {
+    const decoder = new TextDecoder();
+    let buf = "";
+    for await (const chunk of proc.stdout) {
+      buf += decoder.decode(chunk, { stream: true });
+      let nl = buf.indexOf("\n");
+      while (nl !== -1) {
+        yield buf.slice(0, nl).replace(/\r$/, "");
+        buf = buf.slice(nl + 1);
+        nl = buf.indexOf("\n");
+      }
+    }
+    if (buf.trim() !== "") yield buf;
+    const code = await proc.exited;
+    if (code !== 0) throw new Error(`${cmd.join(" ")} exited with ${code}`);
+  } finally {
+    // Covers consumers that stop iterating early — never leave the child
+    // blocked on an undrained pipe.
+    proc.kill();
+    await proc.exited;
+  }
+}
+
+/** Split one CSV line, honoring double quotes (BTS city names contain commas). */
+export function splitCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === '"') {
+      if (inQuotes && line[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else {
+        inQuotes = !inQuotes;
+      }
+    } else if (ch === "," && !inQuotes) {
+      cells.push(field);
+      field = "";
+    } else {
+      field += ch;
+    }
+  }
+  cells.push(field);
+  return cells;
+}

--- a/tests/bts-sync.test.ts
+++ b/tests/bts-sync.test.ts
@@ -1,0 +1,134 @@
+// Pins the BTS FGK aggregation (UA-marketed filter, cancelled handling, quoted
+// fields), the month-replace storage, and the sync's noop/ingest decisions.
+
+import { describe, expect, test } from "bun:test";
+import { getBtsIngestedMonths, replaceBtsMonth } from "../src/database/database";
+import {
+  aggregateBtsCsv,
+  candidateMonths,
+  computeFleetDeltas,
+  monthKey,
+  runBtsSync,
+} from "../src/scripts/bts-sync";
+import { addFleet, makeSyntheticDb } from "./helpers";
+
+const HEADER =
+  '"FlightDate","Marketing_Airline_Network","Flight_Number_Marketing_Airline","Operating_Airline ","Flight_Number_Operating_Airline","Tail_Number","Origin","OriginCityName","Dest","DestCityName","Cancelled","Diverted"';
+
+const CSV_LINES = [
+  HEADER,
+  '"2026-04-01","UA","1326","UA","1326","N73275","AUS","Austin, TX","IAH","Houston, TX","0.00","0.00"',
+  '"2026-04-01","UA","1326","UA","1326","N73275","IAH","Houston, TX","DEN","Denver, CO","0.00","0.00"',
+  '"2026-04-02","UA","5753","OO","5753","N106SY","SFO","San Francisco, CA","SLC","Salt Lake City, UT","0.00","0.00"',
+  '"2026-04-02","UA","5754","OO","5754","N106SY","SLC","Salt Lake City, UT","SFO","San Francisco, CA","1.00","0.00"',
+  '"2026-04-02","UA","4520","G7","4520","N520GJ","ORD","Chicago, IL","CMH","Columbus, OH","0.00","0.00"',
+  '"2026-04-03","UA","999","UA","999","","EWR","Newark, NJ","LAX","Los Angeles, CA","0.00","0.00"',
+  '"2026-04-03","UA","2120","UA","2120","N37502","DEN","Denver, CO","ORD","Chicago, IL","0.00","1.00"',
+  '"2026-04-03","DL","1000","DL","1000","N301DN","ATL","Atlanta, GA","LAX","Los Angeles, CA","0.00","0.00"',
+];
+
+describe("aggregateBtsCsv", () => {
+  test("filters to UA-marketed rows and aggregates operators, tails, and routes", async () => {
+    const agg = await aggregateBtsCsv(CSV_LINES);
+    expect(agg.rows).toBe(7); // DL row excluded
+
+    const ua = agg.operators.find((o) => o.op_carrier === "UA");
+    const oo = agg.operators.find((o) => o.op_carrier === "OO");
+    expect(ua).toMatchObject({ flights: 4, performed: 4, distinct_tails: 2 });
+    expect(oo).toMatchObject({ flights: 2, performed: 1, distinct_tails: 1 });
+
+    // Cancelled flights don't count as departures; blank tails are dropped.
+    expect(agg.tails.find((t) => t.tail_number === "N73275")?.departures).toBe(2);
+    expect(agg.tails.find((t) => t.tail_number === "N106SY")?.departures).toBe(1);
+    expect(agg.tails.length).toBe(4);
+
+    expect(agg.routes.find((r) => r.origin === "AUS" && r.dest === "IAH")?.performed).toBe(1);
+    // The cancelled SLC-SFO leg is not a performed departure.
+    expect(agg.routes.some((r) => r.origin === "SLC" && r.dest === "SFO")).toBe(false);
+    // The diverted DEN-ORD leg departed but didn't complete the scheduled route.
+    expect(agg.routes.some((r) => r.origin === "DEN" && r.dest === "ORD")).toBe(false);
+    expect(agg.tails.find((t) => t.tail_number === "N37502")?.departures).toBe(1);
+  });
+});
+
+describe("storage and fleet deltas", () => {
+  test("replaceBtsMonth is idempotent per month and getBtsIngestedMonths reports it", async () => {
+    const db = makeSyntheticDb();
+    const agg = await aggregateBtsCsv(CSV_LINES);
+    replaceBtsMonth(db, "2026-04", agg);
+    replaceBtsMonth(db, "2026-04", agg);
+    expect(getBtsIngestedMonths(db)).toEqual(["2026-04"]);
+    expect(
+      db.query("SELECT COUNT(*) AS n FROM bts_monthly_tails WHERE month = '2026-04'").get()
+    ).toEqual({ n: 4 });
+  });
+
+  test("computeFleetDeltas separates missing-from-fleet and inactive narrowbodies", async () => {
+    const db = makeSyntheticDb();
+    addFleet(db, "N73275", "confirmed", { aircraftType: "Boeing 737-824" });
+    addFleet(db, "N106SY", "confirmed", { aircraftType: "E175" });
+    addFleet(db, "N12345", "unknown", { aircraftType: "Boeing 737-900" }); // not in BTS month
+    addFleet(db, "N2645U", "unknown", { aircraftType: "Boeing 777-200" }); // widebody — excluded
+    const agg = await aggregateBtsCsv(CSV_LINES);
+    const deltas = computeFleetDeltas(db, agg);
+    expect(deltas.missingFromFleet).toEqual(["N37502", "N520GJ"]);
+    expect(deltas.inactiveInFleet).toEqual(["N12345"]);
+  });
+});
+
+describe("runBtsSync", () => {
+  test("ingests the newest published month, then noops on the next run", async () => {
+    const db = makeSyntheticDb();
+    addFleet(db, "N73275", "confirmed", { aircraftType: "Boeing 737-824" });
+    let calls = 0;
+    const loadMonth = async (_year: number, _month: number) => {
+      calls++;
+      return calls === 1 ? CSV_LINES : null;
+    };
+
+    const first = await runBtsSync(db, { loadMonth });
+    expect(first.outcome).toBe("ingested");
+    expect(first.rows).toBe(7);
+    expect(getBtsIngestedMonths(db).length).toBe(1);
+
+    const second = await runBtsSync(db, { loadMonth });
+    expect(second.outcome).toBe("noop");
+  });
+
+  test("nooping months that aren't published yet without erroring", async () => {
+    const db = makeSyntheticDb();
+    const result = await runBtsSync(db, { loadMonth: async () => null });
+    expect(result.outcome).toBe("noop");
+    expect(getBtsIngestedMonths(db)).toEqual([]);
+  });
+
+  test("a failing newer month doesn't block backfilling an older one", async () => {
+    const db = makeSyntheticDb();
+    let calls = 0;
+    const loadMonth = async () => {
+      calls++;
+      if (calls === 1) throw new Error("BTS served a 503");
+      return CSV_LINES;
+    };
+    const result = await runBtsSync(db, { loadMonth });
+    expect(result.outcome).toBe("ingested");
+    expect(getBtsIngestedMonths(db).length).toBe(1);
+  });
+
+  test("reports error, not noop, when every candidate month fails", async () => {
+    const db = makeSyntheticDb();
+    const loadMonth = async () => {
+      throw new Error("BTS outage");
+    };
+    const result = await runBtsSync(db, { loadMonth });
+    expect(result.outcome).toBe("error");
+    expect(getBtsIngestedMonths(db)).toEqual([]);
+  });
+
+  test("monthKey and candidateMonths respect the publication lag", () => {
+    expect(monthKey(2026, 4)).toBe("2026-04");
+    const months = candidateMonths(new Date("2026-06-14T12:00:00Z"));
+    expect(months[0]).toEqual({ year: 2026, month: 4 });
+    expect(months.at(-1)).toEqual({ year: 2026, month: 2 });
+  });
+});


### PR DESCRIPTION
We have no carrier-reported ground truth for which tails actually fly UA-marketed schedules — FR24 misses regional operators and gives no denominator for route or fleet activity. BTS publishes the Marketing Carrier On-Time file monthly (~2-month lag) with the operating carrier and tail for every UA-marketed domestic flight.

- Daily `bts_sync` job probes for newly published months, downloads the zip with curl, and streams the ~330MB CSV through `unzip -p` keeping aggregates only
- Stores per-operator active-tail counts, per-tail departures, and per-route departures in three `bts_monthly_*` tables (shadow only — nothing feeds the serving path)
- Compares each month's active tails against `united_fleet` and emits `bts.active_tails` / `bts.fleet_delta` gauges plus `scraper.sync` counters
- Extracts shared bulk-download helpers into `src/utils/bulk-data.ts`; faa-registry now uses them (404 is the only "not published" case — other HTTP errors surface)
- Verified against the real April 2026 file: 129k UA-marketed rows, 1,501 active tails