### PR TITLE
Skip RTS grace cap once a tail is confirmed

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -2839,8 +2839,14 @@ export function updateFleetVerificationResult(
 
   // A long error streak clearing is a return-to-service: hold a tight re-check
   // window for a week so a retrofit isn't missed by the 14d negative cadence.
+  // Grace ends once the tail confirms — that's the transition it exists to catch.
   const returnedToService = !result.error && (prev?.check_attempts ?? 0) >= RTS_STREAK_THRESHOLD;
-  const rtsUntil = returnedToService ? now + RTS_GRACE_SECS : (prev?.rts_until ?? null);
+  const rtsUntil =
+    result.starlinkStatus === "confirmed"
+      ? null
+      : returnedToService
+        ? now + RTS_GRACE_SECS
+        : (prev?.rts_until ?? null);
 
   let nextCheckDelay: number;
   if (result.error) {

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -2839,14 +2839,8 @@ export function updateFleetVerificationResult(
 
   // A long error streak clearing is a return-to-service: hold a tight re-check
   // window for a week so a retrofit isn't missed by the 14d negative cadence.
-  // Grace ends once the tail confirms — that's the transition it exists to catch.
   const returnedToService = !result.error && (prev?.check_attempts ?? 0) >= RTS_STREAK_THRESHOLD;
-  const rtsUntil =
-    result.starlinkStatus === "confirmed"
-      ? null
-      : returnedToService
-        ? now + RTS_GRACE_SECS
-        : (prev?.rts_until ?? null);
+  const rtsUntil = returnedToService ? now + RTS_GRACE_SECS : (prev?.rts_until ?? null);
 
   let nextCheckDelay: number;
   if (result.error) {
@@ -2864,7 +2858,7 @@ export function updateFleetVerificationResult(
   } else {
     nextCheckDelay = 14 * 24 * 3600;
   }
-  if (!result.error && rtsUntil && rtsUntil > now)
+  if (!result.error && result.starlinkStatus !== "confirmed" && rtsUntil && rtsUntil > now)
     nextCheckDelay = Math.min(nextCheckDelay, 24 * 3600);
 
   const jitter = (Math.random() - 0.5) * 0.2 * nextCheckDelay;

--- a/tests/united-verdict.test.ts
+++ b/tests/united-verdict.test.ts
@@ -706,6 +706,12 @@ describe("discovery scheduling", () => {
     });
     updateFleetVerificationResult(db, TAIL, { starlinkStatus: "negative", verifiedWifi: "Viasat" });
     expect(nextCheckHours(db, TAIL)).toBeLessThan(30);
+
+    updateFleetVerificationResult(db, TAIL, {
+      starlinkStatus: "confirmed",
+      verifiedWifi: "Starlink",
+    });
+    expect(nextCheckHours(db, TAIL)).toBeGreaterThan(6 * 24);
     db.close();
   });
 


### PR DESCRIPTION
Confirmed tails under RTS grace were re-checked daily instead of weekly — N14240 confirmed 6/25 then got re-checked 6/27, 6/28, 6/29. Six wasted checks per RTS hit.

- Gate the 24h cap on `starlinkStatus !== 'confirmed'`; `rts_until` stays set so a later flip back to negative re-enters the tight cadence