### PR TITLE
fix: serve the current route on flight permalinks, align hub denominator

### DIFF
--- a/src/components/airlines-page.tsx
+++ b/src/components/airlines-page.tsx
@@ -26,9 +26,11 @@ export interface AirlineOverview {
 }
 
 function fleetShare(stat: PerAirlineStat): { fleet: number; pct: number } {
-  // % over the FULL fleet (same convention as the hub status cards) so it
-  // reads as "odds on a random flight".
-  const fleet = stat.fleetTotal ?? stat.total;
+  // % over the FULL fleet so it reads as "odds on a random flight". `total` is
+  // the same denominator the airline's own tracker publishes; fleetTotal counts
+  // only the tails we hold rows for, which is smaller and would make the hub
+  // quote a higher percentage than the tenant site for the same airline.
+  const fleet = stat.total;
   return { fleet, pct: fleet > 0 ? Math.round((stat.starlink / fleet) * 100) : 0 };
 }
 

--- a/src/components/atoms.tsx
+++ b/src/components/atoms.tsx
@@ -82,7 +82,9 @@ export const STATUS_TONE = {
 export function AirlineStatusCards({ stats }: { stats: PerAirlineStat[] }) {
   const ranked = [...stats]
     .map((a) => {
-      const fleet = a.fleetTotal ?? a.total;
+      // `total`, not fleetTotal — see fleetShare in airlines-page: the hub must
+      // quote the same denominator the airline's own tracker publishes.
+      const fleet = a.total;
       return { ...a, fleet, pct: fleet > 0 ? (a.starlink / fleet) * 100 : 0 };
     })
     .sort((a, b) => b.pct - a.pct);

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1804,11 +1804,20 @@ export interface FlightRoutePair {
   /** Times we've seen this flight number on this leg (route cache + live window). */
   times: number;
   dur_sec: number | null;
+  /** 1 when the leg appears in the live schedule window, 0 when it is only history. */
+  scheduled: number;
 }
 
-/** Route pairs a flight number flies, most-flown first — the accumulated
- * flight_routes cache unioned with the live upcoming_flights window (which
- * covers legs the cache hasn't recorded yet). */
+/** Route pairs a flight number flies, currently-scheduled legs first and
+ * most-flown within that — the accumulated flight_routes cache unioned with the
+ * live upcoming_flights window (which covers legs the cache hasn't recorded yet).
+ *
+ * Ordering leads with `scheduled` rather than raw frequency because
+ * flight_routes.seen_count accumulates for the life of a flight number. When a
+ * number is reassigned to a new city pair, the retired leg keeps out-counting
+ * the current one indefinitely, so callers that take routes[0] as "the" route —
+ * page titles, meta descriptions, Flight JSON-LD — would advertise a route the
+ * flight no longer flies. */
 export function getFlightRoutePairs(
   db: Database,
   variants: string[],
@@ -1817,7 +1826,8 @@ export function getFlightRoutePairs(
   const placeholders = variants.map(() => "?").join(",");
   const upcoming = withAirline(
     `SELECT departure_airport, arrival_airport, COUNT(*) AS times,
-            CAST(AVG(arrival_time - departure_time) AS INTEGER) AS dur_sec
+            CAST(AVG(arrival_time - departure_time) AS INTEGER) AS dur_sec,
+            1 AS scheduled
      FROM upcoming_flights WHERE flight_number IN (${placeholders})`,
     airline,
     "",
@@ -1825,16 +1835,17 @@ export function getFlightRoutePairs(
   );
   return db
     .query(
-      `SELECT departure_airport, arrival_airport, SUM(times) AS times, MAX(dur_sec) AS dur_sec
+      `SELECT departure_airport, arrival_airport, SUM(times) AS times, MAX(dur_sec) AS dur_sec,
+              MAX(scheduled) AS scheduled
        FROM (
          SELECT origin AS departure_airport, destination AS arrival_airport,
-                seen_count AS times, duration_sec AS dur_sec
+                seen_count AS times, duration_sec AS dur_sec, 0 AS scheduled
          FROM flight_routes WHERE flight_number IN (${placeholders})
          UNION ALL
          ${upcoming.sql} GROUP BY departure_airport, arrival_airport
        )
        GROUP BY departure_airport, arrival_airport
-       ORDER BY times DESC LIMIT 4`
+       ORDER BY scheduled DESC, times DESC LIMIT 4`
     )
     .all(...variants, ...upcoming.params) as FlightRoutePair[];
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1694,7 +1694,6 @@ function flightPageMeta(
   cfg: AirlineConfig,
   facts: FlightFacts
 ): PageMeta {
-  const brand = ctx.site.brand;
   const route = facts.routes[0] ?? null;
   const routeLabel = route ? ` (${route.departure_airport} → ${route.arrival_airport})` : "";
   const answer = flightMetaAnswer(reader, cfg, flightNumber, facts);
@@ -1712,11 +1711,14 @@ function flightPageMeta(
       })
     : "";
 
+  // The route pair carries both the WiFi intent and the flight-status intent
+  // people actually type, and it fits well inside the ~60 chars Google renders
+  // once the brand suffix is gone (Google appends the site name itself).
   return {
-    siteTitle: `Does ${flightNumber} Have Starlink WiFi? | ${brand.title}`,
+    siteTitle: `Does ${flightNumber}${routeLabel} Have Starlink WiFi?`,
     siteDescription: `Does ${cfg.name} ${flightNumber}${routeLabel} have free Starlink WiFi?${answer} Pick a date for a firm answer once aircraft assignments publish.`,
     keywords: `${flightNumber} starlink, does ${flightNumber} have wifi, ${flightNumber} wifi, ${cfg.name} ${flightNumber} starlink`,
-    ogTitle: `Does ${flightNumber} Have Starlink WiFi?`,
+    ogTitle: `Does ${flightNumber}${routeLabel} Have Starlink WiFi?`,
     ogDescription: `${cfg.name} ${flightNumber}${routeLabel} — check Starlink availability and get a probability estimate.`,
     pageJsonLd,
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,11 @@ export interface PerAirlineStat {
   code: string;
   name: string;
   starlink: number;
+  /** Published fleet size — the denominator every surface must divide by. */
   total: number;
+  /** Tails we actually hold rows for. Smaller than `total`; the gap is a
+   * coverage signal, NOT a denominator. Dividing by it makes the hub quote a
+   * higher percentage than the airline's own tracker for the same airline. */
   fleetTotal?: number;
   installs30d?: number;
   status?: RolloutStatus;

--- a/tests/flight-route-pairs.test.ts
+++ b/tests/flight-route-pairs.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Route-pair ordering.
+ *
+ * flight_routes.seen_count accumulates for the life of a flight number, so a
+ * retired leg out-counts the current one forever once a number is reassigned.
+ * Callers treat routes[0] as "the" route (page title, meta description, Flight
+ * JSON-LD), so a currently-scheduled leg must sort ahead of a heavier historical
+ * one — otherwise every permalink for a reassigned flight advertises a route it
+ * no longer flies.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getFlightRoutePairs } from "../src/database/database";
+import { makeSyntheticDb, utc } from "./helpers";
+
+function seedReassignedFlight() {
+  const db = makeSyntheticDb();
+  // The retired leg: flown for months, huge seen_count, no longer scheduled.
+  db.run(
+    `INSERT INTO flight_routes
+       (flight_number, origin, destination, duration_sec, first_seen_at, last_seen_at, seen_count)
+     VALUES ('UA1340', 'IAH', 'EWR', 10800, ?, ?, 240)`,
+    [utc("2025-01-01T00:00:00Z"), utc("2026-05-01T00:00:00Z")]
+  );
+  // The current leg: only a handful of live rows, but it is what actually flies.
+  const dep = utc("2026-08-15T17:55:00Z");
+  for (let i = 0; i < 3; i++) {
+    db.run(
+      `INSERT INTO upcoming_flights
+         (tail_number, flight_number, departure_airport, arrival_airport,
+          departure_time, arrival_time, last_updated, airline)
+       VALUES ('N12345', 'UA1340', 'EWR', 'SFO', ?, ?, ?, 'UA')`,
+      [dep + i * 86400, dep + i * 86400 + 21600, dep]
+    );
+  }
+  return db;
+}
+
+describe("getFlightRoutePairs ordering", () => {
+  test("a scheduled leg outranks a heavier historical leg", () => {
+    const db = seedReassignedFlight();
+    const rows = getFlightRoutePairs(db, ["UA1340"], "UA");
+
+    expect(rows.length).toBe(2);
+    // routes[0] is what the title/meta/JSON-LD advertise.
+    expect(rows[0].departure_airport).toBe("EWR");
+    expect(rows[0].arrival_airport).toBe("SFO");
+    expect(rows[0].scheduled).toBe(1);
+    // The retired leg is still surfaced, just demoted despite its higher count.
+    expect(rows[1].departure_airport).toBe("IAH");
+    expect(rows[1].scheduled).toBe(0);
+    expect(rows[1].times).toBeGreaterThan(rows[0].times);
+    db.close();
+  });
+
+  test("history-only flights keep most-flown-first ordering", () => {
+    const db = makeSyntheticDb();
+    for (const [origin, destination, seen] of [
+      ["ORD", "DEN", 12],
+      ["ORD", "LAX", 90],
+    ] as const) {
+      db.run(
+        `INSERT INTO flight_routes
+           (flight_number, origin, destination, duration_sec, first_seen_at, last_seen_at, seen_count)
+         VALUES ('UA4242', ?, ?, 7200, ?, ?, ?)`,
+        [origin, destination, utc("2026-01-01T00:00:00Z"), utc("2026-08-01T00:00:00Z"), seen]
+      );
+    }
+    const rows = getFlightRoutePairs(db, ["UA4242"], "UA");
+
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["LAX", "DEN"]);
+    expect(rows.every((r) => r.scheduled === 0)).toBe(true);
+    db.close();
+  });
+
+  test("a leg that is both scheduled and historical merges into one row", () => {
+    const db = makeSyntheticDb();
+    db.run(
+      `INSERT INTO flight_routes
+         (flight_number, origin, destination, duration_sec, first_seen_at, last_seen_at, seen_count)
+       VALUES ('UA7', 'SFO', 'SIN', 61200, ?, ?, 30)`,
+      [utc("2026-01-01T00:00:00Z"), utc("2026-08-10T00:00:00Z")]
+    );
+    const dep = utc("2026-08-16T12:00:00Z");
+    db.run(
+      `INSERT INTO upcoming_flights
+         (tail_number, flight_number, departure_airport, arrival_airport,
+          departure_time, arrival_time, last_updated, airline)
+       VALUES ('N54321', 'UA7', 'SFO', 'SIN', ?, ?, ?, 'UA')`,
+      [dep, dep + 61200, dep]
+    );
+    const rows = getFlightRoutePairs(db, ["UA7"], "UA");
+
+    expect(rows.length).toBe(1);
+    expect(rows[0].scheduled).toBe(1);
+    expect(rows[0].times).toBe(31);
+    db.close();
+  });
+});


### PR DESCRIPTION
Three data-accuracy fixes behind the `/check-flight/*` permalinks — the one surface earning genuine non-branded organic traffic (12.3K impressions / 1000+ URLs over the last 28 days).

## 1. Flight permalinks advertised routes the flight no longer flies

`getFlightRoutePairs` ordered by `times DESC`. `flight_routes.seen_count` accumulates for the life of a flight number, so when a number is reassigned to a new city pair the **retired leg out-counts the current one indefinitely**.

Callers take `routes[0]` as "the" route — page title, meta description, `Flight` JSON-LD — so the permalink advertises a dead route. Live example: our `/check-flight/UA1340` renders **IAH → EWR** while the flight actually operates **EWR → SFO**.

Currently-scheduled legs (present in the `upcoming_flights` window) now sort first, most-flown within that. History-only flights keep the previous ordering exactly.

## 2. Route pair in the permalink title

The route was already computed and already in the meta description — the `<title>` just didn't use it, and spent ~30 characters on a brand suffix Google appends itself.

```
- Does UA1340 Have Starlink WiFi? | United Airlines Starlink Tracker
+ Does UA1340 (EWR → SFO) Have Starlink WiFi?
```

Keeps the question phrasing that matches how people actually search, adds the route/status intent, fits inside the ~60 chars Google renders.

**Depends on #1** — templating a stale route into 4,411 titles would be worse than omitting it.

I deliberately did *not* put a Starlink percentage in the title. It would churn on every data update, and title churn is its own SEO cost. Easy to add later if we want it.

## 3. The hub and the tenant sites published different percentages

The hub divided by `fleetTotal` (tails we hold rows for, 1,641 for UA) while each airline's own tracker divides by `total` (published fleet size, 1,817). Same airline, two numbers: **32% on the hub vs 28.6% on unitedstarlinktracker.com**.

Both now use `total`. `fleetTotal` stays — the gap between the two is a real coverage signal — but is documented as explicitly not-a-denominator so this doesn't get reintroduced.

## Testing

- New `tests/flight-route-pairs.test.ts` pins the ordering invariant. Verified it **fails** against the old `ORDER BY` and passes with the fix.
- Full suite: 759 pass / 0 fail.
- `tsc --noEmit` output diffed against `main` — no new errors (repo has pre-existing ones).
- Confirmed `getFlightRoutePairs` only feeds the rendered page, **not** the frozen `/api/check-flight` wire contract the Chrome extension depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)