### PR TITLE
Add passenger-verify dark launch: geofeed detect + onboard probe

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,5 +247,6 @@
 
     <!-- Chrome Extension Schema -->
     {{chromeExtensionJsonLd}}
+    {{passengerProbeSnippet}}
   </body>
 </html>

--- a/server.ts
+++ b/server.ts
@@ -15,9 +15,11 @@ import { startFleetSync } from "./src/scripts/fleet-sync";
 import { startQatarScheduleIngester } from "./src/scripts/qatar-schedule-ingester";
 import { startSecAnchorsJob } from "./src/scripts/sec-anchors";
 import { runSheetScrape } from "./src/scripts/sheet-scrape";
+import { startGeofeedJob } from "./src/scripts/starlink-geofeed";
 import { startStarlinkVerifier } from "./src/scripts/starlink-verifier";
 import { syncShipNumbers } from "./src/scripts/sync-ship-numbers";
 import { createApp } from "./src/server/app";
+import { passengerVerifyEnabled } from "./src/server/passenger-detect";
 import { type JobHandle, type JobRunContext, startJob } from "./src/utils/job-runner";
 import { info, error as logError } from "./src/utils/logger";
 
@@ -126,6 +128,9 @@ if (JOBS_ENABLED) {
 
   // BTS FGK monthly shadow ingest (daily check; ingests when a new month posts).
   track(startBtsSyncJob(db));
+
+  // Starlink RFC 8805 geofeed → backs the passenger-verify dark-launch probe.
+  if (passengerVerifyEnabled) track(startGeofeedJob(db));
 
   // Daily prune of subprocess-crash log rows (no observation, just noise).
   track(

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -456,6 +456,44 @@ export function setupTables(db: Database) {
     `);
   }
 
+  // Starlink RFC 8805 geofeed prefixes — backs isStarlinkIp().
+  if (!tableExists(db, "starlink_prefixes")) {
+    db.exec(`
+      CREATE TABLE starlink_prefixes (
+        cidr TEXT PRIMARY KEY,
+        lo TEXT NOT NULL,
+        hi TEXT NOT NULL,
+        v6 INTEGER NOT NULL,
+        fetched_at INTEGER NOT NULL
+      );
+    `);
+  }
+
+  // Passenger-verify dark-launch probe results. Everything except ip / in_geofeed
+  // is client-asserted; trust filtering happens at read time.
+  if (!tableExists(db, "passenger_reports")) {
+    db.exec(`
+      CREATE TABLE passenger_reports (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        reported_at INTEGER NOT NULL,
+        ip TEXT NOT NULL,
+        ip_prefix TEXT NOT NULL,
+        in_geofeed INTEGER NOT NULL,
+        source TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        claimed_flight TEXT,
+        claimed_tail TEXT,
+        claimed_date TEXT,
+        router_id TEXT,
+        ua_hash TEXT,
+        airborne_match INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX idx_passenger_reports_prefix ON passenger_reports(ip_prefix, reported_at);
+      CREATE INDEX idx_passenger_reports_tail ON passenger_reports(claimed_tail, reported_at);
+      CREATE INDEX idx_passenger_reports_at ON passenger_reports(reported_at);
+    `);
+  }
+
   if (tableExists(db, "starlink_planes")) {
     const columns = db.query("PRAGMA table_info(starlink_planes)").all();
     const migrationsRun = [];
@@ -3217,6 +3255,105 @@ export function replaceFaaRegistry(
       );
     }
   })();
+}
+
+export function replaceStarlinkPrefixes(
+  db: Database,
+  rows: ReadonlyArray<{ cidr: string; lo: bigint; hi: bigint; v6: boolean }>
+): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.transaction(() => {
+    db.query("DELETE FROM starlink_prefixes").run();
+    for (const r of rows) {
+      db.query(
+        "INSERT OR REPLACE INTO starlink_prefixes (cidr, lo, hi, v6, fetched_at) VALUES (?, ?, ?, ?, ?)"
+      ).run(r.cidr, r.lo.toString(), r.hi.toString(), r.v6 ? 1 : 0, now);
+    }
+  })();
+}
+
+export function getStarlinkPrefixes(
+  db: Database
+): Array<{ cidr: string; lo: bigint; hi: bigint; v6: boolean }> {
+  const rows = db.query("SELECT cidr, lo, hi, v6 FROM starlink_prefixes").all() as Array<{
+    cidr: string;
+    lo: string;
+    hi: string;
+    v6: number;
+  }>;
+  return rows.map((r) => ({ cidr: r.cidr, lo: BigInt(r.lo), hi: BigInt(r.hi), v6: r.v6 === 1 }));
+}
+
+export interface PassengerReportInsert {
+  ip: string;
+  ip_prefix: string;
+  in_geofeed: boolean;
+  source: string;
+  outcome: string;
+  claimed_flight: string | null;
+  claimed_tail: string | null;
+  claimed_date: string | null;
+  router_id: string | null;
+  ua_hash: string | null;
+  airborne_match: boolean;
+}
+
+export function recordPassengerReport(db: Database, r: PassengerReportInsert): void {
+  db.query(`
+    INSERT INTO passenger_reports
+      (reported_at, ip, ip_prefix, in_geofeed, source, outcome,
+       claimed_flight, claimed_tail, claimed_date, router_id, ua_hash, airborne_match)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    Math.floor(Date.now() / 1000),
+    r.ip,
+    r.ip_prefix,
+    r.in_geofeed ? 1 : 0,
+    r.source,
+    r.outcome,
+    r.claimed_flight,
+    r.claimed_tail,
+    r.claimed_date,
+    r.router_id,
+    r.ua_hash,
+    r.airborne_match ? 1 : 0
+  );
+}
+
+export function isFlightAirborne(
+  db: Database,
+  variants: readonly string[],
+  nowSec = Math.floor(Date.now() / 1000)
+): boolean {
+  if (variants.length === 0) return false;
+  const placeholders = variants.map(() => "?").join(",");
+  return (
+    db
+      .query(
+        `SELECT 1 FROM upcoming_flights
+         WHERE flight_number IN (${placeholders}) AND departure_time <= ? AND arrival_time >= ?
+         LIMIT 1`
+      )
+      .get(...variants, nowSec, nowSec) !== null
+  );
+}
+
+/** Per-prefix per-tail dedupe window — limits ballot-stuffing within one flight. */
+export function passengerReportSeenRecently(
+  db: Database,
+  ipPrefix: string,
+  tail: string | null,
+  windowSec: number
+): boolean {
+  const since = Math.floor(Date.now() / 1000) - windowSec;
+  const row = db
+    .query(
+      `SELECT 1 FROM passenger_reports
+       WHERE ip_prefix = ? AND reported_at > ? AND claimed_tail IS ?
+       LIMIT 1`
+    )
+    .get(ipPrefix, since, tail);
+  return row !== null;
 }
 
 /** Upsert anchors keyed by (airline, metric, as-of date) — editing SEED_ANCHORS

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -17,6 +17,7 @@ export {
   normalizeFleet,
   normalizeAirlineTag,
   normalizeOpCarrier,
+  normalizeProbeOutcome,
   normalizeStarlinkStatus,
   classifyUserAgent,
   bucketDaysOut,

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -100,6 +100,23 @@ export function normalizeOpCarrier(raw: string | null | undefined): string {
   return UA_OPERATING_CARRIERS.has(code) ? code.toLowerCase() : "other";
 }
 
+// passenger.probe outcome is client-supplied — closed enum or it's a cardinality bomb.
+const PROBE_OUTCOMES = new Set([
+  "onboard_api",
+  "onboard_noflight",
+  "cors_blocked",
+  "csp_blocked",
+  "fetch_error",
+  "timeout",
+  "unknown",
+]);
+export function normalizeProbeOutcome(raw: string | null | undefined): string {
+  if (!raw) return "unknown";
+  if (PROBE_OUTCOMES.has(raw)) return raw;
+  if (/^onboard_http_\d{3}$/.test(raw)) return raw;
+  return "other";
+}
+
 // Bounded user-agent classification (≤6 buckets, never the raw UA).
 const BOT_UA = /bot|spider|crawler|curl|wget|python-requests|go-http-client|headless|httpclient/i;
 export function classifyUserAgent(ua: string | null | undefined): string {
@@ -194,6 +211,13 @@ export const COUNTERS = {
 
   // Route lookup fallback chain hit source — tags: source (memory|sqlite|fr24|upcoming|miss), airline
   ROUTE_LOOKUP: "route.lookup",
+
+  // Passenger-verify dark launch: HTML request whose cf-connecting-ip is in the
+  // Starlink geofeed — tags: tenant, client_class
+  PASSENGER_DETECT: "passenger.detect",
+  // Probe beacon outcome — tags: outcome (onboard_api|cors_blocked|csp_blocked|
+  //   fetch_error|timeout|onboard_http_*|onboard_noflight|unknown), in_geofeed (0|1), airline
+  PASSENGER_PROBE: "passenger.probe",
 } as const;
 
 /**
@@ -235,6 +259,9 @@ export const GAUGES = {
   // BTS monthly shadow ingest. tags: op_carrier, airline / kind (missing_from_fleet|inactive_in_fleet), airline
   BTS_ACTIVE_TAILS: "bts.active_tails",
   BTS_FLEET_DELTA: "bts.fleet_delta",
+
+  // Starlink RFC 8805 geofeed prefix count — tags: airline:all
+  GEOFEED_PREFIXES: "geofeed.prefixes",
 } as const;
 
 /**

--- a/src/scripts/starlink-geofeed.ts
+++ b/src/scripts/starlink-geofeed.ts
@@ -1,0 +1,78 @@
+/**
+ * Daily fetch of Starlink's RFC 8805 geofeed (~4k prefixes). Gives us
+ * `isStarlinkIp(clientIp)` for the passenger-verify dark-launch probe.
+ * The geofeed locates by PoP, not aircraft, so it answers "on Starlink?"
+ * only — never which flight.
+ */
+
+import type { Database } from "bun:sqlite";
+import { replaceStarlinkPrefixes } from "../database/database";
+import { COUNTERS, GAUGES, metrics, withSpan } from "../observability";
+import { type ParsedPrefix, parseCidr } from "../utils/ip-prefix";
+import { type JobHandle, startJob } from "../utils/job-runner";
+import { info, error as logError } from "../utils/logger";
+
+const GEOFEED_URL = "https://geoip.starlinkisp.net/feed.csv";
+
+export interface GeofeedSyncResult {
+  outcome: "success" | "error";
+  prefixes: number;
+}
+
+export function parseGeofeed(body: string): ParsedPrefix[] {
+  const out = new Map<string, ParsedPrefix>();
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const cidr = line.split(",")[0]?.trim();
+    if (!cidr) continue;
+    const parsed = parseCidr(cidr);
+    if (parsed) out.set(parsed.cidr, parsed);
+  }
+  return [...out.values()];
+}
+
+export async function runGeofeedSync(
+  db: Database,
+  fetchBody: () => Promise<string> = () => fetch(GEOFEED_URL).then((r) => r.text())
+): Promise<GeofeedSyncResult> {
+  return withSpan("scraper.starlink_geofeed", async (span) => {
+    span.setTag("job.type", "background");
+    try {
+      const body = await fetchBody();
+      const prefixes = parseGeofeed(body);
+      // A short or empty body is a fetch failure (CDN error page), not a real
+      // empty feed — keep yesterday's table rather than blanking the matcher.
+      if (prefixes.length < 100) throw new Error(`geofeed parsed to ${prefixes.length} prefixes`);
+      replaceStarlinkPrefixes(db, prefixes);
+      metrics.gauge(GAUGES.GEOFEED_PREFIXES, prefixes.length, { airline: "all" });
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "starlink_geofeed",
+        airline: "all",
+        status: "success",
+      });
+      info(`starlink-geofeed sync: ${prefixes.length} prefixes`);
+      return { outcome: "success", prefixes: prefixes.length };
+    } catch (err) {
+      logError("starlink-geofeed sync failed", err);
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "starlink_geofeed",
+        airline: "all",
+        status: "error",
+      });
+      span.setTag("error", true);
+      return { outcome: "error", prefixes: 0 };
+    }
+  });
+}
+
+export function startGeofeedJob(db: Database): JobHandle {
+  return startJob({
+    name: "starlink_geofeed",
+    intervalMs: 24 * 3600 * 1000,
+    initialDelayMs: 30 * 1000,
+    run: async () => {
+      await runGeofeedSync(db);
+    },
+  });
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -92,6 +92,12 @@ import {
   tenantConfig,
   tenantScope,
 } from "./context";
+import {
+  PROBE_SNIPPET,
+  StarlinkIpDetector,
+  handlePassengerProbe,
+  passengerVerifyEnabled,
+} from "./passenger-detect";
 
 type Handler = (ctx: RequestContext) => Response | Promise<Response>;
 type RouteTable = Record<string, Handler>;
@@ -1393,6 +1399,8 @@ function buildBaseTemplateVars(
     canonicalPath: escapeHtmlAttr(canonicalPath),
     analyticsSnippet: analyticsSnippet(site),
     headSnippet: site.headSnippet ?? "",
+    // Dark-launch probe is UA-only; the onboard portal URL is United's.
+    passengerProbeSnippet: ctx.onStarlinkIp && site.scope === "UA" ? PROBE_SNIPPET : "",
     webSiteJsonLd: siteWebJsonLd(site, brandVars.siteDescription),
     webPageJsonLd: sitePageJsonLd(site, {
       path: canonicalPath,
@@ -1765,8 +1773,28 @@ function clientIp(req: Request): string {
 
 export function createApp(db: Database): App {
   const getReader = createReaderFactory(db);
+  const detector = passengerVerifyEnabled ? new StarlinkIpDetector(db) : null;
   const ipHits = new Map<string, number[]>();
   let lastSweep = 0;
+
+  const apiPassengerProbe: Handler = async ({ req, ip, onStarlinkIp }) => {
+    if (req.method !== "POST") return methodNotAllowed(true);
+    let body: unknown;
+    try {
+      // sendBeacon posts text/plain; req.json() handles that.
+      body = await req.json();
+    } catch {
+      body = {};
+    }
+    handlePassengerProbe(
+      db,
+      ip,
+      onStarlinkIp,
+      req.headers.get("user-agent"),
+      (body ?? {}) as Record<string, unknown>
+    );
+    return new Response(null, { status: 202, headers: SECURITY_HEADERS.api });
+  };
 
   function rateLimited(ip: string, bucket: string, now: number): boolean {
     if (LOCAL_IPS.has(ip)) return false;
@@ -1804,6 +1832,7 @@ export function createApp(db: Database): App {
     "/api/plan-route": apiPlanRoute,
     "/api/mismatches": apiMismatches,
     "/api/fleet-discovery": apiFleetDiscovery,
+    "/api/passenger-probe": apiPassengerProbe,
     "/mcp": mcp,
     "/robots.txt": robotsTxt,
     "/llms.txt": llmsTxt,
@@ -1897,8 +1926,8 @@ export function createApp(db: Database): App {
         : url.pathname.startsWith("/check-flight/")
           ? "page"
           : null;
+    const ip = clientIp(req);
     if (meterClass) {
-      const ip = clientIp(req);
       if (rateLimited(ip, meterClass, Date.now())) {
         metrics.increment(COUNTERS.HTTP_RATE_LIMITED, { route, tenant: tenantScope(tenant) });
         return new Response(JSON.stringify({ error: "rate limit exceeded" }), {
@@ -1926,8 +1955,15 @@ export function createApp(db: Database): App {
       return response;
     }
 
+    const onStarlinkIp = detector?.match(ip) ?? false;
+    if (onStarlinkIp) {
+      metrics.increment(COUNTERS.PASSENGER_DETECT, {
+        tenant: tenantScope(tenant),
+        client_class: classifyUserAgent(req.headers.get("user-agent")),
+      });
+    }
     const reader: ScopedReader = getReader(tenantScope(tenant));
-    const ctx: RequestContext = { req, url, site, tenant, reader, getReader };
+    const ctx: RequestContext = { req, url, ip, site, tenant, reader, getReader, onStarlinkIp };
 
     // "web.request" not "http.request" — the latter collides with dd-trace's
     // auto-instrumented outbound fetch spans. `type: web` marks it service-entry.
@@ -1938,7 +1974,8 @@ export function createApp(db: Database): App {
         span.setTag("http.route", route);
         span.setTag("resource.name", `${req.method} ${route}`);
         span.setTag("tenant", tenantScope(tenant));
-        span.setTag("http.client_ip", clientIp(req));
+        span.setTag("http.client_ip", ip);
+        if (onStarlinkIp) span.setTag("starlink_ip", true);
         const ua = req.headers.get("user-agent");
         if (ua) span.setTag("http.useragent", ua);
 

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -13,11 +13,15 @@ export { createReaderFactory };
 export interface RequestContext {
   req: Request;
   url: URL;
+  /** Server-observed client IP (cf-connecting-ip). */
+  ip: string;
   site: SiteConfig;
   tenant: Tenant;
   reader: ScopedReader;
   /** Mint a reader for a specific airline (hub endpoints that detect airline from flight-number prefix). */
   getReader: (scope: Scope) => ScopedReader;
+  /** Server-observed: `ip` is in the Starlink geofeed. */
+  onStarlinkIp: boolean;
 }
 
 export function tenantScope(tenant: Tenant): Scope {

--- a/src/server/passenger-detect.ts
+++ b/src/server/passenger-detect.ts
@@ -1,0 +1,143 @@
+/**
+ * Passenger-verify dark launch. Detects whether a request's cf-connecting-ip
+ * is in Starlink's geofeed, and for matching visitors injects a no-UI probe
+ * that beacons whether onboard.united.com's flight API resolves from their
+ * browser. Everything client-sent is treated as untrusted claim; the only
+ * server-observed signal is the IP. PASSENGER_VERIFY env: "off" disables
+ * everything, "on" would surface UI (not built yet), default = probe only.
+ */
+
+import { createHash } from "node:crypto";
+import {
+  buildAirlineFlightNumberVariants,
+  detectMarketingCarrier,
+  ensureAirlinePrefix,
+} from "../airlines/flight-number";
+import { looksLikeValidTailNumber } from "../airlines/registry";
+import {
+  getStarlinkPrefixes,
+  isFlightAirborne,
+  passengerReportSeenRecently,
+  recordPassengerReport,
+} from "../database/database";
+import type { Database } from "../database/reader";
+import { COUNTERS, metrics, normalizeAirlineTag, normalizeProbeOutcome } from "../observability";
+import { PROBE_CONNECT_ORIGINS } from "../utils/constants";
+import { PrefixSet, dedupePrefix } from "../utils/ip-prefix";
+import { info } from "../utils/logger";
+
+export const PASSENGER_VERIFY_MODE = process.env.PASSENGER_VERIFY ?? "probe";
+export const passengerVerifyEnabled = PASSENGER_VERIFY_MODE !== "off";
+const DEDUPE_WINDOW_SEC = 6 * 3600;
+const RELOAD_TTL_MS = 10 * 60 * 1000;
+
+export class StarlinkIpDetector {
+  private prefixes: PrefixSet;
+  private loadedAt = Date.now();
+
+  constructor(private readonly db: Database) {
+    this.prefixes = new PrefixSet(getStarlinkPrefixes(db));
+  }
+
+  /** Self-refreshes from the table at most once per RELOAD_TTL — the daily
+   * geofeed job has no back-channel into the app, so this is how new prefixes
+   * land in the matcher without exposing a reload hook on App. */
+  match(ip: string): boolean {
+    if (Date.now() - this.loadedAt > RELOAD_TTL_MS) {
+      this.prefixes = new PrefixSet(getStarlinkPrefixes(this.db));
+      this.loadedAt = Date.now();
+      info(`passenger-detect: reloaded ${this.prefixes.size} Starlink prefixes`);
+    }
+    return this.prefixes.contains(ip);
+  }
+}
+
+// Single-fire send() guard so a >4s response can't double-beacon (timeout
+// then onboard_api would land in different dedupe buckets).
+export const PROBE_SNIPPET = `<script>(function(){try{
+var done=0,send=function(o){if(done)return;done=1;try{navigator.sendBeacon&&navigator.sendBeacon("/api/passenger-probe",JSON.stringify(o))}catch(e){}};
+setTimeout(function(){send({source:"probe",outcome:"timeout"})},4000);
+fetch("${PROBE_CONNECT_ORIGINS[0]}/api/auth/token",{credentials:"omit",cache:"no-store"})
+ .then(function(r){return r.ok?r.json().then(function(d){return{ok:1,d:d}}):{ok:0,status:r.status}})
+ .then(function(r){
+   if(r.ok&&r.d&&r.d.flightInfo){var f=r.d.flightInfo;
+     send({source:"probe",outcome:"onboard_api",claimed_flight:(f.airlineCode||"")+(f.flightNumber||""),claimed_tail:f.tailNumber||null,claimed_date:f.flightDate||null});
+   }else{send({source:"probe",outcome:r.ok?"onboard_noflight":"onboard_http_"+r.status});}
+ })
+ .catch(function(e){var m=String(e&&e.message||e);
+   send({source:"probe",outcome:m.indexOf("CSP")>=0||m.indexOf("Content Security")>=0?"csp_blocked":m.indexOf("CORS")>=0||m.indexOf("cross-origin")>=0?"cors_blocked":"fetch_error"});
+ });
+}catch(e){}})();</script>`;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface ProbeBody {
+  source?: unknown;
+  outcome?: unknown;
+  claimed_flight?: unknown;
+  claimed_tail?: unknown;
+  claimed_date?: unknown;
+  router_id?: unknown;
+}
+
+function clampString(v: unknown, max: number, re?: RegExp): string | null {
+  if (typeof v !== "string") return null;
+  const s = v.trim().slice(0, max);
+  if (s === "") return null;
+  return re && !re.test(s) ? null : s;
+}
+
+export function handlePassengerProbe(
+  db: Database,
+  ip: string,
+  inGeofeed: boolean,
+  userAgent: string | null,
+  body: ProbeBody
+): "duplicate" | "stored" {
+  const ipPrefix = dedupePrefix(ip) ?? ip;
+
+  const source = clampString(body.source, 16, /^(probe|manual)$/) ?? "probe";
+  const outcome = normalizeProbeOutcome(clampString(body.outcome, 32));
+  const claimedFlightRaw = clampString(body.claimed_flight, 8)?.toUpperCase() ?? null;
+  const carrier = claimedFlightRaw ? detectMarketingCarrier(claimedFlightRaw) : null;
+  const claimedFlight = carrier ? ensureAirlinePrefix(carrier, claimedFlightRaw!) : null;
+  const claimedTailRaw = clampString(body.claimed_tail, 10);
+  const claimedTail =
+    claimedTailRaw && looksLikeValidTailNumber(claimedTailRaw.toUpperCase())
+      ? claimedTailRaw.toUpperCase()
+      : null;
+  const claimedDate = clampString(body.claimed_date, 10, DATE_RE);
+  const routerId = clampString(body.router_id, 64);
+  const uaHash = userAgent
+    ? createHash("sha256").update(userAgent).digest("hex").slice(0, 16)
+    : null;
+
+  // Dedupe stops one device (or one fabricated curl loop) from stuffing the
+  // table; rate-limiting per IP is already applied by the /api/* meter.
+  if (passengerReportSeenRecently(db, ipPrefix, claimedTail, DEDUPE_WINDOW_SEC)) {
+    return "duplicate";
+  }
+
+  metrics.increment(COUNTERS.PASSENGER_PROBE, {
+    outcome,
+    in_geofeed: inGeofeed ? "1" : "0",
+    airline: normalizeAirlineTag(carrier?.code ?? null),
+  });
+
+  const variants =
+    carrier && claimedFlight ? buildAirlineFlightNumberVariants(carrier, claimedFlight) : [];
+  recordPassengerReport(db, {
+    ip,
+    ip_prefix: ipPrefix,
+    in_geofeed: inGeofeed,
+    source,
+    outcome,
+    claimed_flight: claimedFlight,
+    claimed_tail: claimedTail,
+    claimed_date: claimedDate,
+    router_id: routerId,
+    ua_hash: uaHash,
+    airborne_match: inGeofeed && isFlightAirborne(db, variants),
+  });
+  return "stored";
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -59,10 +59,16 @@ export function pickVerifiableFlight<
   );
 }
 
+// Hosts the passenger-verify probe fetch reaches; also imported by the snippet
+// builder so the CSP allowlist and the script URL can never drift apart. Only
+// added to connect-src when the feature isn't disabled.
+export const PROBE_CONNECT_ORIGINS = ["https://onboard.united.com"] as const;
+const probeOrigins = process.env.PASSENGER_VERIFY === "off" ? [] : PROBE_CONNECT_ORIGINS;
+
 // Security headers
 const { scriptOrigins: ANALYTICS_SCRIPT_ORIGINS, connectOrigins: ANALYTICS_CONNECT_ORIGINS } =
   analyticsOrigins();
-const CONNECT_SRC = ["'self'", ...ANALYTICS_CONNECT_ORIGINS].join(" ");
+const CONNECT_SRC = ["'self'", ...probeOrigins, ...ANALYTICS_CONNECT_ORIGINS].join(" ");
 const SCRIPT_SRC = ["'self'", "'unsafe-inline'", "https://unpkg.com", ...ANALYTICS_SCRIPT_ORIGINS]
   .filter(Boolean)
   .join(" ");

--- a/src/utils/ip-prefix.ts
+++ b/src/utils/ip-prefix.ts
@@ -1,0 +1,129 @@
+/**
+ * CIDR prefix set with O(log n) containment lookup. v4 and v6 are both held as
+ * bigint [lo, hi] ranges so a single binary search covers both. Built once from
+ * the daily Starlink geofeed (~4k rows) and queried per HTML request.
+ */
+
+export interface ParsedPrefix {
+  cidr: string;
+  lo: bigint;
+  hi: bigint;
+  v6: boolean;
+}
+
+function parseV4(addr: string): bigint | null {
+  const m = addr.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return null;
+  let n = 0n;
+  for (let i = 1; i <= 4; i++) {
+    const octet = Number(m[i]);
+    if (octet > 255) return null;
+    n = (n << 8n) | BigInt(octet);
+  }
+  return n;
+}
+
+function parseV6(addr: string): bigint | null {
+  // Strip a trailing zone index (fe80::1%en0); reject embedded-v4 forms.
+  const a = addr.replace(/%.+$/, "");
+  if (!/^[0-9a-fA-F:]+$/.test(a) || a.includes(":::")) return null;
+  const split = a.split("::");
+  if (split.length > 2) return null;
+  const head = split[0] === "" ? [] : split[0].split(":");
+  const tail = split.length === 2 ? (split[1] === "" ? [] : split[1].split(":")) : [];
+  const fill = 8 - head.length - tail.length;
+  if (split.length === 2 ? fill < 0 : head.length !== 8) return null;
+  const groups = split.length === 2 ? [...head, ...Array(fill).fill("0"), ...tail] : head;
+  let n = 0n;
+  for (const g of groups) {
+    if (g.length === 0 || g.length > 4) return null;
+    const v = Number.parseInt(g, 16);
+    if (Number.isNaN(v)) return null;
+    n = (n << 16n) | BigInt(v);
+  }
+  return n;
+}
+
+export function ipToBigint(addr: string): { value: bigint; v6: boolean } | null {
+  if (addr.includes(":")) {
+    const v = parseV6(addr);
+    return v === null ? null : { value: v, v6: true };
+  }
+  const v = parseV4(addr);
+  return v === null ? null : { value: v, v6: false };
+}
+
+export function parseCidr(cidr: string): ParsedPrefix | null {
+  const m = cidr.match(/^(.+)\/(\d{1,3})$/);
+  if (!m) return null;
+  const ip = ipToBigint(m[1]);
+  const bits = Number(m[2]);
+  if (!ip) return null;
+  const total = ip.v6 ? 128 : 32;
+  // /0 is a valid CIDR but never a sane geofeed entry — fail closed.
+  if (bits < 1 || bits > total) return null;
+  const hostBits = BigInt(total - bits);
+  const lo = (ip.value >> hostBits) << hostBits;
+  const hi = lo | ((1n << hostBits) - 1n);
+  return { cidr, lo, hi, v6: ip.v6 };
+}
+
+export class PrefixSet {
+  private readonly v4: ParsedPrefix[];
+  private readonly v6: ParsedPrefix[];
+
+  constructor(prefixes: readonly ParsedPrefix[]) {
+    const sort = (a: ParsedPrefix, b: ParsedPrefix) => (a.lo < b.lo ? -1 : a.lo > b.lo ? 1 : 0);
+    // Coalesce overlapping/nested ranges so the binary search's "largest lo ≤ ip"
+    // invariant is total — RFC 8805 permits overlaps and a nested /24 would
+    // otherwise shadow its enclosing /16 for everything past the /24's hi.
+    const coalesce = (sorted: ParsedPrefix[]): ParsedPrefix[] => {
+      const out: ParsedPrefix[] = [];
+      for (const p of sorted) {
+        const prev = out.at(-1);
+        if (prev && p.lo <= prev.hi + 1n) {
+          if (p.hi > prev.hi) prev.hi = p.hi;
+        } else {
+          out.push({ ...p });
+        }
+      }
+      return out;
+    };
+    this.v4 = coalesce(prefixes.filter((p) => !p.v6).sort(sort));
+    this.v6 = coalesce(prefixes.filter((p) => p.v6).sort(sort));
+  }
+
+  get size(): number {
+    return this.v4.length + this.v6.length;
+  }
+
+  contains(addr: string): boolean {
+    const ip = ipToBigint(addr);
+    if (!ip) return false;
+    const ranges = ip.v6 ? this.v6 : this.v4;
+    // Largest lo <= ip.value, then check hi. Ranges are pre-coalesced so this
+    // single check is total.
+    let lo = 0;
+    let hi = ranges.length - 1;
+    let found = -1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      if (ranges[mid].lo <= ip.value) {
+        found = mid;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return found >= 0 && ip.value <= ranges[found].hi;
+  }
+}
+
+/** Aggregation prefix the report-dedupe key uses (a plane's clients share it).
+ * Opaque key, not a real CIDR string — don't parse it back. */
+export function dedupePrefix(addr: string): string | null {
+  const ip = ipToBigint(addr);
+  if (!ip) return null;
+  const hostBits = ip.v6 ? 72n : 8n;
+  return `${ip.v6 ? "v6" : "v4"}:${(ip.value >> hostBits).toString(16)}`;
+}

--- a/tests/isolation.test.ts
+++ b/tests/isolation.test.ts
@@ -700,6 +700,9 @@ describe("route-table coverage", () => {
         "/api/predict-flight",
         "/api/check-any-flight",
         "/api/compare-route",
+        // Write-only beacon; reads upcoming_flights cross-airline by design
+        // (only to set a stored boolean; nothing leaves the 202 body).
+        "/api/passenger-probe",
       ])
     );
     // /api/plan-route + /api/predict-flight are exercised separately above —

--- a/tests/passenger-detect.test.ts
+++ b/tests/passenger-detect.test.ts
@@ -1,0 +1,153 @@
+// CIDR matching, geofeed parsing, and the passenger-probe trust model
+// (server records its own IP/geofeed verdict, never trusts client claims).
+
+import { describe, expect, test } from "bun:test";
+import { replaceStarlinkPrefixes } from "../src/database/database";
+import { parseGeofeed, runGeofeedSync } from "../src/scripts/starlink-geofeed";
+import {
+  PROBE_SNIPPET,
+  StarlinkIpDetector,
+  handlePassengerProbe,
+} from "../src/server/passenger-detect";
+import { PrefixSet, dedupePrefix, ipToBigint, parseCidr } from "../src/utils/ip-prefix";
+import { makeSyntheticDb } from "./helpers";
+
+// The two prefixes observed live on UA2019 / N73275 (2026-06-13).
+const UA2019_V4 = "74.244.242.0/24";
+const UA2019_V6 = "2605:59ca:8010::/45";
+const ONBOARD_IP_V4 = "74.244.242.158";
+const ONBOARD_IP_V6 = "2605:59ca:8015:b40:f410:c136:b5cc:9db0";
+
+const FEED = `# RFC 8805 — geofeed
+${UA2019_V4},US,US-IL,Chicago,
+${UA2019_V6},US,US-IL,Chicago,
+9.246.0.0/24,FR,FR-IDF,Paris,
+2a0d:3340::/32,DE,,Frankfurt,
+not-a-cidr,XX,,,
+`;
+
+describe("ip-prefix", () => {
+  test("v4 + v6 round-trip and CIDR bounds", () => {
+    expect(ipToBigint("74.244.242.158")?.value).toBe(0x4af4f29en);
+    expect(ipToBigint("::1")?.value).toBe(1n);
+    expect(ipToBigint("999.0.0.1")).toBeNull();
+    expect(ipToBigint("2605::1::2")).toBeNull();
+    const p = parseCidr(UA2019_V6)!;
+    expect(p.v6).toBe(true);
+    expect(p.hi - p.lo).toBe((1n << 83n) - 1n);
+  });
+
+  test("malformed input returns null instead of throwing", () => {
+    // attacker-set XFF must never RangeError
+    expect(ipToBigint("::1:2:3:4:5:6:7:8:9")).toBeNull();
+    expect(ipToBigint("1:2:3:4:5:6:7:8:9")).toBeNull();
+    // empty/zero mask is rejected, not match-everything
+    expect(parseCidr("1.2.3.4/")).toBeNull();
+    expect(parseCidr("1.2.3.4/0")).toBeNull();
+    expect(parseCidr("2001::/0")).toBeNull();
+    expect(parseCidr("1.2.3.4/33")).toBeNull();
+  });
+
+  test("PrefixSet matches inside, rejects outside, coalesces overlaps", () => {
+    const set = new PrefixSet(parseGeofeed(FEED));
+    expect(set.contains(ONBOARD_IP_V4)).toBe(true);
+    expect(set.contains(ONBOARD_IP_V6)).toBe(true);
+    expect(set.contains("8.8.8.8")).toBe(false);
+    expect(set.contains("2605:59ca:8020::1")).toBe(false);
+    expect(set.contains("garbage")).toBe(false);
+    // a nested /24 must not shadow its enclosing /16
+    const nested = new PrefixSet([parseCidr("10.0.0.0/16")!, parseCidr("10.0.5.0/24")!]);
+    expect(nested.contains("10.0.6.1")).toBe(true);
+    expect(nested.contains("10.1.0.1")).toBe(false);
+    // /56 dedupe key collapses one plane's clients to a single bucket.
+    expect(dedupePrefix(ONBOARD_IP_V6)).toBe(dedupePrefix("2605:59ca:8015:b40::abcd"));
+  });
+});
+
+describe("geofeed sync", () => {
+  test("stores parsed prefixes; refuses to blank the table on a thin body", async () => {
+    const db = makeSyntheticDb();
+    const big = Array.from({ length: 200 }, (_, i) => `10.${i >> 8}.${i & 255}.0/24,,,,`).join(
+      "\n"
+    );
+    const ok = await runGeofeedSync(db, async () => `${FEED}\n${big}`);
+    expect(ok.outcome).toBe("success");
+    expect(ok.prefixes).toBeGreaterThan(200);
+
+    const detector = new StarlinkIpDetector(db);
+    expect(detector.match(ONBOARD_IP_V4)).toBe(true);
+
+    // A short body (CDN error page, partial fetch) keeps yesterday's table.
+    const thin = await runGeofeedSync(db, async () => "9.0.0.0/24,,,\n");
+    expect(thin.outcome).toBe("error");
+    expect(detector.match(ONBOARD_IP_V4)).toBe(true);
+  });
+});
+
+describe("passenger-probe trust model", () => {
+  function seeded() {
+    const db = makeSyntheticDb();
+    replaceStarlinkPrefixes(db, parseGeofeed(FEED));
+    return { db, detect: new StarlinkIpDetector(db) };
+  }
+
+  test("records server-seen IP/geofeed verdict and normalizes claims", () => {
+    const { db, detect } = seeded();
+    const result = handlePassengerProbe(db, ONBOARD_IP_V4, detect.match(ONBOARD_IP_V4), "Mozilla", {
+      source: "probe",
+      outcome: "onboard_api",
+      claimed_flight: "UAL2019",
+      claimed_tail: "n73275",
+      claimed_date: "2026-06-13",
+    });
+    expect(result).toBe("stored");
+    const row = db.query("SELECT * FROM passenger_reports").get() as Record<string, unknown>;
+    expect(row.in_geofeed).toBe(1);
+    expect(row.claimed_flight).toBe("UA2019");
+    expect(row.claimed_tail).toBe("N73275");
+    expect(row.ip).toBe(ONBOARD_IP_V4);
+  });
+
+  test("off-geofeed forged report is stored with in_geofeed=0", () => {
+    const { db, detect } = seeded();
+    handlePassengerProbe(db, "8.8.8.8", detect.match("8.8.8.8"), "curl", {
+      outcome: "onboard_api",
+      claimed_flight: "UA2019",
+      claimed_tail: "N73275",
+    });
+    const row = db
+      .query("SELECT in_geofeed, airborne_match FROM passenger_reports")
+      .get() as Record<string, unknown>;
+    expect(row.in_geofeed).toBe(0);
+    expect(row.airborne_match).toBe(0);
+  });
+
+  test("dedupes by /56 prefix + tail within the window", () => {
+    const { db } = seeded();
+    const body = { source: "probe", outcome: "onboard_api", claimed_tail: "N73275" };
+    handlePassengerProbe(db, ONBOARD_IP_V6, true, null, body);
+    const dup = handlePassengerProbe(db, "2605:59ca:8015:b40::1", true, null, body);
+    expect(dup).toBe("duplicate");
+    expect(db.query("SELECT COUNT(*) AS n FROM passenger_reports").get()).toEqual({ n: 1 });
+  });
+
+  test("rejects malformed claims by clamping to null, not erroring", () => {
+    const { db } = seeded();
+    handlePassengerProbe(db, ONBOARD_IP_V4, true, null, {
+      outcome: "Made; DROP--",
+      claimed_flight: "<script>alert(1)</script>",
+      claimed_tail: "DROP TABLE",
+      claimed_date: "yesterday",
+    });
+    const row = db.query("SELECT * FROM passenger_reports").get() as Record<string, unknown>;
+    expect(row.claimed_flight).toBeNull();
+    expect(row.claimed_tail).toBeNull();
+    expect(row.claimed_date).toBeNull();
+    expect(row.outcome).toBe("other");
+  });
+
+  test("probe snippet beacons to /api/passenger-probe and the CSP-allowed origin", () => {
+    expect(PROBE_SNIPPET).toContain("/api/passenger-probe");
+    expect(PROBE_SNIPPET).toContain("onboard.united.com");
+  });
+});


### PR DESCRIPTION
We can't tell when a visitor is on Starlink in-flight wifi, so there's no way to ask them to confirm a tail's wifi status — the only signal that beats every upstream lag. This ships the detection foundation with zero visible UI so we can measure Starlink-IP traffic and learn whether onboard.united.com's flight API is reachable from the browser before building the modal.

- Daily `starlink_geofeed` job fetches Starlink's RFC 8805 feed (~3.8k prefixes) into `starlink_prefixes`; per-request `StarlinkIpDetector` checks `cf-connecting-ip` against a coalesced bigint range set
- For UA-tenant visitors whose IP matches, an inline no-UI script tries `onboard.united.com/api/auth/token` and `sendBeacon`s the outcome to `/api/passenger-probe` — answers the CORS question with real in-flight traffic
- `passenger_reports` table stores server-seen `{ip, in_geofeed, claimed_flight, claimed_tail, airborne_match}` with /56 prefix dedupe; everything client-sent is treated as untrusted claim and clamped
- `passenger.detect` and `passenger.probe{outcome}` counters; `PASSENGER_VERIFY=off` disables the detector, job, snippet, and CSP host
- Verified live: 3,820 prefixes; the UA2019/N73275 capture IPs match; attacker XFF can't 500; probe gated to UA tenant only