### PR TITLE
fix(check-flight): don't dead-end when the URL isn't a flight number

### DIFF
--- a/src/components/check-flight-page.tsx
+++ b/src/components/check-flight-page.tsx
@@ -31,9 +31,19 @@ export interface FlightFacts {
   upcoming: FlightUpcomingDeparture[];
 }
 
+/** A permalink segment that is not a flight number this site can answer for.
+ * `query` is the offending segment (null when it could not be decoded), never
+ * trusted — React escapes it at render. */
+export interface InvalidFlightQuery {
+  query: string | null;
+  reason: "not-a-flight-number" | "other-carrier";
+  airportHint: boolean;
+}
+
 interface CheckFlightPageProps {
   site: SiteConfig;
   flight?: FlightFacts;
+  invalid?: InvalidFlightQuery;
 }
 
 const fmtDay = (sec: number) =>
@@ -182,7 +192,43 @@ function FlightFactBlocks({ flight }: { flight: FlightFacts }) {
   );
 }
 
-export default function CheckFlightPage({ site, flight }: CheckFlightPageProps) {
+function InvalidQueryNotice({
+  invalid,
+  example,
+  shortName,
+  showRoutePlanner,
+}: {
+  invalid: InvalidFlightQuery;
+  example: string;
+  shortName: string;
+  showRoutePlanner: boolean;
+}) {
+  const quoted = invalid.query ? `“${invalid.query}”` : "That";
+  return (
+    <div className="bg-surface-elevated border border-subtle rounded p-4 mb-4">
+      <p className="text-sm text-secondary">
+        {invalid.reason === "other-carrier"
+          ? `${quoted} isn't a ${shortName} flight number — this tracker only covers ${shortName} flights.`
+          : `${quoted} isn't a flight number.`}
+      </p>
+      <p className="text-sm text-muted mt-1">
+        Flight numbers look like <span className="font-mono text-secondary">{example}</span> — a
+        two-letter airline code followed by 1–4 digits. Try again below.
+      </p>
+      {invalid.airportHint && showRoutePlanner && (
+        <p className="text-sm text-muted mt-2">
+          Looking for an airport or a route instead? Try the{" "}
+          <a href="/route-planner" className="text-accent hover:underline">
+            route planner
+          </a>
+          .
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default function CheckFlightPage({ site, flight, invalid }: CheckFlightPageProps) {
   const cfg = siteAirline(site);
   const airlineName = flight?.airlineName ?? cfg.name;
   const homeTitle = site.brand.title;
@@ -211,15 +257,19 @@ export default function CheckFlightPage({ site, flight }: CheckFlightPageProps) 
       <header className="relative py-5 sm:py-6 text-center mb-6">
         <a href="/" className="block">
           <h1 className="font-display text-3xl sm:text-4xl font-bold text-primary mb-2 tracking-tight hover:text-accent transition-colors">
-            {flight
-              ? `Does ${flight.flightNumber} Have Starlink WiFi?`
-              : `Check If Your ${airlineName} Flight Has Starlink WiFi`}
+            {invalid
+              ? "That Doesn't Look Like a Flight Number"
+              : flight
+                ? `Does ${flight.flightNumber} Have Starlink WiFi?`
+                : `Check If Your ${airlineName} Flight Has Starlink WiFi`}
           </h1>
         </a>
         <p className="text-base text-secondary font-display">
-          {flight
-            ? flightSummary(flight)
-            : "Enter your flight number and date to see if your aircraft has free Starlink internet"}
+          {invalid
+            ? `Enter a ${shortName} flight number below to check for Starlink`
+            : flight
+              ? flightSummary(flight)
+              : "Enter your flight number and date to see if your aircraft has free Starlink internet"}
         </p>
       </header>
 
@@ -228,6 +278,14 @@ export default function CheckFlightPage({ site, flight }: CheckFlightPageProps) 
           <h2 className="font-display text-lg font-semibold text-primary mb-4">
             Check by flight number
           </h2>
+          {invalid && (
+            <InvalidQueryNotice
+              invalid={invalid}
+              example={flightExample}
+              shortName={shortName}
+              showRoutePlanner={site.features.routePlannerPage}
+            />
+          )}
           <form id="check-flight-form" className="space-y-4">
             <div className="flex flex-col sm:flex-row gap-3">
               <div className="flex-1">

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -57,7 +57,10 @@ import {
   type AirlineOverview,
   AirlinesIndexPage,
 } from "../components/airlines-page";
-import CheckFlightPage, { type FlightFacts } from "../components/check-flight-page";
+import CheckFlightPage, {
+  type FlightFacts,
+  type InvalidFlightQuery,
+} from "../components/check-flight-page";
 import FleetPage from "../components/fleet-page";
 import McpPage from "../components/mcp-page";
 import MethodologyPage, { hasMethodology } from "../components/methodology-page";
@@ -1504,7 +1507,8 @@ async function renderSubPage<P extends { site: SiteConfig }>(
   component: React.ComponentType<P>,
   canonicalPath: string,
   meta: PageMeta,
-  props?: Omit<P, "site">
+  props?: Omit<P, "site">,
+  status = 200
 ): Promise<Response> {
   const reactHtml = ReactDOMServer.renderToString(
     React.createElement(component, { site: ctx.site, ...(props ?? {}) } as unknown as P)
@@ -1523,7 +1527,12 @@ async function renderSubPage<P extends { site: SiteConfig }>(
   });
 
   const template = await getHtmlTemplate();
-  return new Response(renderHtml(template, htmlVariables), { headers: SECURITY_HEADERS.html });
+  return new Response(renderHtml(template, htmlVariables), {
+    status,
+    // Keep the HTML CSP even on 404s: this page runs the inline lookup script,
+    // which SECURITY_HEADERS.notFound would block.
+    headers: SECURITY_HEADERS.html,
+  });
 }
 
 function subPageMeta(
@@ -1580,27 +1589,36 @@ function resolveFlightCfg(ctx: RequestContext, flightNumber: string): AirlineCon
   return detectAirline(flightNumber);
 }
 
+type CheckFlightPath =
+  | { kind: "bare" }
+  | { kind: "flight"; raw: string; fn: string; date: string | null }
+  | { kind: "invalid"; raw: string | null };
+
 /** Parse `/check-flight/{flightNumber}[/{date}]`. `raw` is the segment as
  * requested, `fn` its canonical spelling (uppercase, zero-padding stripped) —
- * a mismatch means 301, so each flight has exactly one indexable URL. Returns
- * null for the bare page or a malformed segment. */
-function parseCheckFlightPath(
-  pathname: string
-): { raw: string; fn: string; date: string | null } | null {
+ * a mismatch means 301, so each flight has exactly one indexable URL. A segment
+ * that isn't a flight number is `invalid` (raw null when it wouldn't decode) so
+ * the handler can explain itself instead of dead-ending on a bare 404. */
+function parseCheckFlightPath(pathname: string): CheckFlightPath {
   const rest = pathname.slice("/check-flight/".length).replace(/\/+$/, "");
-  if (!rest) return null;
+  if (!rest) return { kind: "bare" };
   const [first, second] = rest.split("/");
   let raw: string;
   try {
     raw = decodeURIComponent(first ?? "").trim();
   } catch {
-    return null; // malformed % escape — fall through to the generic page
+    return { kind: "invalid", raw: null }; // malformed % escape
   }
   const fn = stripFlightNumberZeros(raw.toUpperCase());
-  if (!/^[A-Z]{2}\d{1,4}$/.test(fn)) return null;
+  if (!/^[A-Z]{2}\d{1,4}$/.test(fn)) return { kind: "invalid", raw };
   const date = second && /^\d{4}-\d{2}-\d{2}$/.test(second) ? second : null;
-  return { raw, fn, date };
+  return { kind: "flight", raw, fn, date };
 }
+
+/** Cap what an invalid segment can echo back into the page. React escapes it;
+ * this only keeps a pasted essay from wrecking the layout. */
+const echoQuery = (raw: string | null): string | null =>
+  raw ? (raw.length > 24 ? `${raw.slice(0, 24)}…` : raw) : null;
 
 const AIRPORT_CODE_RE = /^[A-Z0-9]{3,4}$/;
 
@@ -1731,7 +1749,28 @@ const checkFlightPage: Handler = (ctx) => {
   // content + meta + Flight JSON-LD; the date-less URL is canonical so date
   // variants don't dilute it.
   const parsed = parseCheckFlightPath(ctx.url.pathname);
-  if (parsed) {
+  // A segment that isn't a flight number (an airport code, a city, a typo —
+  // the homepage form navigates here with whatever was typed) still 404s, but
+  // renders the real page with a notice and the working lookup form instead of
+  // the bare not-found document.
+  const invalidPage = (invalid: InvalidFlightQuery) =>
+    renderSubPage(
+      ctx,
+      CheckFlightPage,
+      "/check-flight",
+      { ...subPageMeta(ctx, "check-flight"), robotsMeta: "noindex, nofollow" },
+      { invalid },
+      404
+    );
+  if (parsed.kind === "invalid") {
+    const query = echoQuery(parsed.raw);
+    return invalidPage({
+      query,
+      reason: "not-a-flight-number",
+      airportHint: query !== null && AIRPORT_CODE_RE.test(query.toUpperCase()),
+    });
+  }
+  if (parsed.kind === "flight") {
     const { raw, fn, date } = parsed;
     if (raw !== fn) {
       // Non-canonical spellings (ua123, UA0123) 301 home, date preserved.
@@ -1741,7 +1780,10 @@ const checkFlightPage: Handler = (ctx) => {
       );
     }
     const cfg = resolveFlightCfg(ctx, fn);
-    if (!cfg) return notFound(ctx.site);
+    // Shape-valid but carrying another carrier's prefix on this host. The
+    // notice never names that carrier — a tenant host must not confirm what
+    // else exists (same rule the /api foreign-prefix gate follows).
+    if (!cfg) return invalidPage({ query: fn, reason: "other-carrier", airportHint: false });
     const reader = ctx.tenant === "ALL" ? ctx.getReader(cfg.code) : ctx.reader;
     const variants = buildFlightLookupVariants(cfg, fn);
     // Existence gate (same data test as the sitemap): no rows behind the
@@ -1766,9 +1808,8 @@ const checkFlightPage: Handler = (ctx) => {
       { flight: facts }
     );
   }
-  // Bare /check-flight is the generic indexable page; anything else under the
-  // prefix is a malformed segment (bad escape, not a flight number) → hard 404.
-  if (ctx.url.pathname.replace(/\/+$/, "") !== "/check-flight") return notFound(ctx.site);
+  // Bare /check-flight (with or without a trailing slash) — the generic
+  // indexable page.
   return renderSubPage(ctx, CheckFlightPage, "/check-flight", subPageMeta(ctx, "check-flight"));
 };
 

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -149,12 +149,41 @@ describe("flight permalink gate + normalization", () => {
     expect(html).toContain('id="check-flight-form"');
   });
 
-  test("malformed and other-carrier segments → hard 404", async () => {
+  test("malformed and other-carrier segments → 404, noindex", async () => {
     for (const seg of ["UA123X", "banana", "AA123"]) {
       const res = await app.dispatch(req(`/check-flight/${seg}`, HOST));
       expect(res.status, seg).toBe(404);
       expect(await res.text(), seg).toContain("noindex");
     }
+  });
+
+  // A 404 must still be usable: the segment users actually mistype (an airport
+  // code from the homepage form) explains itself and offers the lookup again.
+  test("non-flight-number segment → 404 page with notice, form, and route-planner hint", async () => {
+    const res = await app.dispatch(req("/check-flight/PHX", HOST));
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("isn&#x27;t a flight number");
+    expect(html).toContain("PHX");
+    expect(html).toContain('id="check-flight-form"');
+    expect(html).toContain('href="/route-planner"');
+    expect(html).not.toContain("The page you&#x27;re looking for doesn&#x27;t exist");
+  });
+
+  test("non-airport garbage → 404 page with notice but no route-planner hint", async () => {
+    const res = await app.dispatch(req("/check-flight/phoenix%20arizona", HOST));
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("isn&#x27;t a flight number");
+    expect(html).not.toContain('href="/route-planner"');
+  });
+
+  test("other-carrier segment → 404 page that never names the other carrier", async () => {
+    const res = await app.dispatch(req("/check-flight/AA123", HOST));
+    expect(res.status).toBe(404);
+    const html = await res.text();
+    expect(html).toContain("AA123");
+    expect(html).not.toContain("American");
   });
 
   test("zero-padded spelling → 301 to the canonical flight URL", async () => {


### PR DESCRIPTION
## The problem

The flight box on the homepage navigates to `/check-flight/<whatever you typed>`. Type an airport code, a city, or a typo and you get the bare 404 document — no site chrome, no lookup form, no hint about what went wrong. Dead end.

**Before** — `https://unitedstarlinktracker.com/check-flight/TEST`

<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/4802b722-9bea-4048-bf4d-ba598a3d9a49" />

## The fix

Still a 404 (right status, still `noindex`), but now it's the real check-flight page: it says what went wrong and puts the lookup form right there, pre-filled with what you typed so you can fix it in place.

**After**

<img width="2560" height="1271" alt="image" src="https://github.com/user-attachments/assets/a0849cf5-22cd-4c20-941c-c65a41dbd0f2" />

## What changed

- `parseCheckFlightPath` returns a discriminated result (`bare` / `flight` / `invalid`) instead of `null`, so the handler can tell the bare page from a segment that isn't a flight number.
- Invalid segments render `CheckFlightPage` with a notice at 404 instead of falling through to `notFound()`. Segments that look like airport codes (`PHX`, `SFO`) link to the route planner.
- A flight number carrying another carrier's prefix (`AA123` on the UA host) gets the same page, with a notice that never names that carrier — same rule the `/api` foreign-prefix gate follows.
- `renderSubPage` takes an optional status, so a page can render at 404 while keeping the HTML CSP the inline lookup script needs.
- The echoed segment is length-capped and React-escaped; the existing XSS test is untouched and still passes.

## Tests

`bun test tests/` → 759 pass. Existing 404/`noindex` assertions unchanged. New cases:

- `/check-flight/PHX` → 404 with the notice, the form, and a route-planner link
- `/check-flight/phoenix%20arizona` → 404 with the notice, no route-planner link
- `/check-flight/AA123` → 404 that never says "American"

## Not in this PR

The homepage and check-flight forms still let `PHX` round-trip to the server — they only guard against empty input today. Client-side validation is a follow-up
