### PR TITLE
Fix passenger-probe dedupe swallowing manual reports; no-cors probe

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -137,6 +137,7 @@ if (JOBS_ENABLED) {
     startJob({
       name: "prune_crash_rows",
       intervalMs: 24 * 3600 * 1000,
+      initialDelayMs: 60 * 60 * 1000,
       run: () => {
         const n = pruneCrashRows(db);
         if (n > 0) info(`Pruned ${n} stale crash rows from verification log`);

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -3338,10 +3338,13 @@ export function isFlightAirborne(
   );
 }
 
-/** Per-prefix per-tail dedupe window — limits ballot-stuffing within one flight. */
+/** Per-(prefix, source, tail) dedupe window — limits ballot-stuffing within
+ * one flight without letting the page-load probe row swallow a later manual
+ * submission from the same client. */
 export function passengerReportSeenRecently(
   db: Database,
   ipPrefix: string,
+  source: string,
   tail: string | null,
   windowSec: number
 ): boolean {
@@ -3349,10 +3352,10 @@ export function passengerReportSeenRecently(
   const row = db
     .query(
       `SELECT 1 FROM passenger_reports
-       WHERE ip_prefix = ? AND reported_at > ? AND claimed_tail IS ?
+       WHERE ip_prefix = ? AND reported_at > ? AND source = ? AND claimed_tail IS ?
        LIMIT 1`
     )
-    .get(ipPrefix, since, tail);
+    .get(ipPrefix, since, source, tail);
   return row !== null;
 }
 

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -22,7 +22,7 @@
  *   kind:            missing_from_fleet | inactive_in_fleet                 (2)
  *   status:          success | error | rate_limited | timeout | killed |
  *                    exit_error | parse_error | spawn_error | partial |
- *                    aborted | scrape_error                          (~11)
+ *                    aborted | scrape_error | noop                   (~12)
  *   http_status:     upstream HTTP status code on vendor.request error/
  *                    rate_limited emits (fr24 only)                  (~10)
  *   result:          success | error | aircraft_mismatch | tail_unknown  (4)
@@ -102,20 +102,15 @@ export function normalizeOpCarrier(raw: string | null | undefined): string {
 
 // passenger.probe outcome is client-supplied — closed enum or it's a cardinality bomb.
 const PROBE_OUTCOMES = new Set([
-  "onboard_api",
-  "onboard_noflight",
-  "cors_blocked",
-  "csp_blocked",
-  "fetch_error",
+  "onboard_reachable",
+  "onboard_unreachable",
   "timeout",
   "manual_report",
   "unknown",
 ]);
 export function normalizeProbeOutcome(raw: string | null | undefined): string {
   if (!raw) return "unknown";
-  if (PROBE_OUTCOMES.has(raw)) return raw;
-  if (/^onboard_http_\d{3}$/.test(raw)) return raw;
-  return "other";
+  return PROBE_OUTCOMES.has(raw) ? raw : "other";
 }
 
 // Bounded user-agent classification (≤6 buckets, never the raw UA).
@@ -158,7 +153,7 @@ export function bucketDaysOut(days: number): string {
  */
 export const COUNTERS = {
   // Scraper events
-  SCRAPER_SYNC: "scraper.sync", // tags: source, airline, status (success|partial|aborted|error)
+  SCRAPER_SYNC: "scraper.sync", // tags: source, airline, status (success|partial|aborted|error|noop)
   PLANES_DISCOVERED: "planes.discovered", // tags: source, airline
 
   // New Starlink installation detected on an aircraft

--- a/src/scripts/bts-sync.ts
+++ b/src/scripts/bts-sync.ts
@@ -256,6 +256,13 @@ export async function runBtsSync(db: Database, deps: BtsSyncDeps = {}): Promise<
         span.setTag("error", true);
         return { outcome: "error", month: null, rows: 0 };
       }
+      // Emit a noop counter so a dead job is distinguishable from "month not
+      // published yet" — without it both look like zero scraper.sync events.
+      metrics.increment(COUNTERS.SCRAPER_SYNC, {
+        source: "bts",
+        airline: airlineTag,
+        status: "noop",
+      });
       span.setTag("result", "noop");
       return { outcome: "noop", month: null, rows: 0 };
     },

--- a/src/server/passenger-detect.ts
+++ b/src/server/passenger-detect.ts
@@ -57,21 +57,14 @@ export class StarlinkIpDetector {
   }
 }
 
-// Single-fire send() guard so a >4s response can't double-beacon (timeout
-// then onboard_api would land in different dedupe buckets).
+// Browsers report a CORS reject as a bare TypeError, so the only readable
+// signal is opaque resolve vs reject — that's all we beacon.
 export const PROBE_SNIPPET = `<script>(function(){try{
 var done=0,send=function(o){if(done)return;done=1;try{navigator.sendBeacon&&navigator.sendBeacon("/api/passenger-probe",JSON.stringify(o))}catch(e){}};
 setTimeout(function(){send({source:"probe",outcome:"timeout"})},4000);
-fetch("${PROBE_CONNECT_ORIGINS[0]}/api/auth/token",{credentials:"omit",cache:"no-store"})
- .then(function(r){return r.ok?r.json().then(function(d){return{ok:1,d:d}}):{ok:0,status:r.status}})
- .then(function(r){
-   if(r.ok&&r.d&&r.d.flightInfo){var f=r.d.flightInfo;
-     send({source:"probe",outcome:"onboard_api",claimed_flight:(f.airlineCode||"")+(f.flightNumber||""),claimed_tail:f.tailNumber||null,claimed_date:f.flightDate||null});
-   }else{send({source:"probe",outcome:r.ok?"onboard_noflight":"onboard_http_"+r.status});}
- })
- .catch(function(e){var m=String(e&&e.message||e);
-   send({source:"probe",outcome:m.indexOf("CSP")>=0||m.indexOf("Content Security")>=0?"csp_blocked":m.indexOf("CORS")>=0||m.indexOf("cross-origin")>=0?"cors_blocked":"fetch_error"});
- });
+fetch("${PROBE_CONNECT_ORIGINS[0]}/api/auth/token",{mode:"no-cors",credentials:"omit",cache:"no-store"})
+ .then(function(){send({source:"probe",outcome:"onboard_reachable"})})
+ .catch(function(){send({source:"probe",outcome:"onboard_unreachable"})});
 }catch(e){}})();</script>`;
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
@@ -117,17 +110,18 @@ export function handlePassengerProbe(
     ? createHash("sha256").update(userAgent).digest("hex").slice(0, 16)
     : null;
 
-  // Dedupe stops one device (or one fabricated curl loop) from stuffing the
-  // table; rate-limiting per IP is already applied by the /api/* meter.
-  if (passengerReportSeenRecently(db, ipPrefix, claimedTail, DEDUPE_WINDOW_SEC)) {
-    return "duplicate";
-  }
-
+  // Metric first so deduped beacons stay visible in DD; the dedupe key
+  // includes source so the auto-probe row can never swallow a manual submit.
   metrics.increment(COUNTERS.PASSENGER_PROBE, {
     outcome,
+    source,
     in_geofeed: inGeofeed ? "1" : "0",
     airline: normalizeAirlineTag(carrier?.code ?? null),
   });
+
+  if (passengerReportSeenRecently(db, ipPrefix, source, claimedTail, DEDUPE_WINDOW_SEC)) {
+    return "duplicate";
+  }
 
   const variants =
     carrier && claimedFlight ? buildAirlineFlightNumberVariants(carrier, claimedFlight) : [];

--- a/tests/passenger-detect.test.ts
+++ b/tests/passenger-detect.test.ts
@@ -122,13 +122,23 @@ describe("passenger-probe trust model", () => {
     expect(row.airborne_match).toBe(0);
   });
 
-  test("dedupes by /56 prefix + tail within the window", () => {
+  test("dedupes by /56 prefix + source + tail; auto-probe never swallows manual", () => {
     const { db } = seeded();
-    const body = { source: "probe", outcome: "onboard_api", claimed_tail: "N73275" };
-    handlePassengerProbe(db, ONBOARD_IP_V6, true, null, body);
-    const dup = handlePassengerProbe(db, "2605:59ca:8015:b40::1", true, null, body);
-    expect(dup).toBe("duplicate");
-    expect(db.query("SELECT COUNT(*) AS n FROM passenger_reports").get()).toEqual({ n: 1 });
+    const probe = { source: "probe", outcome: "onboard_unreachable" };
+    handlePassengerProbe(db, ONBOARD_IP_V6, true, null, probe);
+    expect(handlePassengerProbe(db, "2605:59ca:8015:b40::1", true, null, probe)).toBe("duplicate");
+    // The page-load probe row must NOT dedupe out a manual banner submission
+    // seconds later (both have claimed_tail=null but different source).
+    const manual = handlePassengerProbe(db, ONBOARD_IP_V6, true, null, {
+      source: "manual",
+      outcome: "manual_report",
+      claimed_flight: "UA2019",
+    });
+    expect(manual).toBe("stored");
+    expect(db.query("SELECT source FROM passenger_reports ORDER BY id").all()).toEqual([
+      { source: "probe" },
+      { source: "manual" },
+    ]);
   });
 
   test("rejects malformed claims by clamping to null, not erroring", () => {


### PR DESCRIPTION
The 1-week review found 0/107 manual banner submissions is a code bug, not 0% conversion: the auto-probe fires on page load with `claimed_tail=null`, the manual banner submit also has `claimed_tail=null`, and the dedupe key was `(ip_prefix, claimed_tail IS NULL)` — so every manual beacon hit the probe's row from seconds earlier and was silently dropped before the metric and the insert.

- Dedupe key now includes `source` (bounded to probe|manual) so the auto-probe row can never swallow a later manual submit; metric increment moved above the dedupe early-return so swallowed beacons stay visible
- Onboard probe switched to `mode:'no-cors'` opaque resolve/reject — browsers report a CORS reject as a bare TypeError so the old e.message classifier was unreachable (107/107 fetch_error); outcomes are now `onboard_reachable|onboard_unreachable|timeout`
- `normalizeProbeOutcome` is a closed enum (dropped the `onboard_http_\d{3}` passthrough that became attacker-only series surface with the metric moved above dedupe)
- Hygiene from the same review: bts-sync emits `status:noop` so a dead job is distinguishable from "month not published"; `prune_crash_rows` gets an `initialDelayMs` so the daily redeploy stops skipping it
