### PR TITLE
Expose per-family fleet totals and a ranked Starlink routes endpoint

### DIFF
--- a/scripts/capture-golden.ts
+++ b/scripts/capture-golden.ts
@@ -12,12 +12,15 @@
 
 import { Database } from "bun:sqlite";
 import { mkdir, writeFile } from "node:fs/promises";
+import { setupTables } from "../src/database/database";
 import { createApp } from "../src/server/app";
 import { mcpReq } from "../tests/helpers";
 
 const OUT = "tests/golden";
 
-const app = createApp(new Database(":memory:"));
+const db = new Database(":memory:");
+setupTables(db);
+const app = createApp(db);
 const r = await app.dispatch(mcpReq("unitedstarlinktracker.com", "tools/list", {}));
 if (r.status !== 200) throw new Error(`mcp tools/list → ${r.status}`);
 

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -224,7 +224,7 @@ function buildTools(scope: Scope) {
     },
     {
       name: "get_fleet_stats",
-      description: `Use when the user asks "how far along is the Starlink rollout?" or wants overall fleet numbers. Returns ${carrier} Starlink installation counts and percentages across mainline and express fleets. Not for per-flight checks — use check_flight for that.`,
+      description: `Use when the user asks "how far along is the Starlink rollout?" or wants overall fleet numbers. Returns ${carrier} Starlink installation counts and percentages across mainline and express fleets, plus a per-aircraft-type breakdown (installed/total per family). Not for per-flight checks — use check_flight for that.`,
       inputSchema: {
         type: "object",
         properties: {},
@@ -1527,10 +1527,15 @@ ${lines.join("\n")}`;
       ? `**Mainline Fleet**: ${fleetStats.mainline.starlink} of ${fleetStats.mainline.total} aircraft (${fleetStats.mainline.percentage.toFixed(1)}%)`
       : null,
   ].filter((l) => l !== null);
+  const familyLines = reader
+    .getFleetPageData()
+    .families.filter((f) => f.family !== "unknown")
+    .map((f) => `- ${f.family}: ${f.starlink} of ${f.total} (${pct(f.starlink, f.total)}%)`);
   const text = [
     `${cfg.name} Starlink Installation Progress (as of ${lastUpdated}):`,
     `**Combined Fleet**: ${starlinkPlanes.length} of ${totalCount} aircraft (${pct(starlinkPlanes.length, totalCount)}%) have Starlink WiFi`,
     subfleetLines.join("\n"),
+    familyLines.length > 0 ? `**By Aircraft Type**:\n${familyLines.join("\n")}` : null,
     `**Rollout**: ${cfg.rollout.statusLabel} — ${cfg.rollout.phaseNote}`,
     "Starlink WiFi is free for passengers on equipped aircraft.",
   ]

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -370,15 +370,37 @@ const apiFleetSummary: Handler = ({ req, getReader }) => {
     const r = getReader(cfg.code);
     const installed = r.getStarlinkPlanes().length;
     const total = r.getTotalCount();
+    const families = r.getFleetPageData().families.map((f) => ({
+      family: f.family,
+      body: f.body,
+      installed: f.starlink,
+      total: f.total,
+      percentage: f.total > 0 ? Math.round((f.starlink / f.total) * 1000) / 10 : 0,
+    }));
     return {
       code: cfg.code,
       name: cfg.name,
       installed,
       total,
       percentage: total > 0 ? Math.round((installed / total) * 1000) / 10 : 0,
+      families,
     };
   });
   return new Response(JSON.stringify({ airlines, generatedAt: new Date().toISOString() }), {
+    headers: { ...SECURITY_HEADERS.api, "Cache-Control": "public, max-age=300" },
+  });
+};
+
+const apiRoutes: Handler = ({ req, site, reader }) => {
+  if (req.method !== "GET") return methodNotAllowed(true);
+  if (!site.features.routesPage) {
+    return new Response(JSON.stringify({ error: "Not found" }), {
+      status: 404,
+      headers: SECURITY_HEADERS.api,
+    });
+  }
+  const schedule = reader.getRouteStarlinkSchedule();
+  return new Response(JSON.stringify(schedule), {
     headers: { ...SECURITY_HEADERS.api, "Cache-Control": "public, max-age=300" },
   });
 };
@@ -1832,6 +1854,7 @@ export function createApp(db: Database): App {
     "/routes": routesPage,
     "/api/data": apiData,
     "/api/fleet-summary": apiFleetSummary,
+    "/api/routes": apiRoutes,
     "/api/check-flight": apiCheckFlight,
     "/api/check-any-flight": apiCheckAnyFlight,
     "/api/compare-route": apiCompareRoute,

--- a/tests/golden/mcp-tools-list.json
+++ b/tests/golden/mcp-tools-list.json
@@ -31,7 +31,7 @@
       },
       {
         "name": "get_fleet_stats",
-        "description": "Use when the user asks \"how far along is the Starlink rollout?\" or wants overall fleet numbers. Returns United Airlines Starlink installation counts and percentages across mainline and express fleets. Not for per-flight checks — use check_flight for that.",
+        "description": "Use when the user asks \"how far along is the Starlink rollout?\" or wants overall fleet numbers. Returns United Airlines Starlink installation counts and percentages across mainline and express fleets, plus a per-aircraft-type breakdown (installed/total per family). Not for per-flight checks — use check_flight for that.",
         "inputSchema": {
           "type": "object",
           "properties": {},

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -277,6 +277,14 @@ describe("MCP tools", () => {
     expect(json.result.isError).toBeUndefined();
   });
 
+  test("get_fleet_stats: includes per-aircraft-type breakdown", async () => {
+    const json = await mcpCall("tools/call", { name: "get_fleet_stats", arguments: {} });
+    const text = json.result.content[0].text as string;
+    expect(text).toContain("**By Aircraft Type**");
+    expect(text).toMatch(/- \S+: \d+ of \d+ \(\d+\.\d%\)/);
+    expect(text).not.toContain("unknown");
+  });
+
   test("predict_flight_starlink: unseen mainline flight gets low fleet prior", async () => {
     // Pick a flight number in mainline range (1-2999) not in verification log
     const unseen = db
@@ -1043,6 +1051,98 @@ describe("getRouteStarlinkSchedule", () => {
       new Request("http://x/routes", { headers: { Host: "airlinestarlinktracker.com" } })
     );
     expect(hub.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/fleet-summary — per-family installed/total breakdown
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("/api/fleet-summary families", () => {
+  test("each airline entry carries a per-family installed/total breakdown", async () => {
+    const app = createApp(db);
+    const res = await app.dispatch(
+      new Request("http://x/api/fleet-summary", {
+        headers: { Host: "unitedstarlinktracker.com" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      airlines: {
+        code: string;
+        installed: number;
+        total: number;
+        families: {
+          family: string;
+          body: string;
+          installed: number;
+          total: number;
+          percentage: number;
+        }[];
+      }[];
+    };
+    const ua = body.airlines.find((a) => a.code === "UA");
+    expect(ua).toBeDefined();
+    if (!ua) return;
+
+    expect(ua.families.length).toBeGreaterThan(1);
+    for (const f of ua.families) {
+      expect(f.family.length).toBeGreaterThan(0);
+      expect(f.installed).toBeGreaterThanOrEqual(0);
+      expect(f.installed).toBeLessThanOrEqual(f.total);
+      expect(f.percentage).toBeGreaterThanOrEqual(0);
+      expect(f.percentage).toBeLessThanOrEqual(100);
+    }
+    expect(ua.families.some((f) => f.installed > 0)).toBe(true);
+    const famTotal = ua.families.reduce((s, f) => s + f.total, 0);
+    expect(famTotal).toBeGreaterThan(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// /api/routes — machine-readable form of the /routes schedule
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("/api/routes", () => {
+  test("returns the ranked Starlink route schedule", async () => {
+    const app = createApp(db);
+    const res = await app.dispatch(
+      new Request("http://x/api/routes", { headers: { Host: "unitedstarlinktracker.com" } })
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      rows: {
+        origin: string;
+        destination: string;
+        departures: number;
+        flight_numbers: number;
+        next_departure: number;
+      }[];
+      totalDepartures: number;
+      windowLabel: string;
+    };
+    expect(typeof body.totalDepartures).toBe("number");
+    expect(typeof body.windowLabel).toBe("string");
+    expect(Array.isArray(body.rows)).toBe(true);
+    expect(body.rows.length).toBeLessThanOrEqual(60);
+    for (const r of body.rows) {
+      expect(r.origin).toMatch(/^[A-Z0-9]{3,4}$/);
+      expect(r.destination).toMatch(/^[A-Z0-9]{3,4}$/);
+      expect(r.departures).toBeGreaterThan(0);
+      expect(r.flight_numbers).toBeGreaterThan(0);
+      expect(typeof r.next_departure).toBe("number");
+    }
+    for (let i = 1; i < body.rows.length; i++) {
+      expect(body.rows[i].departures).toBeLessThanOrEqual(body.rows[i - 1].departures);
+    }
+  });
+
+  test("404s where the routes feature is off", async () => {
+    const app = createApp(db);
+    const res = await app.dispatch(
+      new Request("http://x/api/routes", { headers: { Host: "airlinestarlinktracker.com" } })
+    );
+    expect(res.status).toBe(404);
   });
 });
 

--- a/tests/isolation.test.ts
+++ b/tests/isolation.test.ts
@@ -116,6 +116,7 @@ const ENDPOINTS = [
   "/route-planner",
   "/api/data",
   "/api/fleet-summary",
+  "/api/routes",
   "/api/check-flight?flight_number=HA9999&date=2026-03-22",
   "/api/check-flight?flight_number=QR9999&date=2026-03-22",
   "/api/mismatches",


### PR DESCRIPTION
Adds per-aircraft-family installed/total counts to `/api/fleet-summary` and `get_fleet_stats` (closes #69), and exposes the `/routes` schedule as machine-readable JSON at `/api/routes`.