### PR TITLE
seo: question-intent FAQ entries + route-planner metadata rewrite

### DIFF
--- a/src/airlines/content/ua.tsx
+++ b/src/airlines/content/ua.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { ModelPie, StatRing, computeModelBreakdown } from "../../components/atoms";
 import type { AirlineContent, HeroProps } from "./index";
 
+// Rough observed install cadence — shown in the stat strip and the rollout FAQ;
+// update both go stale together.
+const INSTALLS_PER_MONTH = "40+";
+
 const UAHero = ({ stats, starlinkData }: HeroProps) => {
   const { fleetStats, starlinkCount: x, totalCount: y, percentage } = stats;
   const modelData = computeModelBreakdown(starlinkData);
@@ -44,7 +48,7 @@ export const content: AirlineContent = {
       FREE
     </span>,
     <span key="installs" className="hidden sm:inline">
-      <span className="text-accent font-semibold">40+</span> installs/mo
+      <span className="text-accent font-semibold">{INSTALLS_PER_MONTH}</span> installs/mo
     </span>,
   ],
 
@@ -91,7 +95,7 @@ export const content: AirlineContent = {
               for every equipped tail number.
             </p>
           ),
-          ld: "Mostly United Express flights (UA3000-6999) so far — {{expressPercentage}}% of the Express regional fleet (E175, CRJ-550) is equipped, versus {{mainlinePercentage}}% of mainline. Check a specific flight by number and date at /check-flight, or browse the fleet page for every equipped tail number.",
+          ld: "Mostly United Express flights (UA3000-6999) so far — {{expressPercentageRounded}}% of the Express regional fleet (E175, CRJ-550) is equipped, versus {{mainlinePercentageRounded}}% of mainline. Check a specific flight by number and date at /check-flight, or browse the fleet page for every equipped tail number.",
         },
         {
           q: "Does my United flight have Starlink?",
@@ -189,8 +193,9 @@ export const content: AirlineContent = {
           q: "How fast is United's Starlink rollout?",
           a: ({ starlinkCount }) => (
             <p>
-              About 40+ installs a month. United's first Starlink install was March 2025;{" "}
-              <span className="text-accent">{starlinkCount}</span> aircraft are equipped today. The{" "}
+              About {INSTALLS_PER_MONTH} installs a month. United's first Starlink install was March
+              2025; <span className="text-accent">{starlinkCount}</span> aircraft are equipped
+              today. The{" "}
               <a href="/fleet" className="text-accent hover:underline">
                 fleet page
               </a>{" "}
@@ -198,7 +203,7 @@ export const content: AirlineContent = {
               verified.
             </p>
           ),
-          ld: "About 40+ installs a month. United's first Starlink install was March 2025; {{starlinkCount}} aircraft are equipped today. The fleet page charts the rollout tail by tail, and this page's counters update as new installs are verified.",
+          ld: `About ${INSTALLS_PER_MONTH} installs a month. United's first Starlink install was March 2025; {{starlinkCount}} aircraft are equipped today. The fleet page charts the rollout tail by tail, and this page's counters update as new installs are verified.`,
         },
         {
           q: "When will my route get Starlink?",

--- a/src/airlines/content/ua.tsx
+++ b/src/airlines/content/ua.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { ModelPie, StatRing, computeModelBreakdown } from "../../components/atoms";
 import type { AirlineContent, HeroProps } from "./index";
 
-// Rough observed install cadence — shown in the stat strip and the rollout FAQ;
-// update both go stale together.
+// Rough observed install cadence — shown in the stat strip and the rollout FAQ,
+// so both go stale together when the rate changes.
 const INSTALLS_PER_MONTH = "40+";
 
 const UAHero = ({ stats, starlinkData }: HeroProps) => {

--- a/src/airlines/content/ua.tsx
+++ b/src/airlines/content/ua.tsx
@@ -73,6 +73,27 @@ export const content: AirlineContent = {
       title: "Checking your flight",
       items: [
         {
+          q: "Which United flights have Starlink?",
+          a: ({ fleetStats }) => (
+            <p>
+              Mostly United Express flights (UA3000–6999) so far —{" "}
+              {(fleetStats?.express.percentage || 0).toFixed(0)}% of the Express regional fleet
+              (E175, CRJ-550) is equipped, versus{" "}
+              {(fleetStats?.mainline.percentage || 0).toFixed(0)}% of mainline. To find out about a
+              specific flight,{" "}
+              <a href="/check-flight" className="text-accent hover:underline">
+                check it by number and date
+              </a>
+              , or browse the{" "}
+              <a href="/fleet" className="text-accent hover:underline">
+                fleet page
+              </a>{" "}
+              for every equipped tail number.
+            </p>
+          ),
+          ld: "Mostly United Express flights (UA3000-6999) so far — {{expressPercentage}}% of the Express regional fleet (E175, CRJ-550) is equipped, versus {{mainlinePercentage}}% of mainline. Check a specific flight by number and date at /check-flight, or browse the fleet page for every equipped tail number.",
+        },
+        {
           q: "Does my United flight have Starlink?",
           a: () => (
             <p>
@@ -163,6 +184,21 @@ export const content: AirlineContent = {
             </p>
           ),
           ld: "Not yet — {{percentage}}% of the fleet is equipped today. United Express regional jets (E175, CRJ-550) are at {{expressPercentage}}%; mainline narrowbodies and widebodies are following. The fleet page lists every verified tail.",
+        },
+        {
+          q: "How fast is United's Starlink rollout?",
+          a: ({ starlinkCount }) => (
+            <p>
+              About 40+ installs a month. United's first Starlink install was March 2025;{" "}
+              <span className="text-accent">{starlinkCount}</span> aircraft are equipped today. The{" "}
+              <a href="/fleet" className="text-accent hover:underline">
+                fleet page
+              </a>{" "}
+              charts the rollout tail by tail, and the counters above update as new installs are
+              verified.
+            </p>
+          ),
+          ld: "About 40+ installs a month. United's first Starlink install was March 2025; {{starlinkCount}} aircraft are equipped today. The fleet page charts the rollout tail by tail, and this page's counters update as new installs are verified.",
         },
         {
           q: "When will my route get Starlink?",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1385,6 +1385,8 @@ function buildBaseTemplateVars(
     percentage,
     mainlinePercentage: (fleetStats?.mainline.percentage || 0).toFixed(2),
     expressPercentage: (fleetStats?.express.percentage || 0).toFixed(2),
+    mainlinePercentageRounded: (fleetStats?.mainline.percentage || 0).toFixed(0),
+    expressPercentageRounded: (fleetStats?.express.percentage || 0).toFixed(0),
   };
 
   // Brand copy is registry-authored and may embed count placeholders (e.g.

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1475,10 +1475,10 @@ function subPageMeta(
     };
   if (page === "route-planner")
     return {
-      siteTitle: `Starlink Route Planner — Find ${short} Flights With Starlink WiFi`,
-      siteDescription: `Find the best way to fly ${name} with Starlink WiFi. Compare direct flights and smart connections ranked by Starlink probability. Plan productive travel with full-coverage routings.`,
-      keywords: `starlink route planner, best route for starlink, plan starlink trip, ${name} starlink connections`,
-      ogTitle: `Starlink Route Planner — ${short}`,
+      siteTitle: `${short} Starlink Route Planner — Find Flights With Starlink WiFi`,
+      siteDescription: `See which ${name} routes and flights have Starlink WiFi. Compare direct flights and one-stop connections between any two cities, ranked by Starlink probability, and book the routing with coverage the whole way.`,
+      keywords: `${name} starlink route planner, which ${cfg?.iata ?? "airline"} flights have starlink, ${name} starlink routes, best route for starlink, plan starlink trip`,
+      ogTitle: `${short} Starlink Route Planner`,
       ogDescription:
         "Find direct flights and smart connections with the highest Starlink probability.",
     };


### PR DESCRIPTION
## What

Targets high-impression, low-CTR question queries from Search Console on unitedstarlinktracker.com:

- **New FAQ: "Which United flights have Starlink?"** (2.1k impr/6mo) — answers with the live express vs mainline percentage breakdown and links to /check-flight and /fleet. Renders from `ContentStats` so the numbers are always current.
- **New FAQ: "How fast is United's Starlink rollout?"** ("united starlink rollout", 1.5k impr) — install rate, March 2025 start, live equipped count, link to the fleet rollout page.
- Both entries carry `ld` strings with `{{...}}` placeholders, so they flow into the existing server-rendered FAQPage JSON-LD (`buildFaqJsonLd` → `faqJsonLd` template var) with resolved counts.
- **Route-planner metadata rewrite** (8.2k impr, 0.3% CTR): title now leads with the tenant brand keyword — "United Starlink Route Planner — Find Flights With Starlink WiFi" — and the description opens with "See which United Airlines routes and flights have Starlink WiFi". Stays per-tenant via the existing `subPageMeta` shortName/name lookup, so Alaska/Hawaiian render sensible copy.

## Why

The FAQ system, per-tenant content files, and JSON-LD emission already existed — this fills the two question gaps GSC shows we rank for but don't answer verbatim, and fixes the route-planner title/meta intent mismatch. No new components, no client JS, no keyword stuffing; all claims match data the page already renders.

## Test notes

- `bun run lint` clean (4 pre-existing warnings in untouched files; changed files lint clean)
- `bun run test:setup && bun run test` — 710 pass, 0 fail
- `bunx tsc --noEmit` fails on a pre-existing tsconfig issue (`downlevelIteration` removed in the TS version bunx pulls) — unrelated to this change; reproduces with the diff stashed
- Public contracts untouched (no API or MCP changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)