### PR TITLE
Discovery: RTS grace, subfleet cascade, stale-fleet bump

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1923,35 +1923,17 @@ function emitFleetStatusChange(
   });
 }
 
-interface FleetStatusRow {
-  starlink_status: string | null;
-  fleet: string | null;
-  airline: string | null;
-  aircraft_type: string | null;
-}
-
-function getFleetStatusRow(db: Database, tail: string): FleetStatusRow | null {
-  return db
-    .query(
-      "SELECT starlink_status, fleet, airline, aircraft_type FROM united_fleet WHERE tail_number = ?"
-    )
-    .get(tail) as FleetStatusRow | null;
-}
-
-// Covers every observation-driven status write so the cascade can't be missed
-// by adding a new write path (the metric emit already follows this pattern).
-function onFleetStatusWrite(
+function getFleetStatusRow(
   db: Database,
-  tail: string,
-  prev: FleetStatusRow | null,
-  next: StarlinkStatus
-): void {
-  emitFleetStatusChange(prev, next);
-  if (prev?.airline && prev.starlink_status !== "confirmed" && next === "confirmed") {
-    const n = cascadeSubfleetDiscovery(db, tail, prev.aircraft_type, prev.airline);
-    if (n)
-      info(`first-of-family ${normalizeAircraftType(prev.aircraft_type)}: bumped ${n} siblings`);
-  }
+  tail: string
+): { starlink_status: string | null; fleet: string | null; airline: string | null } | null {
+  return db
+    .query("SELECT starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?")
+    .get(tail) as {
+    starlink_status: string | null;
+    fleet: string | null;
+    airline: string | null;
+  } | null;
 }
 
 export function setFleetVerified(
@@ -1965,7 +1947,7 @@ export function setFleetVerified(
   db.query(
     "UPDATE united_fleet SET verified_wifi = ?, verified_at = ?, starlink_status = ? WHERE tail_number = ?"
   ).run(wifi, now, status, tail);
-  onFleetStatusWrite(db, tail, prev, status);
+  emitFleetStatusChange(prev, status);
 }
 
 export function touchFleetVerifiedAt(db: Database, tail: string): void {
@@ -2398,7 +2380,9 @@ export function cascadeSubfleetDiscovery(
 
   const now = Math.floor(Date.now() / 1000);
   db.query(
-    `UPDATE united_fleet SET next_check_after = ?, discovery_priority = 0.9
+    `UPDATE united_fleet
+     SET next_check_after = MIN(next_check_after, ?),
+         discovery_priority = MAX(discovery_priority, 0.9)
      WHERE tail_number IN (${toBump.map(() => "?").join(",")})`
   ).run(now, ...toBump);
   return toBump.length;
@@ -2523,10 +2507,8 @@ export function reconcileConsensus(db: Database): number {
     // Write authority: only observed-wifi sources. Type-derived rows (alaska
     // wifi = type inference) must not flip verified_wifi from here.
     const consensus = computeWifiConsensus(db, tail, { sources: OBSERVED_WIFI_SOURCES });
-    const status = consensusToFleetStatus(consensus.verdict);
-    if (status !== null && consensus.verdict !== current) {
+    if (consensus.verdict !== null && consensus.verdict !== current) {
       updateVerifiedWifi(db, tail, consensus.verdict);
-      setFleetVerified(db, tail, consensus.verdict, status);
       healed++;
     }
   }
@@ -2894,8 +2876,7 @@ export function updateFleetVerificationResult(
       SET check_attempts = check_attempts + 1,
           last_check_error = ?,
           next_check_after = ?,
-          discovery_priority = ?,
-          rts_until = NULL
+          discovery_priority = ?
       WHERE tail_number = ?
     `).run(result.error, nextCheckAfter, priority, tailNumber);
   } else {
@@ -2919,7 +2900,7 @@ export function updateFleetVerificationResult(
       rtsUntil,
       tailNumber
     );
-    onFleetStatusWrite(db, tailNumber, prev, result.starlinkStatus);
+    emitFleetStatusChange(prev, result.starlinkStatus);
   }
 }
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1923,17 +1923,35 @@ function emitFleetStatusChange(
   });
 }
 
