### PR TITLE
fix: plumb missing metric tags on freshness/lookup/detection metrics

### DIFF
--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -503,9 +503,11 @@ function recordMcpFlightLookup(
   outcome: LookupOutcome,
   confidence: LookupConfidence
 ): void {
+  // result mirrors outcome — see app.ts recordFlightLookup.
   metrics.increment(COUNTERS.FLIGHT_LOOKUP_RESULT, {
     endpoint: "mcp",
     outcome,
+    result: outcome,
     confidence,
     airline: mcpAirlineTag(scope),
   });

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -26,6 +26,8 @@
  *   http_status:     upstream HTTP status code on vendor.request error/
  *                    rate_limited emits (fr24 only)                  (~10)
  *   result:          success | error | aircraft_mismatch | tail_unknown  (4)
+ *                    on flight.lookup_result it mirrors `outcome` (+5)
+ *   dataset:         mirrors `job` on data.freshness_seconds             (~7)
  *   client_class:    bot | claude | extension | browser | unknown    (5)
  *   confidence:      high | medium | low | none                      (4)
  *   outcome:         verified_yes | verified_no | predicted | no_data | error  (5)
@@ -157,7 +159,7 @@ export const COUNTERS = {
   PLANES_DISCOVERED: "planes.discovered", // tags: source, airline
 
   // New Starlink installation detected on an aircraft
-  // tags: fleet, aircraft_type
+  // tags: fleet, aircraft_type, airline
   PLANES_STARLINK_DETECTED: "planes.starlink_detected",
 
   // Per-tail verification check outcome
@@ -193,12 +195,13 @@ export const COUNTERS = {
   FLEET_SHEET_DISAGREEMENT: "fleet.sheet_disagreement",
 
   // A discovery check was skipped (couldn't run the United.com scrape)
-  // tags: fleet, reason (no_flights)
+  // tags: fleet, reason (no_flights), airline
   FLEET_CHECK_SKIPPED: "fleet.check_skipped",
 
   // User-facing flight lookup outcome — how often we actually answer the question.
   // tags: endpoint (api_check|api_predict|mcp), outcome (verified_yes|verified_no|
-  //   predicted|no_data|error), confidence (high|medium|low|none), airline,
+  //   predicted|no_data|error), result (mirrors outcome — DD monitors group by
+  //   result), confidence (high|medium|low|none), airline,
   //   days_out (past|0..3|4_7|8_14|15_30|31_plus — only the /api/check-flight handler, non-QR)
   FLIGHT_LOOKUP_RESULT: "flight.lookup_result",
 
@@ -223,7 +226,8 @@ export const GAUGES = {
   // Seconds since the last successful data write per pipeline, derived from the
   // DB itself (MAX(timestamp)) — not from a "last ran at" heartbeat. Heartbeats
   // prove the loop is alive; this proves it's still producing data.
-  // tags: job (flight_updater|verifier|departures|qatar_ingester), airline
+  // tags: job (flight_updater|verifier|departures|qatar_ingester), dataset
+  //   (mirrors job — DD monitors group by dataset), airline
   DATA_FRESHNESS_SECONDS: "data.freshness_seconds",
 
   // Backtest precision of firm "yes/no Starlink" calls — tags: airline, window, call

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -226,8 +226,8 @@ export const GAUGES = {
   // Seconds since the last successful data write per pipeline, derived from the
   // DB itself (MAX(timestamp)) — not from a "last ran at" heartbeat. Heartbeats
   // prove the loop is alive; this proves it's still producing data.
-  // tags: job (flight_updater|verifier|departures|qatar_ingester), dataset
-  //   (mirrors job — DD monitors group by dataset), airline
+  // tags: job (see FRESHNESS_QUERIES in data-freshness.ts for the full set),
+  //   dataset (mirrors job — DD monitors group by dataset), airline
   DATA_FRESHNESS_SECONDS: "data.freshness_seconds",
 
   // Backtest precision of firm "yes/no Starlink" calls — tags: airline, window, call

--- a/src/scripts/data-freshness.ts
+++ b/src/scripts/data-freshness.ts
@@ -139,8 +139,12 @@ export function emitDataFreshness(db: Database, queries = FRESHNESS_QUERIES): vo
           else continue;
         }
         const ageSec = Math.max(0, now - ts);
+        // dataset mirrors job: DD monitors/dashboards group this gauge by
+        // dataset, which read N/A while only job was emitted. job stays so
+        // existing series and queries keep working.
         metrics.gauge(GAUGES.DATA_FRESHNESS_SECONDS, ageSec, {
           job,
+          dataset: job,
           airline: normalizeAirlineTag(row.airline),
         });
       }

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -335,6 +335,7 @@ export async function verifyPlane(
                 fleet: fleetTag,
                 sheet_says: sheetSaysStarlink ? "starlink" : "not_starlink",
                 crawler_says: crawlerSaysStarlink ? "starlink" : "not_starlink",
+                airline: normalizeAirlineTag("UA"),
               });
               info(
                 `SHEET DISAGREEMENT: ${plane.tail_number} sheet=${sheetClaim.wifi} crawler=${consensus.verdict} (${consensus.reason})`

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -199,7 +199,11 @@ export async function verifyPlane(
           info(`No upcoming flights for ${plane.tail_number}, skipping`);
         }
         span.setTag("result", "no_flights");
-        metrics.increment(COUNTERS.FLEET_CHECK_SKIPPED, { reason: "no_flights", fleet: fleetTag });
+        metrics.increment(COUNTERS.FLEET_CHECK_SKIPPED, {
+          reason: "no_flights",
+          fleet: fleetTag,
+          airline: normalizeAirlineTag("UA"),
+        });
         // Schedule for later check
         updateFleetVerificationResult(db, plane.tail_number, {
           starlinkStatus: plane.starlink_status as StarlinkStatus,
@@ -282,6 +286,7 @@ export async function verifyPlane(
           metrics.increment(COUNTERS.PLANES_STARLINK_DETECTED, {
             fleet: fleetTag,
             aircraft_type: aircraftTypeTag,
+            airline: checkTags.airline,
           });
         } else {
           span.setTag("result", "not_starlink");

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -393,9 +393,12 @@ function recordFlightLookup(
   airlineCode: string,
   daysOut?: number
 ): void {
+  // result mirrors outcome: DD monitors group this counter by result, which
+  // read N/A while only outcome was emitted. outcome stays for existing series.
   metrics.increment(COUNTERS.FLIGHT_LOOKUP_RESULT, {
     endpoint,
     outcome,
+    result: outcome,
     confidence,
     airline: normalizeAirlineTag(airlineCode),
     ...(daysOut !== undefined && { days_out: bucketDaysOut(daysOut) }),

--- a/tests/jobs.test.ts
+++ b/tests/jobs.test.ts
@@ -715,6 +715,7 @@ describe("qatar_ingester freshness sentinel", () => {
     const call = qatarGauge(captureGauges(db));
     expect(call).toBeDefined();
     expect(call?.tags?.airline).toBe("qatar");
+    expect(call?.tags?.dataset).toBe("qatar_ingester");
     // ts fell back to 0 — staleness is the full epoch age, decades not hours.
     expect(call?.value as number).toBeGreaterThan(50 * 365 * 24 * 3600);
     db.close();


### PR DESCRIPTION
## What

Fixes three `starlink.*` metrics that were reporting with missing/unusable tags in Datadog:

- **`starlink.data.freshness_seconds`** — monitors group by `dataset`, but the emitter only set `job`, so every series read `dataset:N/A` (a ~46h staleness was visible but unattributable). The gauge now emits `dataset` mirroring `job`.
- **`starlink.flight.lookup_result`** — same class of bug: consumers group by `result`, emitter only set `outcome`. Both the REST (`src/server/app.ts`) and MCP (`src/api/mcp-server.ts`) paths now emit `result` mirroring `outcome`.
- **`starlink.planes.starlink_detected`** — the fleet-discovery emit never set `airline`, so `withDefaultAirline` injected `unmapped`. It now passes the canonical airline via `normalizeAirlineTag`. The sibling `fleet.check_skipped` emit in the same file had the identical bug and is fixed too.

Swept every other emitter in `src/` (verification, scraper, vendor, precision, sweep, passenger, BTS, FAA, ADS-B) — all already tag correctly or are intentionally tenant-tagged http metrics; no other changes.

## Why this shape

- Metric **names are untouched** (Datadog history preserved) — only tags change, per convention in `src/observability/metrics.ts`.
- Legacy `job`/`outcome` tag keys are **kept alongside** the new `dataset`/`result` mirrors so any existing queries keyed on them keep working; the tag-cardinality budget header and per-metric doc comments are updated.

## Testing

- `bun run test:setup && bun run test` — 710 pass, 0 fail. Extended the existing qatar_ingester freshness sentinel test in `tests/jobs.test.ts` to assert the `dataset` tag.
- `bun run lint` — clean (4 preexisting warnings, unchanged from main).
- `bunx tsc --noEmit` is not part of this repo's toolchain (latest tsc rejects the tsconfig's `downlevelIteration`; pinning TS 5.8 shows only preexisting errors identical to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)