### PR TITLE
Add visible passenger-confirm banner for Starlink-IP visitors

### DIFF
--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -11,6 +11,7 @@ import type {
   RecentInstall,
 } from "../types";
 import { HeaderStatStrip } from "./atoms";
+import { PassengerBanner } from "./passenger-banner";
 
 // Reusable FAQ accordion item — eliminates ~30 lines of boilerplate per question
 function FaqItem({ q, children }: { q: string; children: React.ReactNode }) {
@@ -66,6 +67,7 @@ interface PageProps {
   recentInstalls?: RecentInstall[];
   flightsByTail?: Record<string, Flight[]>;
   airportDepartures?: AirportDepartures;
+  showPassengerBanner?: boolean;
 }
 
 // Squarified treemap layout (Bruls et al.) — greedily add items to the current
@@ -270,6 +272,7 @@ export default function Page({
   recentInstalls,
   flightsByTail = {},
   airportDepartures,
+  showPassengerBanner = false,
 }: PageProps) {
   // Apply date overrides to the aircraft data
   const applyDateOverrides = (data: Aircraft[]): Aircraft[] => {
@@ -445,6 +448,8 @@ export default function Page({
     <div className="w-full mx-auto px-4 sm:px-6 md:px-8 bg-base min-h-screen flex flex-col relative">
       {/* Subtle grid background */}
       <div className="absolute inset-0 grid-pattern opacity-50 pointer-events-none" />
+
+      {showPassengerBanner && <PassengerBanner />}
 
       <header className="relative py-5 sm:py-6 text-center mb-2">
         <h1 className="font-display text-3xl sm:text-4xl md:text-5xl font-bold text-primary mb-1 tracking-tight">

--- a/src/components/passenger-banner.tsx
+++ b/src/components/passenger-banner.tsx
@@ -1,0 +1,78 @@
+// Only ever rendered when the server already saw a Starlink-geofeed IP on the
+// UA tenant — the gate lives in passenger-detect.ts, not here.
+
+export function PassengerBanner() {
+  return (
+    <>
+      <div id="psgr-banner" className="relative max-w-3xl mx-auto w-full mb-4 mt-4 hidden">
+        <div className="bg-surface-elevated border border-accent/40 rounded-lg p-4 sm:p-5 shadow-lg shadow-accent/10">
+          <button
+            id="psgr-dismiss"
+            type="button"
+            aria-label="Dismiss"
+            className="absolute top-2 right-3 text-muted hover:text-secondary text-lg leading-none"
+          >
+            ×
+          </button>
+          <div className="text-[10px] font-mono text-accent uppercase tracking-wider mb-1">
+            Detected · Starlink wifi
+          </div>
+          <p className="text-sm text-secondary mb-3 pr-6">
+            You look like you're connected through Starlink. If you're on a flight right now,
+            telling us the flight number helps confirm this aircraft's wifi for other travelers.
+          </p>
+          <form id="psgr-form" noValidate className="flex flex-col sm:flex-row gap-2">
+            <input
+              type="text"
+              name="flight_number"
+              aria-label="Flight number"
+              placeholder="e.g. UA2019"
+              autoComplete="off"
+              required
+              className="flex-1 font-mono text-sm px-3 py-2 bg-surface border border-subtle rounded text-primary placeholder-muted focus:outline-none focus:border-accent"
+            />
+            <button
+              type="submit"
+              className="font-mono text-sm px-4 py-2 bg-accent/20 border border-accent rounded text-accent hover:bg-accent/30 transition-colors"
+            >
+              Confirm flight
+            </button>
+          </form>
+          <output
+            id="psgr-thanks"
+            className="hidden text-xs font-mono text-[var(--color-success)] mt-2"
+          >
+            ✓ Thanks — recorded.
+          </output>
+          <p className="text-[10px] text-muted mt-2">
+            We only store the flight number and the fact your IP is in Starlink's published range.
+          </p>
+        </div>
+      </div>
+      <script
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: static SSR-only inline handler
+        dangerouslySetInnerHTML={{ __html: PSGR_BANNER_SCRIPT }}
+      />
+    </>
+  );
+}
+
+// localStorage writes are individually try-wrapped: legacy Safari private mode /
+// quota-full throws on setItem but not getItem, and that must not block the UI.
+const PSGR_BANNER_SCRIPT = `(function(){try{
+var KEY="psgr_banner_v1",ls=function(v){try{localStorage.setItem(KEY,v)}catch(e){}};
+var b=document.getElementById("psgr-banner");
+if(!b||localStorage.getItem(KEY))return;
+b.classList.remove("hidden");
+document.getElementById("psgr-dismiss").onclick=function(){b.classList.add("hidden");ls("dismissed")};
+document.getElementById("psgr-form").addEventListener("submit",function(e){
+  e.preventDefault();
+  var v=(e.target.flight_number.value||"").toUpperCase().replace(/\\s+/g,"");
+  if(!/^[A-Z]{2,3}\\d{1,4}$/.test(v))return;
+  try{navigator.sendBeacon&&navigator.sendBeacon("/api/passenger-probe",JSON.stringify({source:"manual",outcome:"manual_report",claimed_flight:v}))}catch(x){}
+  document.getElementById("psgr-thanks").classList.remove("hidden");
+  e.target.querySelector("button").disabled=true;
+  ls("sent:"+v);
+  setTimeout(function(){b.classList.add("hidden")},2500);
+});
+}catch(e){}})();`;

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -108,6 +108,7 @@ const PROBE_OUTCOMES = new Set([
   "csp_blocked",
   "fetch_error",
   "timeout",
+  "manual_report",
   "unknown",
 ]);
 export function normalizeProbeOutcome(raw: string | null | undefined): string {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -96,6 +96,7 @@ import {
   PROBE_SNIPPET,
   StarlinkIpDetector,
   handlePassengerProbe,
+  isPassengerVerifyAudience,
   passengerVerifyEnabled,
 } from "./passenger-detect";
 
@@ -1400,7 +1401,9 @@ function buildBaseTemplateVars(
     analyticsSnippet: analyticsSnippet(site),
     headSnippet: site.headSnippet ?? "",
     // Dark-launch probe is UA-only; the onboard portal URL is United's.
-    passengerProbeSnippet: ctx.onStarlinkIp && site.scope === "UA" ? PROBE_SNIPPET : "",
+    passengerProbeSnippet: isPassengerVerifyAudience(ctx.onStarlinkIp, site.scope)
+      ? PROBE_SNIPPET
+      : "",
     webSiteJsonLd: siteWebJsonLd(site, brandVars.siteDescription),
     webPageJsonLd: sitePageJsonLd(site, {
       path: canonicalPath,
@@ -1638,6 +1641,7 @@ const homePage: Handler = async (ctx) => {
       recentInstalls: isHub ? reader.getRecentInstalls(15, 5) : undefined,
       flightsByTail,
       airportDepartures: reader.getAirportDepartures(),
+      showPassengerBanner: isPassengerVerifyAudience(ctx.onStarlinkIp, site.scope),
     })
   );
 

--- a/src/server/passenger-detect.ts
+++ b/src/server/passenger-detect.ts
@@ -28,6 +28,11 @@ import { info } from "../utils/logger";
 
 export const PASSENGER_VERIFY_MODE = process.env.PASSENGER_VERIFY ?? "probe";
 export const passengerVerifyEnabled = PASSENGER_VERIFY_MODE !== "off";
+
+/** Single audience gate for both the auto-probe snippet and the visible banner. */
+export function isPassengerVerifyAudience(onStarlinkIp: boolean, siteScope: string): boolean {
+  return passengerVerifyEnabled && onStarlinkIp && siteScope === "UA";
+}
 const DEDUPE_WINDOW_SEC = 6 * 3600;
 const RELOAD_TTL_MS = 10 * 60 * 1000;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -104,6 +104,9 @@ export const SECURITY_HEADERS = {
   html: {
     ...BASE_RESPONSE_HEADERS,
     "Content-Type": "text/html",
+    // Rendered HTML varies by client IP (passenger banner/probe) — never let
+    // an edge cache serve one visitor's render to another.
+    "Cache-Control": "private, no-store",
     "Content-Security-Policy": `default-src 'self' https://unpkg.com; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;`,
   },
   notFound: {


### PR DESCRIPTION
The dark-launch probe (#58) showed ~12 in-flight Starlink-IP visitors/day on the UA site, all hitting `fetch_error` on the onboard.united.com cross-origin call — auto-fill won't work, so we ask. This adds the visible "looks like you're on Starlink — confirm your flight" banner above the homepage hero for that audience only.

- Gated by `isPassengerVerifyAudience` (server-seen geofeed IP + UA tenant) — same predicate as the auto-probe; never renders for anyone else
- SSR + inline vanilla JS: localStorage one-shot (dismiss or submit), `sendBeacon` to the existing `/api/passenger-probe` with `{source:"manual", outcome:"manual_report", claimed_flight}`
- Endpoint already treats every field as untrusted, normalizes the flight number, dedupes by /56 prefix; `manual_report` added to the outcome enum
- HTML responses now carry `Cache-Control: private, no-store` since the page varies by client IP (CF was already DYNAMIC, this makes it explicit)
- a11y: labeled input, `<output>` for the live confirmation, dismiss has aria-label
