### PR TITLE
Mark Alaska satellite site live so cross-links route to alaskastarlinktracker.com

### DIFF
--- a/src/airlines/registry.ts
+++ b/src/airlines/registry.ts
@@ -745,7 +745,7 @@ export const SITES: Record<string, SiteConfig> = {
   alaska: {
     key: "alaska",
     scope: "AS",
-    live: false,
+    live: true,
     hosts: ["alaskastarlinktracker.com", "www.alaskastarlinktracker.com"],
     canonicalHost: "alaskastarlinktracker.com",
     brand: AIRLINES.AS.brand,

--- a/tests/isolation.test.ts
+++ b/tests/isolation.test.ts
@@ -457,12 +457,12 @@ describe("hub host shows enabled airlines only", () => {
     expect(text).not.toContain("A7-TST");
   });
 
-  test("homepage links stay on the live generic hub for unlaunched airlines", async () => {
+  test("homepage links go to live airline sites, hub-filtered for unlaunched", async () => {
     const { text } = await bodyOf("/", HUB);
     expect(text).toContain("https://airlinestarlinktracker.com/?filter=HA");
-    expect(text).toContain("https://airlinestarlinktracker.com/?filter=AS");
+    expect(text).toContain("https://alaskastarlinktracker.com/");
     expect(text).not.toContain("https://hawaiianstarlinktracker.com/");
-    expect(text).not.toContain("https://alaskastarlinktracker.com/");
+    expect(text).not.toContain("https://airlinestarlinktracker.com/?filter=AS");
     expect(text).not.toContain("https://qatarstarlinktracker.com/");
   });
 


### PR DESCRIPTION
## What

Flips `SITES.alaska.live` from `false` to `true` in `src/airlines/registry.ts`, and updates the isolation test that pinned the old behavior.

## Why

alaskastarlinktracker.com serves production traffic (673 visitors/30d, +74% MoM) and has its own search demand, but the registry still marked it not-live. The `live` flag gates every `liveOnly` site resolution via `siteForAirline(code, true)` / `airlineHomeUrl(code)`:

- **Hub airline status cards** (`reader.ts` `href: airlineHomeUrl(code)`) — the whole Alaska card on airlinestarlinktracker.com now links to `https://alaskastarlinktracker.com/` instead of `https://airlinestarlinktracker.com/?filter=AS` (a self-link that kept airline-specific intent on the hub).
- **Recent-installs feed** tail links (`atoms.tsx`) — Alaska tails now deep-link to the satellite with `?q=<tail>`.
- **Hub `/llms.txt`** tracked-airlines list — now points AI agents at the Alaska tracker directly.
- **Route-compare API** `canonicalHost` / `routePlannerBase` (`reader.ts brand()`) — Alaska rows now expose the satellite's route-planner chips.
- **Predictor script** report URLs.

Qatar and Hawaiian stay `live: false` — their DNS is dead. No Delta config added (separate effort).

## Already correct, deliberately untouched

- **Canonical tags**: `index.html` emits `<link rel="canonical" href="https://{{host}}{{canonicalPath}}">` with `host` always set to `site.canonicalHost` (`app.ts` `buildBaseTemplateVars`), so www variants canonicalize to the apex on every page.
- **www redirects**: `hostRedirect` in `app.ts` 301s any non-canonical alias in `site.hosts` (GET/HEAD, path+query preserved) — the GSC www.unitedstarlinktracker.com leak is not a code gap.
- **Per-site sitemaps**: `sitemap` handler builds from `sitePages(site)` which filters on `site.features`, plus `/check-flight/UA###` entries only when `checkFlightPage` is on — Alaska's sitemap already reflects only its real pages; `live` never gated sitemap contents.

## Test notes

- `bun run test:setup && bun run test`: 710 pass, 0 fail (includes the updated `tests/isolation.test.ts` hub-homepage-links test, which now asserts Alaska links to the satellite while HA stays hub-filtered and dead domains never appear).
- `bun run lint`: clean (4 pre-existing `useTemplate` warnings on main in untouched files).
- `bunx tsc --noEmit`: fails on `downlevelIteration` (option removed in the latest TS that bunx fetches); repo has no pinned TypeScript or typecheck script, so this is environmental and pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)