### PR TITLE
Slack notify on each newly-confirmed Starlink tail

### DIFF
--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -34,6 +34,7 @@ import { icaoToIata } from "../utils/airport-tz";
 import { extractFlightNumber, pickVerifiableFlight, unitedLookupDate } from "../utils/constants";
 import { type JobHandle, startJob } from "../utils/job-runner";
 import { info, error as logError, warn } from "../utils/logger";
+import { notifyNewStarlinkPlane } from "../utils/notify";
 import type { StarlinkCheckResult } from "./united-starlink-checker";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
 import {
@@ -295,6 +296,19 @@ export async function verifyPlane(
           );
           // FLEET_STATUS_CHANGE is emitted at the DB write site (updateFleetVerificationResult).
           emitFleetSnapshot(db);
+          if (starlinkStatus === "confirmed") {
+            void notifyNewStarlinkPlane({
+              tail: plane.tail_number,
+              aircraftType: result.aircraftType || plane.aircraft_type,
+              fleet: plane.fleet,
+              prevStatus,
+              firstFlight: forVerification && {
+                flight_number: `UA${forVerification.flightNumber}`,
+                origin: forVerification.origin,
+                dest: forVerification.destination,
+              },
+            });
+          }
         }
 
         // Sheet-independence KPI: flag whenever the crawler's consensus

--- a/src/utils/notify.ts
+++ b/src/utils/notify.ts
@@ -1,0 +1,52 @@
+/**
+ * Slack incoming-webhook notifier. Reads SLACK_WEBHOOK_URL at call time so a
+ * missing/rotated value degrades to a no-op log instead of a startup failure.
+ */
+
+import { info, error as logError } from "./logger";
+
+const MENTION = process.env.SLACK_MENTION ?? "<@U07HKUAAD0B>";
+
+export interface NewPlaneNotice {
+  tail: string;
+  aircraftType: string | null;
+  fleet: string | null;
+  prevStatus: string;
+  firstFlight?: { flight_number: string; origin: string; dest: string } | null;
+}
+
+export async function notifySlack(text: string): Promise<boolean> {
+  const url = process.env.SLACK_WEBHOOK_URL;
+  if (!url) {
+    info(`[slack disabled] ${text}`);
+    return false;
+  }
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) throw new Error(`slack webhook ${res.status}`);
+    return true;
+  } catch (err) {
+    logError("slack notify failed", err);
+    return false;
+  }
+}
+
+export function formatNewPlaneNotice(n: NewPlaneNotice): string {
+  const route = n.firstFlight
+    ? ` — next: ${n.firstFlight.flight_number} ${n.firstFlight.origin}→${n.firstFlight.dest}`
+    : "";
+  const type = n.aircraftType ? ` (${n.aircraftType}${n.fleet ? `, ${n.fleet}` : ""})` : "";
+  return (
+    `🛰️ *New Starlink plane:* \`${n.tail}\`${type}${route} ` +
+    `· was \`${n.prevStatus}\` · <https://unitedstarlinktracker.com/fleet|fleet> ${MENTION}`
+  );
+}
+
+export async function notifyNewStarlinkPlane(n: NewPlaneNotice): Promise<void> {
+  await notifySlack(formatNewPlaneNotice(n));
+}


### PR DESCRIPTION
When fleet-discovery flips a tail's `starlink_status` to `confirmed`, post a Slack message with the tail, aircraft type, subfleet, the flight it was verified on, and a fleet-page link, tagging the configured user.

- `src/utils/notify.ts`: `notifySlack` reads `SLACK_WEBHOOK_URL` at call time (no-op log if unset, 5s timeout, never throws); `SLACK_MENTION` env overrides the default user tag
- Hooked at the existing `STATUS CHANGE` site in fleet-discovery, fire-and-forget so a webhook failure can't block the verification loop
- No secrets in the repo — webhook URL is a Coolify env var
