### PR TITLE
ADS-B classifier cleanup: non_revenue, low_speed, full-fleet sweep

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -91,6 +91,11 @@ function tableExists(db: Database, tableName: string) {
   return db.query("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(tableName);
 }
 
+function addColumn(db: Database, table: string, column: string, ddl: string): void {
+  if (hasColumn(db, table, column)) return;
+  db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${ddl}`);
+}
+
 export type VerificationSource = "united" | "flightradar24" | "spreadsheet" | "alaska" | "qatar";
 
 export interface VerificationLogEntry {
@@ -455,6 +460,8 @@ export function setupTables(db: Database) {
       CREATE INDEX idx_adsb_obs_at ON adsb_observations(observed_at);
     `);
   }
+  addColumn(db, "adsb_sweeps", "non_revenue", "INTEGER NOT NULL DEFAULT 0");
+  addColumn(db, "adsb_sweeps", "low_speed", "INTEGER NOT NULL DEFAULT 0");
 
   // Starlink RFC 8805 geofeed prefixes — backs isStarlinkIp().
   if (!tableExists(db, "starlink_prefixes")) {
@@ -3457,6 +3464,15 @@ export function getBtsIngestedMonths(db: Database): string[] {
   ).map((r) => r.month);
 }
 
+export function getFleetTailsWithStatus(
+  db: Database,
+  airline: string
+): Array<{ tail_number: string; starlink_status: string }> {
+  return db
+    .query("SELECT tail_number, starlink_status FROM united_fleet WHERE airline = ?")
+    .all(airline) as Array<{ tail_number: string; starlink_status: string }>;
+}
+
 const ADSB_OBSERVATION_RETENTION_DAYS = 7;
 const ADSB_SWEEP_RETENTION_DAYS = 90;
 