-function getFleetStatusRow(
-  db: Database,
-  tail: string
-): { starlink_status: string | null; fleet: string | null; airline: string | null } | null {
+interface FleetStatusRow {
+  starlink_status: string | null;
+  fleet: string | null;
+  airline: string | null;
+  aircraft_type: string | null;
+}
+
+function getFleetStatusRow(db: Database, tail: string): FleetStatusRow | null {
   return db
-    .query("SELECT starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?")
-    .get(tail) as {
-    starlink_status: string | null;
-    fleet: string | null;
-    airline: string | null;
-  } | null;
+    .query(
+      "SELECT starlink_status, fleet, airline, aircraft_type FROM united_fleet WHERE tail_number = ?"
+    )
+    .get(tail) as FleetStatusRow | null;
+}
+
+// Covers every observation-driven status write so the cascade can't be missed
+// by adding a new write path (the metric emit already follows this pattern).
+function onFleetStatusWrite(
+  db: Database,
+  tail: string,
+  prev: FleetStatusRow | null,
+  next: StarlinkStatus
+): void {
+  emitFleetStatusChange(prev, next);
+  if (prev?.airline && prev.starlink_status !== "confirmed" && next === "confirmed") {
+    const n = cascadeSubfleetDiscovery(db, tail, prev.aircraft_type, prev.airline);
+    if (n)
+      info(`first-of-family ${normalizeAircraftType(prev.aircraft_type)}: bumped ${n} siblings`);
+  }
 }
 
 export function setFleetVerified(
@@ -1947,7 +1965,7 @@ export function setFleetVerified(
   db.query(
     "UPDATE united_fleet SET verified_wifi = ?, verified_at = ?, starlink_status = ? WHERE tail_number = ?"
   ).run(wifi, now, status, tail);
-  emitFleetStatusChange(prev, status);
+  onFleetStatusWrite(db, tail, prev, status);
 }
 
 export function touchFleetVerifiedAt(db: Database, tail: string): void {
@@ -2505,8 +2523,10 @@ export function reconcileConsensus(db: Database): number {
     // Write authority: only observed-wifi sources. Type-derived rows (alaska
     // wifi = type inference) must not flip verified_wifi from here.
     const consensus = computeWifiConsensus(db, tail, { sources: OBSERVED_WIFI_SOURCES });
-    if (consensus.verdict !== null && consensus.verdict !== current) {
+    const status = consensusToFleetStatus(consensus.verdict);
+    if (status !== null && consensus.verdict !== current) {
       updateVerifiedWifi(db, tail, consensus.verdict);
+      setFleetVerified(db, tail, consensus.verdict, status);
       healed++;
     }
   }
@@ -2838,11 +2858,7 @@ export function updateFleetVerificationResult(
   // A long error streak clearing is a return-to-service: hold a tight re-check
   // window for a week so a retrofit isn't missed by the 14d negative cadence.
   const returnedToService = !result.error && (prev?.check_attempts ?? 0) >= RTS_STREAK_THRESHOLD;
-  const rtsUntil = returnedToService
-    ? now + RTS_GRACE_SECS
-    : result.error
-      ? null
-      : (prev?.rts_until ?? null);
+  const rtsUntil = returnedToService ? now + RTS_GRACE_SECS : (prev?.rts_until ?? null);
 
   let nextCheckDelay: number;
   if (result.error) {
@@ -2860,7 +2876,8 @@ export function updateFleetVerificationResult(
   } else {
     nextCheckDelay = 14 * 24 * 3600;
   }
-  if (rtsUntil && rtsUntil > now) nextCheckDelay = Math.min(nextCheckDelay, 24 * 3600);
+  if (!result.error && rtsUntil && rtsUntil > now)
+    nextCheckDelay = Math.min(nextCheckDelay, 24 * 3600);
 
   const jitter = (Math.random() - 0.5) * 0.2 * nextCheckDelay;
   const nextCheckAfter = now + nextCheckDelay + jitter;
@@ -2902,7 +2919,7 @@ export function updateFleetVerificationResult(
       rtsUntil,
       tailNumber
     );
-    emitFleetStatusChange(prev, result.starlinkStatus);
+    onFleetStatusWrite(db, tailNumber, prev, result.starlinkStatus);
   }
 }
 

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -233,6 +233,7 @@ export function setupTables(db: Database) {
       info("Database migration: added united_fleet.ship_number");
     }
   }
+  addColumn(db, "united_fleet", "rts_until", "INTEGER");
 
   if (!tableExists(db, "upcoming_flights")) {
     db.query(
@@ -2341,6 +2342,50 @@ export function computeWifiConsensus(
   };
 }
 
+export function consensusToFleetStatus(verdict: string | null): StarlinkStatus | null {
+  return verdict === null ? null : verdict === "Starlink" ? "confirmed" : "negative";
+}
+
+/**
+ * On the first confirmed tail of an aircraft family, pull every negative
+ * sibling forward in the discovery queue. Returns the number of tails bumped
+ * (0 when not first-of-family). Priority 0.9 keeps user-triggered bumps (1.0)
+ * ahead of a large cascade.
+ */
+export function cascadeSubfleetDiscovery(
+  db: Database,
+  confirmedTail: string,
+  aircraftType: string | null,
+  airline: string
+): number {
+  const family = normalizeAircraftType(aircraftType);
+  if (family === "unknown" || family === "other") return 0;
+
+  const peers = db
+    .query(
+      "SELECT tail_number, aircraft_type, starlink_status FROM united_fleet WHERE airline = ? AND tail_number != ?"
+    )
+    .all(airline, confirmedTail) as Array<{
+    tail_number: string;
+    aircraft_type: string | null;
+    starlink_status: string;
+  }>;
+  const sameFamily = peers.filter((p) => normalizeAircraftType(p.aircraft_type) === family);
+  if (sameFamily.some((p) => p.starlink_status === "confirmed")) return 0;
+
+  const toBump = sameFamily
+    .filter((p) => p.starlink_status === "negative")
+    .map((p) => p.tail_number);
+  if (toBump.length === 0) return 0;
+
+  const now = Math.floor(Date.now() / 1000);
+  db.query(
+    `UPDATE united_fleet SET next_check_after = ?, discovery_priority = 0.9
+     WHERE tail_number IN (${toBump.map(() => "?").join(",")})`
+  ).run(now, ...toBump);
+  return toBump.length;
+}
+
 /**
  * Bump discovery priority so a tail is re-checked on the next fleet-discovery
  * cycle. Idempotent: only bumps if not already due.
@@ -2757,6 +2802,11 @@ export function getNextPlanesToVerify(db: Database, limit = 10, airline = "UA"):
     .all(now, airline, limit) as FleetAircraft[];
 }
 
+// 10 consecutive errors with the 1h→24h backoff is ~6 days off the schedule —
+// long enough to mean grounded/maintenance, short of the 20-attempt parked tier.
+const RTS_STREAK_THRESHOLD = 10;
+const RTS_GRACE_SECS = 7 * 24 * 3600;
+
 /**
  * Update fleet verification result
  */
@@ -2772,14 +2822,31 @@ export function updateFleetVerificationResult(
 ): void {
   const now = Math.floor(Date.now() / 1000);
 
-  // Calculate next check time based on status
+  const prev = db
+    .query(
+      "SELECT aircraft_type, check_attempts, rts_until, starlink_status, fleet, airline FROM united_fleet WHERE tail_number = ?"
+    )
+    .get(tailNumber) as {
+    aircraft_type: string | null;
+    check_attempts: number;
+    rts_until: number | null;
+    starlink_status: string | null;
+    fleet: string | null;
+    airline: string | null;
+  } | null;
+
+  // A long error streak clearing is a return-to-service: hold a tight re-check
+  // window for a week so a retrofit isn't missed by the 14d negative cadence.
+  const returnedToService = !result.error && (prev?.check_attempts ?? 0) >= RTS_STREAK_THRESHOLD;
+  const rtsUntil = returnedToService
+    ? now + RTS_GRACE_SECS
+    : result.error
+      ? null
+      : (prev?.rts_until ?? null);
+
   let nextCheckDelay: number;
   if (result.error) {
-    // Exponential backoff for errors: get current attempts
-    const current = db
-      .query("SELECT check_attempts FROM united_fleet WHERE tail_number = ?")
-      .get(tailNumber) as { check_attempts: number } | null;
-    const attempts = (current?.check_attempts || 0) + 1;
+    const attempts = (prev?.check_attempts ?? 0) + 1;
     // 1h, 2h, 4h, 8h, max 24h — but 20+ consecutive failures means parked/stored,
     // and weekly is enough to catch a return to service.
     nextCheckDelay =
@@ -2789,23 +2856,17 @@ export function updateFleetVerificationResult(
     // within a few days instead of waiting 7-14 days between observations.
     nextCheckDelay = 36 * 3600;
   } else if (result.starlinkStatus === "confirmed") {
-    // Re-verify confirmed Starlink in 7 days
     nextCheckDelay = 7 * 24 * 3600;
   } else {
-    // Re-verify non-Starlink in 14 days
     nextCheckDelay = 14 * 24 * 3600;
   }
+  if (rtsUntil && rtsUntil > now) nextCheckDelay = Math.min(nextCheckDelay, 24 * 3600);
 
-  // Add jitter (±10%)
   const jitter = (Math.random() - 0.5) * 0.2 * nextCheckDelay;
   const nextCheckAfter = now + nextCheckDelay + jitter;
 
-  // Recalculate priority
-  const current = db
-    .query("SELECT aircraft_type FROM united_fleet WHERE tail_number = ?")
-    .get(tailNumber) as { aircraft_type: string | null } | null;
   const priority = calculateDiscoveryPriority(
-    current?.aircraft_type || null,
+    prev?.aircraft_type ?? null,
     result.starlinkStatus,
     tailNumber
   );
@@ -2816,11 +2877,11 @@ export function updateFleetVerificationResult(
       SET check_attempts = check_attempts + 1,
           last_check_error = ?,
           next_check_after = ?,
-          discovery_priority = ?
+          discovery_priority = ?,
+          rts_until = NULL
       WHERE tail_number = ?
     `).run(result.error, nextCheckAfter, priority, tailNumber);
   } else {
-    const prev = getFleetStatusRow(db, tailNumber);
     db.query(`
       UPDATE united_fleet
       SET starlink_status = ?,
@@ -2829,9 +2890,18 @@ export function updateFleetVerificationResult(
           check_attempts = 0,
           last_check_error = NULL,
           next_check_after = ?,
-          discovery_priority = ?
+          discovery_priority = ?,
+          rts_until = ?
       WHERE tail_number = ?
-    `).run(result.starlinkStatus, result.verifiedWifi, now, nextCheckAfter, priority, tailNumber);
+    `).run(
+      result.starlinkStatus,
+      result.verifiedWifi,
+      now,
+      nextCheckAfter,
+      priority,
+      rtsUntil,
+      tailNumber
+    );
     emitFleetStatusChange(prev, result.starlinkStatus);
   }
 }

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -12,7 +12,6 @@ import { FlightRadar24API } from "../api/flightradar24-api";
 import {
   type WifiConsensus,
   addDiscoveredStarlinkPlane,
-  cascadeSubfleetDiscovery,
   getFleetDiscoveryStats,
   getNextPlanesToVerify,
   initializeDatabase,
@@ -351,10 +350,8 @@ export async function verifyPlane(
             { airline: "UA", evidence: "observed" }
           );
           updateFlights(db, plane.tail_number, allFlights);
-          const bumped = cascadeSubfleetDiscovery(db, plane.tail_number, plane.aircraft_type, "UA");
-          const cascade = bumped ? `, first-of-family — bumped ${bumped} siblings` : "";
           info(
-            `DISCOVERY: ${plane.tail_number} has Starlink! (stored ${allFlights.length} flights${cascade})`
+            `DISCOVERY: ${plane.tail_number} has Starlink! (stored ${allFlights.length} flights)`
           );
         }
 

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -12,6 +12,7 @@ import { FlightRadar24API } from "../api/flightradar24-api";
 import {
   type WifiConsensus,
   addDiscoveredStarlinkPlane,
+  cascadeSubfleetDiscovery,
   getFleetDiscoveryStats,
   getNextPlanesToVerify,
   initializeDatabase,
@@ -350,8 +351,10 @@ export async function verifyPlane(
             { airline: "UA", evidence: "observed" }
           );
           updateFlights(db, plane.tail_number, allFlights);
+          const bumped = cascadeSubfleetDiscovery(db, plane.tail_number, plane.aircraft_type, "UA");
+          const cascade = bumped ? `, first-of-family — bumped ${bumped} siblings` : "";
           info(
-            `DISCOVERY: ${plane.tail_number} has Starlink! (stored ${allFlights.length} flights)`
+            `DISCOVERY: ${plane.tail_number} has Starlink! (stored ${allFlights.length} flights${cascade})`
           );
         }
 

--- a/src/scripts/united-verdict.ts
+++ b/src/scripts/united-verdict.ts
@@ -15,8 +15,10 @@ import { AIRLINES, OBSERVED_WIFI_SOURCES, verifierSourceTag } from "../airlines/
 import {
   type WifiConsensus,
   computeWifiConsensus,
+  consensusToFleetStatus,
   getShipToTailMap,
   logVerification,
+  setFleetVerified,
   updateVerifiedWifi,
 } from "../database/database";
 import { info, warn } from "../utils/logger";
@@ -224,15 +226,7 @@ export function applyUnitedObservation(
       // Swap-captured tails never get a direct check soon — needsVerification
       // sees the log entry above and skips them — so settle their consensus
       // here or they'd be stuck accumulating obs forever.
-      const swapConsensus = computeWifiConsensus(db, verdict.swapCapture.tail_number, {
-        sources: OBSERVED_WIFI_SOURCES,
-      });
-      if (swapConsensus.verdict !== null) {
-        updateVerifiedWifi(db, verdict.swapCapture.tail_number, swapConsensus.verdict);
-        log.info(
-          `${verdict.swapCapture.tail_number} (swap-captured): verified_wifi → ${swapConsensus.verdict} (${swapConsensus.reason})`
-        );
-      }
+      settleConsensus(db, verdict.swapCapture.tail_number, log, " (swap-captured)");
     }
 
     if (!verdict.trusted) {
@@ -247,24 +241,24 @@ export function applyUnitedObservation(
     // The log row above is already in the window, so consensus includes this
     // check. Gating the column write on the 30-day consensus means one flaky
     // scrape can't hide a plane.
-    const consensus = computeWifiConsensus(db, verdict.expectedTail, {
-      sources: OBSERVED_WIFI_SOURCES,
-    });
-    if (consensus.verdict !== null) {
-      updateVerifiedWifi(db, verdict.expectedTail, consensus.verdict);
-      log.info(
-        `${verdict.expectedTail}: verified_wifi → ${consensus.verdict} (${consensus.reason})`
-      );
-    } else {
-      // Ambiguous — clear to NULL so the check-flight filter
-      // (IS NULL OR = 'Starlink') falls through to spreadsheet trust.
-      updateVerifiedWifi(db, verdict.expectedTail, null);
-      log.info(
-        `${verdict.expectedTail}: consensus ambiguous, verified_wifi cleared (${consensus.reason})`
-      );
-    }
-    return consensus;
+    return settleConsensus(db, verdict.expectedTail, log);
   })();
+}
+
+function settleConsensus(db: Database, tail: string, log: VerdictLog, tag = ""): WifiConsensus {
+  const consensus = computeWifiConsensus(db, tail, { sources: OBSERVED_WIFI_SOURCES });
+  const status = consensusToFleetStatus(consensus.verdict);
+  if (status !== null) {
+    updateVerifiedWifi(db, tail, consensus.verdict);
+    setFleetVerified(db, tail, consensus.verdict, status);
+    log.info(`${tail}${tag}: verified_wifi → ${consensus.verdict} (${consensus.reason})`);
+  } else {
+    // Ambiguous — clear to NULL so the check-flight filter
+    // (IS NULL OR = 'Starlink') falls through to spreadsheet trust.
+    updateVerifiedWifi(db, tail, null);
+    log.info(`${tail}${tag}: consensus ambiguous, verified_wifi cleared (${consensus.reason})`);
+  }
+  return consensus;
 }
 
 /**

--- a/src/scripts/united-verdict.ts
+++ b/src/scripts/united-verdict.ts
@@ -14,11 +14,12 @@ import type { Database } from "bun:sqlite";
 import { AIRLINES, OBSERVED_WIFI_SOURCES, verifierSourceTag } from "../airlines/registry";
 import {
   type WifiConsensus,
+  bumpDiscoveryPriority,
   computeWifiConsensus,
   consensusToFleetStatus,
+  getFleetEntryByTail,
   getShipToTailMap,
   logVerification,
-  setFleetVerified,
   updateVerifiedWifi,
 } from "../database/database";
 import { info, warn } from "../utils/logger";
@@ -226,7 +227,10 @@ export function applyUnitedObservation(
       // Swap-captured tails never get a direct check soon — needsVerification
       // sees the log entry above and skips them — so settle their consensus
       // here or they'd be stuck accumulating obs forever.
-      settleConsensus(db, verdict.swapCapture.tail_number, log, " (swap-captured)");
+      settleConsensus(db, verdict.swapCapture.tail_number, log, {
+        tag: " (swap-captured)",
+        clearOnAmbiguous: false,
+      });
     }
 
     if (!verdict.trusted) {
@@ -245,14 +249,24 @@ export function applyUnitedObservation(
   })();
 }
 
-function settleConsensus(db: Database, tail: string, log: VerdictLog, tag = ""): WifiConsensus {
+function settleConsensus(
+  db: Database,
+  tail: string,
+  log: VerdictLog,
+  opts: { tag?: string; clearOnAmbiguous?: boolean } = {}
+): WifiConsensus {
+  const { tag = "", clearOnAmbiguous = true } = opts;
   const consensus = computeWifiConsensus(db, tail, { sources: OBSERVED_WIFI_SOURCES });
   const status = consensusToFleetStatus(consensus.verdict);
   if (status !== null) {
     updateVerifiedWifi(db, tail, consensus.verdict);
-    setFleetVerified(db, tail, consensus.verdict, status);
     log.info(`${tail}${tag}: verified_wifi → ${consensus.verdict} (${consensus.reason})`);
-  } else {
+    // Discovery is the sole united_fleet status writer; queue a re-check when
+    // its row disagrees so the verifier/swap path can't leave it stale.
+    if (getFleetEntryByTail(db, tail)?.starlink_status !== status) {
+      bumpDiscoveryPriority(db, tail);
+    }
+  } else if (clearOnAmbiguous) {
     // Ambiguous — clear to NULL so the check-flight filter
     // (IS NULL OR = 'Starlink') falls through to spreadsheet trust.
     updateVerifiedWifi(db, tail, null);

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,6 +110,7 @@ export interface FleetAircraft {
   next_check_after: number;
   check_attempts: number;
   last_check_error: string | null;
+  rts_until?: number | null;
 }
 
 // ============ /fleet page data ============

--- a/tests/united-verdict.test.ts
+++ b/tests/united-verdict.test.ts
@@ -10,7 +10,12 @@
 
 import type { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
-import { logVerification, updateShipNumber } from "../src/database/database";
+import {
+  cascadeSubfleetDiscovery,
+  logVerification,
+  updateFleetVerificationResult,
+  updateShipNumber,
+} from "../src/database/database";
 import { type VerifyPlaneDeps, verifyPlane } from "../src/scripts/fleet-discovery";
 import { verifyPlaneStarlink } from "../src/scripts/starlink-verifier";
 import type { StarlinkCheckResult } from "../src/scripts/united-starlink-checker";
@@ -420,13 +425,23 @@ describe("verifyPlaneStarlink write paths (injected checker)", () => {
     db.close();
   });
 
-  test("verification mode never touches united_fleet", async () => {
+  test("verification mode syncs united_fleet status when consensus settles", async () => {
     const db = setup(null);
     addPriors(db, TAIL, "Viasat");
     await run(db, viasatOn(TAIL));
     const uf = fleetRow(db, TAIL);
+    expect(uf.starlink_status).toBe("negative");
+    expect(uf.verified_wifi).toBe("Viasat");
+    expect(uf.next_check_after).toBe(0); // scheduling untouched — discovery owns that
+    db.close();
+  });
+
+  test("verification mode leaves united_fleet alone when consensus is ambiguous", async () => {
+    const db = setup("Starlink");
+    await run(db, viasatOn(TAIL)); // single obs < minObs
+    const uf = fleetRow(db, TAIL);
     expect(uf.starlink_status).toBe("unknown");
-    expect(uf.verified_at).toBe(1); // addFleet seed value
+    expect(uf.verified_at).toBe(1);
     db.close();
   });
 
@@ -638,6 +653,80 @@ describe("verifyPlane (discovery) write paths (injected checker + flights)", () 
     const tags = await captureLoggerTags(() => run(db, makePlane(), viasatOn(null)));
     expect(tags.has("fleet-discovery")).toBe(true);
     expect(tags.has("united-verdict")).toBe(false);
+    db.close();
+  });
+
+  test("swap-captured tail's united_fleet status syncs from consensus", async () => {
+    const db = makeSyntheticDb();
+    addFleet(db, TAIL, "unknown");
+    addFleet(db, SWAP_TAIL, "negative", { verifiedWifi: "Viasat" });
+    addPlane(db, SWAP_TAIL, null);
+    addPriors(db, SWAP_TAIL, "Starlink");
+    await run(db, makePlane(), starlinkOn(SWAP_TAIL));
+    expect(fleetRow(db, SWAP_TAIL).starlink_status).toBe("confirmed");
+    db.close();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Discovery scheduling: return-to-service grace + first-of-family cascade.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("discovery scheduling", () => {
+  const NOW = Math.floor(Date.now() / 1000);
+
+  function nextCheckHours(db: Database, tail: string): number {
+    return (fleetRow(db, tail).next_check_after - NOW) / 3600;
+  }
+
+  test("return-to-service: long error streak → 24h grace, persists across checks, error clears it", () => {
+    const db = makeSyntheticDb();
+    addFleet(db, TAIL, "negative");
+    db.query("UPDATE united_fleet SET check_attempts = 12 WHERE tail_number = ?").run(TAIL);
+
+    updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
+    expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
+    expect(fleetRow(db, TAIL).check_attempts).toBe(0);
+
+    updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
+    expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
+
+    updateFleetVerificationResult(db, TAIL, {
+      starlinkStatus: "negative",
+      verifiedWifi: null,
+      error: "No upcoming flights",
+    });
+    updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
+    expect(nextCheckHours(db, TAIL)).toBeGreaterThan(11 * 24);
+    db.close();
+  });
+
+  test("short error streak does not arm grace", () => {
+    const db = makeSyntheticDb();
+    addFleet(db, TAIL, "negative");
+    db.query("UPDATE united_fleet SET check_attempts = 3 WHERE tail_number = ?").run(TAIL);
+    updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
+    expect(nextCheckHours(db, TAIL)).toBeGreaterThan(11 * 24);
+    db.close();
+  });
+
+  test("cascade: first-of-family bumps negative siblings, second confirm is a no-op", () => {
+    const db = makeSyntheticDb();
+    addFleet(db, "N777A", "confirmed", { aircraftType: "Boeing 777-224(ER)" });
+    addFleet(db, "N777B", "negative", { aircraftType: "Boeing 777-222" });
+    addFleet(db, "N777C", "negative", { aircraftType: "Boeing 777-322(ER)" });
+    addFleet(db, "N777D", "unknown", { aircraftType: "Boeing 777-222" });
+    addFleet(db, "N321A", "negative", { aircraftType: "Airbus A321-271NX" });
+    db.query("UPDATE united_fleet SET next_check_after = ?").run(NOW + 14 * 86400);
+
+    expect(cascadeSubfleetDiscovery(db, "N777A", "Boeing 777-224(ER)", "UA")).toBe(2);
+    expect(fleetRow(db, "N777B").next_check_after).toBeLessThanOrEqual(NOW);
+    expect(fleetRow(db, "N777C").next_check_after).toBeLessThanOrEqual(NOW);
+    expect(fleetRow(db, "N777D").next_check_after).toBeGreaterThan(NOW); // unknown left alone
+    expect(fleetRow(db, "N321A").next_check_after).toBeGreaterThan(NOW); // other family left alone
+
+    db.query("UPDATE united_fleet SET starlink_status='confirmed' WHERE tail_number='N777B'").run();
+    expect(cascadeSubfleetDiscovery(db, "N777C", "Boeing 777-322(ER)", "UA")).toBe(0);
     db.close();
   });
 });

--- a/tests/united-verdict.test.ts
+++ b/tests/united-verdict.test.ts
@@ -425,14 +425,19 @@ describe("verifyPlaneStarlink write paths (injected checker)", () => {
     db.close();
   });
 
-  test("verification mode syncs united_fleet status when consensus settles", async () => {
+  test("verification mode bumps united_fleet for re-check when consensus disagrees with status", async () => {
     const db = setup(null);
+    db.query("UPDATE united_fleet SET next_check_after = ? WHERE tail_number = ?").run(
+      Math.floor(Date.now() / 1000) + 14 * 86400,
+      TAIL
+    );
     addPriors(db, TAIL, "Viasat");
     await run(db, viasatOn(TAIL));
     const uf = fleetRow(db, TAIL);
-    expect(uf.starlink_status).toBe("negative");
-    expect(uf.verified_wifi).toBe("Viasat");
-    expect(uf.next_check_after).toBe(0); // scheduling untouched — discovery owns that
+    // Discovery owns status writes; verifier only queues a re-check.
+    expect(uf.starlink_status).toBe("unknown");
+    expect(uf.verified_at).toBe(1);
+    expect(uf.next_check_after).toBeLessThan(Math.floor(Date.now() / 1000) + 60);
     db.close();
   });
 
@@ -442,6 +447,7 @@ describe("verifyPlaneStarlink write paths (injected checker)", () => {
     const uf = fleetRow(db, TAIL);
     expect(uf.starlink_status).toBe("unknown");
     expect(uf.verified_at).toBe(1);
+    expect(uf.next_check_after).toBe(0);
     db.close();
   });
 
@@ -656,14 +662,19 @@ describe("verifyPlane (discovery) write paths (injected checker + flights)", () 
     db.close();
   });
 
-  test("swap-captured tail's united_fleet status syncs from consensus", async () => {
+  test("swap-captured tail with disagreeing consensus is bumped for discovery re-check", async () => {
     const db = makeSyntheticDb();
     addFleet(db, TAIL, "unknown");
     addFleet(db, SWAP_TAIL, "negative", { verifiedWifi: "Viasat" });
+    db.query("UPDATE united_fleet SET next_check_after = ? WHERE tail_number = ?").run(
+      NOW + 14 * 86400,
+      SWAP_TAIL
+    );
     addPlane(db, SWAP_TAIL, null);
     addPriors(db, SWAP_TAIL, "Starlink");
     await run(db, makePlane(), starlinkOn(SWAP_TAIL));
-    expect(fleetRow(db, SWAP_TAIL).starlink_status).toBe("confirmed");
+    expect(fleetRow(db, SWAP_TAIL).starlink_status).toBe("negative");
+    expect(fleetRow(db, SWAP_TAIL).next_check_after).toBeLessThan(NOW + 60);
     db.close();
   });
 });
@@ -679,7 +690,7 @@ describe("discovery scheduling", () => {
     return (fleetRow(db, tail).next_check_after - NOW) / 3600;
   }
 
-  test("return-to-service: long error streak → 24h grace, persists across checks, error clears it", () => {
+  test("return-to-service: long error streak → 24h grace, survives transient errors", () => {
     const db = makeSyntheticDb();
     addFleet(db, TAIL, "negative");
     db.query("UPDATE united_fleet SET check_attempts = 12 WHERE tail_number = ?").run(TAIL);
@@ -688,16 +699,13 @@ describe("discovery scheduling", () => {
     expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
     expect(fleetRow(db, TAIL).check_attempts).toBe(0);
 
-    updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
-    expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
-
     updateFleetVerificationResult(db, TAIL, {
       starlinkStatus: "negative",
       verifiedWifi: null,
-      error: "No upcoming flights",
+      error: "timeout",
     });
     updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
-    expect(nextCheckHours(db, TAIL)).toBeGreaterThan(11 * 24);
+    expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
     db.close();
   });
 
@@ -710,23 +718,37 @@ describe("discovery scheduling", () => {
     db.close();
   });
 
-  test("cascade: first-of-family bumps negative siblings, second confirm is a no-op", () => {
+  test("cascade: first-of-family bumps negative siblings; later confirm is a no-op", () => {
     const db = makeSyntheticDb();
-    addFleet(db, "N777A", "confirmed", { aircraftType: "Boeing 777-224(ER)" });
+    addFleet(db, "N777A", "negative", { aircraftType: "Boeing 777-224(ER)" });
     addFleet(db, "N777B", "negative", { aircraftType: "Boeing 777-222" });
     addFleet(db, "N777C", "negative", { aircraftType: "Boeing 777-322(ER)" });
     addFleet(db, "N777D", "unknown", { aircraftType: "Boeing 777-222" });
     addFleet(db, "N321A", "negative", { aircraftType: "Airbus A321-271NX" });
-    db.query("UPDATE united_fleet SET next_check_after = ?").run(NOW + 14 * 86400);
+    const FAR = NOW + 14 * 86400;
+    db.query("UPDATE united_fleet SET next_check_after = ?").run(FAR);
 
     expect(cascadeSubfleetDiscovery(db, "N777A", "Boeing 777-224(ER)", "UA")).toBe(2);
-    expect(fleetRow(db, "N777B").next_check_after).toBeLessThanOrEqual(NOW);
-    expect(fleetRow(db, "N777C").next_check_after).toBeLessThanOrEqual(NOW);
-    expect(fleetRow(db, "N777D").next_check_after).toBeGreaterThan(NOW); // unknown left alone
-    expect(fleetRow(db, "N321A").next_check_after).toBeGreaterThan(NOW); // other family left alone
+    expect(fleetRow(db, "N777B").next_check_after).toBeLessThan(NOW + 60);
+    expect(fleetRow(db, "N777C").next_check_after).toBeLessThan(NOW + 60);
+    expect(fleetRow(db, "N777D").next_check_after).toBe(FAR); // unknown left alone
+    expect(fleetRow(db, "N321A").next_check_after).toBe(FAR); // other family left alone
 
-    db.query("UPDATE united_fleet SET starlink_status='confirmed' WHERE tail_number='N777B'").run();
-    expect(cascadeSubfleetDiscovery(db, "N777C", "Boeing 777-322(ER)", "UA")).toBe(0);
+    db.query("UPDATE united_fleet SET starlink_status='confirmed' WHERE tail_number='N777A'").run();
+    expect(cascadeSubfleetDiscovery(db, "N777B", "Boeing 777-222", "UA")).toBe(0);
+    db.close();
+  });
+
+  test("cascade preserves higher-priority bumps", () => {
+    const db = makeSyntheticDb();
+    addFleet(db, "N777A", "negative", { aircraftType: "Boeing 777-222" });
+    addFleet(db, "N777B", "negative", { aircraftType: "Boeing 777-222" });
+    db.query("UPDATE united_fleet SET discovery_priority = 1.0 WHERE tail_number = 'N777B'").run();
+    cascadeSubfleetDiscovery(db, "N777A", "Boeing 777-222", "UA");
+    const prio = db
+      .query("SELECT discovery_priority FROM united_fleet WHERE tail_number = 'N777B'")
+      .get() as { discovery_priority: number };
+    expect(prio.discovery_priority).toBe(1.0);
     db.close();
   });
 });


### PR DESCRIPTION
The first Starlink 777 (N37018, UA14 6/22) wasn't found by discovery — it returned from a ~5-week ground, got two Panasonic checks during the test-flight window, then went to sleep for 14d. Six other tails are similarly stale in `united_fleet` right now.

- Return-to-service grace: when a tail's error streak (≥10) clears, hold a 24h re-check cadence for 7d via new `rts_until` column; survives transient errors mid-grace
- First-of-family cascade: when discovery confirms a tail and no sibling of its aircraft family is confirmed yet, pull every negative sibling into the queue (priority 0.9, MAX-preserving)
- Consensus disagreement bump: when the verdict writer settles a consensus that disagrees with `united_fleet.starlink_status`, bump that tail so discovery re-checks it instead of leaving the row stale
- `updateFleetVerificationResult` consolidates its two pre-reads into one
- Swap-capture path no longer clears `verified_wifi` on ambiguous consensus