### PR TITLE
Ignore the progress sheet's percentage column when parsing mod counts

### DIFF
--- a/src/scripts/fleet-progress.ts
+++ b/src/scripts/fleet-progress.ts
@@ -81,9 +81,11 @@ function parseCsvGrid(csvText: string): string[][] {
   return rows;
 }
 
+// A percentage is never a count: the mainline tab ends with an "Of Total"
+// column whose "2.3%" must not become "2 in mod" (github issue #64).
 function toCount(raw: string | undefined): number | null {
-  if (raw === undefined) return null;
-  const cleaned = raw.replace(/[,%\s]/g, "");
+  if (raw === undefined || raw.includes("%")) return null;
+  const cleaned = raw.replace(/[,\s]/g, "");
   if (cleaned === "") return null;
   const n = Number(cleaned);
   return Number.isFinite(n) ? Math.round(n) : null;
@@ -117,7 +119,11 @@ export function parseProgressCsv(csvText: string, segment: ProgressSegment): Pro
   const columns: Array<{ col: number; type: string }> = [];
   for (let col = 1; col < header.length; col++) {
     const name = cleanTypeCode(header[col] ?? "");
-    if (name) columns.push({ col, type: name });
+    if (!name) continue;
+    // "Of Total" (the %-of-total view) is not an aircraft type — only the
+    // exact "Totals" rollup column survives (github issue #64).
+    if (/^total$/i.test(name)) continue;
+    columns.push({ col, type: name });
   }
   if (columns.length === 0) return [];
 

--- a/tests/fleet-progress.test.ts
+++ b/tests/fleet-progress.test.ts
@@ -6,8 +6,9 @@ import { getFleetProgress, replaceFleetProgress } from "../src/database/database
 import { parseProgressCsv, runFleetProgressSync } from "../src/scripts/fleet-progress";
 import { makeSyntheticDb } from "./helpers";
 
+// Mirrors the real tab shape, including the trailing "Of Total" % column.
 const MAINLINE_NB_CSV = [
-  '"Type","73G","738","738","Totals",""',
+  '"Type","73G","738","738","Totals","Of Total"',
   '"Total","40","67","74","181","100.0%"',
   '"Starlink Complete","0","16","21","37","20.4%"',
   '"W/O Starlink","40","51","53","144","79.6%"',
@@ -60,6 +61,13 @@ describe("parseProgressCsv", () => {
     // row (tail listing) must not overwrite the summary value.
     const e175 = rows.find((r) => r.type_code === "E175");
     expect(e175?.starlink_complete).toBe(125);
+  });
+
+  // Regression, github issue #64: the "Of Total" percentage column rendered as
+  // a fake type row ("Total: 2 in mod") because "2.3%" was parsed as a count.
+  test("the Of Total percentage column never becomes a type row", () => {
+    const rows = parseProgressCsv(MAINLINE_NB_CSV, "mainline_nb");
+    expect(rows.map((r) => r.type_code).sort()).toEqual(["738", "73G", "Totals"]);
   });
 
   test("returns no rows for content without a Totals header", () => {


### PR DESCRIPTION
Fixes #64. The /fleet "Active mod lines by type" grid shows a `Total: 2 in mod, 10 verifying` row that contradicts the per-type list right next to it (which sums to 20 in mod, 9 verifying, matching the segment card).

- The upstream progress sheet's mainline-narrowbody tab ends with an "Of Total" *percentage* column; the parser treated it as an aircraft-type column named "Total" and `toCount("2.3%")` stripped the `%` — so the row was literally "2.3% in mod, 10.0% verifying" rendered as counts.
- `toCount` now rejects any percentage cell, and a total-ish header column that isn't the canonical `Totals` rollup is not treated as an aircraft type.
- Regression test uses the real tab's header shape; verified by re-running the sync against all three live sheets (the phantom row is gone and every segment's `Totals` rollup now equals its per-type sum) and rendering /fleet.
- No prod cleanup needed: the daily job full-replaces `fleet_progress` five minutes after the container starts, so the stale row self-heals on deploy.