@@ -3472,8 +3488,8 @@ export function recordAdsbSweep(
     db.query(`
       INSERT INTO adsb_sweeps
         (swept_at, provider, requests, latency_ms, tails_queried, observed, airborne,
-         matched, mismatched, no_assignment, no_callsign)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         matched, mismatched, no_assignment, no_callsign, non_revenue, low_speed)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       sweep.swept_at,
       sweep.provider,
@@ -3485,7 +3501,9 @@ export function recordAdsbSweep(
       sweep.matched,
       sweep.mismatched,
       sweep.no_assignment,
-      sweep.no_callsign
+      sweep.no_callsign,
+      sweep.non_revenue,
+      sweep.low_speed
     );
     for (const o of observations) {
       db.query(`

--- a/src/scripts/adsb-sweep.ts
+++ b/src/scripts/adsb-sweep.ts
@@ -9,7 +9,7 @@
 
 import type { Database } from "bun:sqlite";
 import { looksLikeValidTailNumber } from "../airlines/registry";
-import { getAllStarlinkPlanes, recordAdsbSweep } from "../database/database";
+import { getFleetTailsWithStatus, recordAdsbSweep } from "../database/database";
 import {
   COUNTERS,
   DISTRIBUTIONS,
@@ -162,14 +162,31 @@ export function callsignMatchesAssignment(
   });
 }
 
-export type ShadowResult = "match" | "mismatch" | "no_assignment" | "no_callsign";
+export type ShadowResult =
+  | "match"
+  | "mismatch"
+  | "no_assignment"
+  | "no_callsign"
+  | "non_revenue"
+  | "low_speed";
+
+// ≥8000 idents are ferry/maintenance/repo across UA + Express operators.
+const NON_REVENUE_MIN_NUM = 8000;
 
 export function classifyObservation(
   aircraft: AdsbAircraft,
   assignedFlights: string[]
 ): { result: ShadowResult; assignedFlight: string | null } {
-  if (!aircraft.callsign || !deriveCallsignFlight(aircraft.callsign)) {
+  // FMS may still show the previous leg's ident through taxi/climb-out.
+  if (aircraft.gs != null && aircraft.gs < 120) {
+    return { result: "low_speed", assignedFlight: null };
+  }
+  const derived = deriveCallsignFlight(aircraft.callsign ?? null);
+  if (!derived) {
     return { result: "no_callsign", assignedFlight: assignedFlights[0] ?? null };
+  }
+  if (derived.num >= NON_REVENUE_MIN_NUM) {
+    return { result: "non_revenue", assignedFlight: null };
   }
   if (assignedFlights.length === 0) {
     return { result: "no_assignment", assignedFlight: null };
@@ -180,9 +197,9 @@ export function classifyObservation(
     : { result: "mismatch", assignedFlight: assignedFlights[0] };
 }
 
-// A flight covers the observation if it's in progress (departed but not yet
-// arrived, with grace) or departs soon — long sectors must stay matchable.
-const ASSIGNMENT_LOOKAHEAD_SEC = 4 * 3600;
+// 1h lookahead (was 4h) — tighter than rotation-slip noise but still covers
+// scheduled-vs-actual departure lag from FR24's stale rows.
+const ASSIGNMENT_LOOKAHEAD_SEC = 3600;
 const ASSIGNMENT_ARRIVAL_GRACE_SEC = 3600;
 
 export interface AdsbShadowResult {
@@ -206,9 +223,12 @@ export async function runAdsbSweepShadow(
         mismatch: 0,
         no_assignment: 0,
         no_callsign: 0,
+        non_revenue: 0,
+        low_speed: 0,
       };
-      const tails = getAllStarlinkPlanes(db, "UA")
-        .map((p) => p.TailNumber)
+      // Full UA fleet — Starlink-only is blind to wrong-yes tail swaps.
+      const tails = getFleetTailsWithStatus(db, "UA")
+        .map((r) => r.tail_number)
         .filter((t) => looksLikeValidTailNumber(t));
       if (tails.length === 0) {
         return { outcome: "success", observed: 0, airborne: 0, counts };
@@ -252,7 +272,7 @@ export async function runAdsbSweepShadow(
         const assignmentRows = db
           .query(
             `SELECT tail_number, flight_number FROM upcoming_flights
-             WHERE departure_time <= ? AND arrival_time >= ?
+             WHERE departure_time <= ? AND arrival_time >= ? AND airline = 'UA'
              ORDER BY ABS(departure_time - ?) ASC`
           )
           .all(now + ASSIGNMENT_LOOKAHEAD_SEC, now - ASSIGNMENT_ARRIVAL_GRACE_SEC, now) as Array<{
@@ -267,7 +287,6 @@ export async function runAdsbSweepShadow(
 
         const observations: Array<Omit<AdsbObservationRecord, "id">> = [];
         for (const ac of aircraft) {
-          // Only airborne aircraft are comparable to a flight assignment.
           let result: ShadowResult | null = null;
           let assignedFlight: string | null = null;
           if (ac.airborne) {
@@ -313,6 +332,8 @@ export async function runAdsbSweepShadow(
             mismatched: counts.mismatch,
             no_assignment: counts.no_assignment,
             no_callsign: counts.no_callsign,
+            non_revenue: counts.non_revenue,
+            low_speed: counts.low_speed,
           },
           observations
         );

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,8 @@ export interface AdsbSweepRecord {
   mismatched: number;
   no_assignment: number;
   no_callsign: number;
+  non_revenue: number;
+  low_speed: number;
 }
 
 /** One aircraft seen during an ADS-B shadow sweep. */
@@ -256,7 +258,7 @@ export interface AdsbObservationRecord {
   lon: number | null;
   aircraft_type: string | null;
   provider: string;
-  /** match | mismatch | no_assignment | no_callsign; null for on-ground observations. */
+  /** match | mismatch | no_assignment | no_callsign | non_revenue | low_speed; null on-ground. */
   shadow_result: string | null;
   assigned_flight: string | null;
 }

--- a/tests/adsb-sweep.test.ts
+++ b/tests/adsb-sweep.test.ts
@@ -8,7 +8,7 @@ import {
   deriveCallsignFlight,
   runAdsbSweepShadow,
 } from "../src/scripts/adsb-sweep";
-import { addFlight, addPlane, makeSyntheticDb } from "./helpers";
+import { addFleet, addFlight, makeSyntheticDb } from "./helpers";
 
 describe("callsign matching", () => {
   test.each([
@@ -44,11 +44,16 @@ describe("classifyObservation", () => {
     aircraftType: "B738",
   });
 
-  test("classifies match, mismatch, no_assignment, and no_callsign", () => {
+  test("classifies match, mismatch, no_assignment, no_callsign, non_revenue, low_speed", () => {
     expect(classifyObservation(aircraft("UAL1326"), ["UAL1326"]).result).toBe("match");
     expect(classifyObservation(aircraft("UAL1326"), ["UAL2436"]).result).toBe("mismatch");
     expect(classifyObservation(aircraft("UAL1326"), []).result).toBe("no_assignment");
     expect(classifyObservation(aircraft(null), ["UAL1326"]).result).toBe("no_callsign");
+    expect(classifyObservation(aircraft("UAL8114"), ["UAL2436"]).result).toBe("non_revenue");
+    expect(classifyObservation(aircraft("SKW9001"), []).result).toBe("non_revenue");
+    expect(classifyObservation({ ...aircraft("UAL1326"), gs: 80 }, ["UAL1326"]).result).toBe(
+      "low_speed"
+    );
   });
 });
 
@@ -56,9 +61,10 @@ describe("runAdsbSweepShadow", () => {
   function seedDb() {
     const db = makeSyntheticDb();
     const now = Math.floor(Date.now() / 1000);
-    addPlane(db, "N73275", "Starlink", { aircraft: "Boeing 737-824" });
-    addPlane(db, "N106SY", "Starlink", { aircraft: "E175" });
-    // One in-progress long sector (departed 5h ago, lands in 1h) and one about to depart.
+    // Sweep reads united_fleet (full fleet, not just Starlink tails).
+    addFleet(db, "N73275", "confirmed", { aircraftType: "Boeing 737-824" });
+    addFleet(db, "N106SY", "confirmed", { aircraftType: "E175" });
+    // One in-progress sector and one about to depart.
     addFlight(db, "N73275", "UAL1326", "AUS", now - 5 * 3600, { arrivalAirport: "IAH" });
     db.query("UPDATE upcoming_flights SET arrival_time = ? WHERE tail_number = 'N73275'").run(
       now + 3600
@@ -82,7 +88,7 @@ describe("runAdsbSweepShadow", () => {
       {
         r: "N106SY",
         hex: "abc123",
-        flight: "SKW9999",
+        flight: "SKW5425",
         alt_baro: 20000,
         gs: 380,
         lat: 37,


### PR DESCRIPTION
First step of the design panel's measurement-only plan (`do_not_commit/adsb-design-panel-2026-06-21.md`). The 7-day shadow data showed 26% mismatch but that's inflated by ferry callsigns, taxi-carryover idents, and a 4h lookahead window that counted leg-N-vs-leg-N+1 rotation slip. This cleans the classifier and expands coverage so the next checkpoint reads the real number.

- `non_revenue` result for callsigns with flight number ≥8000 (ferry/maintenance/repo idents that schedules never carry, all operators)
- `low_speed` result for gs<120 (FMS may still show the previous leg through taxi/climb-out)
- Assignment lookahead 4h→1h — tighter than rotation-slip noise, still covers FR24's scheduled-vs-actual lag
- Sweep now reads all UA `united_fleet` tails (~1,611), not just the ~413 Starlink ones — was structurally blind to a non-Starlink tail swapped onto a flight we'd answer "yes" for; window query gets `airline='UA'` filter
- `addColumn` migration helper (uses existing `hasColumn`); two new sweep-record columns

The `verdict_would_flip` per-observation metric was scoped out after review — getting it semantically right requires `resolveTailVerdict` and check-flight's day-window lookup, not a parallel `=== 'confirmed'` approximation. Separate PR.
