### PR TITLE
feat: real per-route pages at /route-planner/{origin}/{destination}

### DIFF
--- a/src/components/route-page.tsx
+++ b/src/components/route-page.tsx
@@ -1,0 +1,167 @@
+import React from "react";
+import { type SiteConfig, siteAirline } from "../airlines/registry";
+import type { RouteSummary } from "../database/database";
+
+const EYEBROW = "text-[10px] font-mono text-muted uppercase tracking-wider mb-3";
+const PANEL = "bg-surface border border-subtle rounded-lg p-5";
+const SECTION = "relative w-full max-w-4xl mx-auto mb-10";
+
+export function formatDuration(sec: number | null): string | null {
+  if (!sec || sec <= 0) return null;
+  const h = Math.floor(sec / 3600);
+  const m = Math.round((sec % 3600) / 60);
+  if (h === 0) return `${m}m`;
+  return m === 0 ? `${h}h` : `${h}h ${m}m`;
+}
+
+/** The one-line answer the page exists to give. */
+export function routeVerdict(route: RouteSummary, airlineName: string): string {
+  if (route.totalDepartures === 0) {
+    return `No ${airlineName} departures are in the schedule window for ${route.origin} → ${route.destination} right now. Aircraft assignments publish about two days out.`;
+  }
+  if (route.equippedDepartures === 0) {
+    return `None of the ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on a Starlink-equipped aircraft.`;
+  }
+  if (route.equippedDepartures === route.totalDepartures) {
+    return `All ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
+  }
+  return `${route.equippedDepartures} of ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
+}
+
+function FlightNumbers({ route, airlineName }: { route: RouteSummary; airlineName: string }) {
+  if (route.flightNumbers.length === 0) {
+    return (
+      <p className="text-sm text-muted">
+        No flight numbers recorded on this route yet. The route cache fills in as departures are
+        observed.
+      </p>
+    );
+  }
+  return (
+    <>
+      <div className="flex flex-wrap gap-2">
+        {route.flightNumbers.map((f) => (
+          <a
+            key={f.flight_number}
+            href={`/check-flight/${f.flight_number}`}
+            className="font-mono text-sm px-2.5 py-1 rounded border border-subtle bg-surface-elevated text-secondary hover:border-accent hover:text-accent transition-colors"
+          >
+            {f.flight_number}
+            {f.scheduled === 1 && <span className="text-accent"> ·</span>}
+          </a>
+        ))}
+      </div>
+      <p className="text-[11px] text-muted mt-4 leading-snug">
+        Every {airlineName} flight number observed on {route.origin} → {route.destination}. A dot
+        marks numbers currently in the schedule window; the rest are from the observed route
+        history. Follow any number for its per-flight Starlink record.
+      </p>
+    </>
+  );
+}
+
+interface RoutePageProps {
+  route: RouteSummary;
+  site: SiteConfig;
+}
+
+export default function RoutePage({ route, site }: RoutePageProps) {
+  const cfg = siteAirline(site);
+  const airlineName = cfg.name;
+  const backLabel = site.brand.title;
+  const duration = formatDuration(route.durationSec);
+  const scheduledCount = route.flightNumbers.filter((f) => f.scheduled === 1).length;
+
+  return (
+    <div className="w-full mx-auto px-4 sm:px-6 md:px-8 bg-base min-h-screen flex flex-col relative">
+      <div className="absolute inset-0 grid-pattern opacity-50 pointer-events-none" />
+
+      <header className="relative py-5 sm:py-6 text-center mb-6">
+        <h1 className="font-display text-3xl sm:text-4xl font-bold text-primary mb-2 tracking-tight">
+          {route.origin} to {route.destination} Starlink WiFi
+        </h1>
+        <p className="text-base text-secondary font-display max-w-2xl mx-auto">
+          {routeVerdict(route, airlineName)}
+        </p>
+      </header>
+
+      <section className={SECTION}>
+        <div className={PANEL}>
+          <div className={EYEBROW}>Route at a glance</div>
+          <dl className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+            <div>
+              <dt className="text-[10px] font-mono text-muted uppercase tracking-wider">
+                Starlink departures
+              </dt>
+              <dd className="font-display text-2xl font-bold text-primary tabular-nums">
+                {route.equippedDepartures}
+                <span className="text-muted text-base font-normal">/{route.totalDepartures}</span>
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-mono text-muted uppercase tracking-wider">
+                Flight numbers
+              </dt>
+              <dd className="font-display text-2xl font-bold text-primary tabular-nums">
+                {route.flightNumbers.length}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-mono text-muted uppercase tracking-wider">
+                In schedule
+              </dt>
+              <dd className="font-display text-2xl font-bold text-primary tabular-nums">
+                {scheduledCount}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-mono text-muted uppercase tracking-wider">
+                Block time
+              </dt>
+              <dd className="font-display text-2xl font-bold text-primary tabular-nums">
+                {duration ?? "—"}
+              </dd>
+            </div>
+          </dl>
+          <p className="text-[11px] text-muted mt-4 leading-snug">
+            Counted from live tail assignments over the {route.windowLabel}. A route with no
+            equipped departures today can still get one — assignments publish about two days before
+            departure.
+          </p>
+        </div>
+      </section>
+
+      <section className={SECTION}>
+        <div className={PANEL}>
+          <div className={EYEBROW}>
+            {airlineName} flights on {route.origin}–{route.destination}
+          </div>
+          <FlightNumbers route={route} airlineName={airlineName} />
+        </div>
+      </section>
+
+      <section className={`${SECTION} text-center`}>
+        <p className="text-sm text-secondary">
+          Want the reverse leg?{" "}
+          <a
+            href={`/route-planner/${route.destination}/${route.origin}`}
+            className="text-accent hover:underline"
+          >
+            {route.destination} to {route.origin}
+          </a>
+          , or{" "}
+          <a href="/route-planner" className="text-accent hover:underline">
+            compare a full itinerary
+          </a>
+          .
+        </p>
+      </section>
+
+      <footer className="relative py-6 text-center border-t border-subtle text-muted text-sm mt-auto">
+        <a href="/" className="text-accent hover:underline font-display">
+          ← Back to {backLabel}
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -1798,6 +1798,207 @@ export function flightNumberHasData(
   );
 }
 
+/**
+ * Airport codes eligible for a route URL: IATA only, so one airport is exactly
+ * one URL. Rows carrying 4-letter ICAO codes are skipped by both the sitemap
+ * and the page gate, which keeps the two in agreement.
+ */
+export const ROUTE_AIRPORT_RE = /^[A-Z]{3}$/;
+
+export interface SitemapRoute {
+  origin: string;
+  destination: string;
+  /** Newest data-touch across the pair; 0 when unknown so callers omit lastmod. */
+  last_touched: number;
+}
+
+/**
+ * Directed route pairs worth advertising, with real per-route lastmod.
+ *
+ * Anchored on flight_routes rather than the live upcoming_flights window: the
+ * window only covers 48 hours, so gating on it would add and drop thousands of
+ * URLs every couple of days. flight_routes is airline-agnostic (the PK carries
+ * the IATA prefix), so scoping is a GLOB on flight_number — same trick
+ * getSitemapFlights uses.
+ */
+export function getSitemapRoutes(db: Database, airline: string): SitemapRoute[] {
+  const cfg = AIRLINES[airline];
+  if (!cfg) return [];
+  const nowSec = Math.floor(Date.now() / 1000);
+  const latest = new Map<string, number>();
+  const touch = (origin: string, destination: string, t: number | null) => {
+    if (!ROUTE_AIRPORT_RE.test(origin) || !ROUTE_AIRPORT_RE.test(destination)) return;
+    if (origin === destination) return;
+    // Future timestamps are corrupt rows — treat as unknown, keep the route.
+    const sane = t && t <= nowSec ? t : 0;
+    const key = `${origin}-${destination}`;
+    latest.set(key, Math.max(latest.get(key) ?? 0, sane));
+  };
+  const cached = db
+    .query(
+      `SELECT origin, destination, MAX(last_seen_at) AS t FROM flight_routes
+       WHERE flight_number GLOB ? GROUP BY origin, destination`
+    )
+    .all(`${cfg.iata}[0-9]*`) as { origin: string; destination: string; t: number | null }[];
+  const upcoming = db
+    .query(
+      `SELECT departure_airport AS origin, arrival_airport AS destination,
+              MAX(last_updated) AS t
+       FROM upcoming_flights
+       WHERE airline = ? AND departure_airport IS NOT NULL AND arrival_airport IS NOT NULL
+       GROUP BY departure_airport, arrival_airport`
+    )
+    .all(airline) as { origin: string; destination: string; t: number | null }[];
+  for (const r of [...cached, ...upcoming]) touch(r.origin, r.destination, r.t);
+  return [...latest]
+    .map(([key, last_touched]) => {
+      const [origin, destination] = key.split("-");
+      return { origin, destination, last_touched };
+    })
+    .sort((a, b) => a.origin.localeCompare(b.origin) || a.destination.localeCompare(b.destination));
+}
+
+/**
+ * Single-route form of the getSitemapRoutes data test. Pages and sitemap must
+ * agree on which route URLs exist — /route-planner/{o}/{d} is otherwise an
+ * unbounded thin-page space, so unknown pairs 404.
+ */
+export function routeHasData(
+  db: Database,
+  origin: string,
+  destination: string,
+  airline: string
+): boolean {
+  const q = withAirline(
+    "SELECT 1 FROM upcoming_flights WHERE departure_airport = ? AND arrival_airport = ?",
+    airline,
+    "",
+    [origin, destination]
+  );
+  if (db.query(`${q.sql} LIMIT 1`).get(...q.params)) return true;
+  const cfg = AIRLINES[airline];
+  if (!cfg) return false;
+  return Boolean(
+    db
+      .query(
+        `SELECT 1 FROM flight_routes
+         WHERE origin = ? AND destination = ? AND flight_number GLOB ? LIMIT 1`
+      )
+      .get(origin, destination, `${cfg.iata}[0-9]*`)
+  );
+}
+
+export interface RouteSummary {
+  origin: string;
+  destination: string;
+  /** Marketing flight numbers observed on the pair, most-flown first. */
+  flightNumbers: Array<{ flight_number: string; times: number; scheduled: number }>;
+  /** Median-ish block time across observations, seconds. */
+  durationSec: number | null;
+  /** Departures on a Starlink-equipped tail in the live window. */
+  equippedDepartures: number;
+  /** All departures in the live window, equipped or not. */
+  totalDepartures: number;
+  windowLabel: string;
+}
+
+/** Everything a /route-planner/{origin}/{destination} page renders. */
+export function getRouteSummary(
+  db: Database,
+  origin: string,
+  destination: string,
+  airline: string,
+  nowSec = Math.floor(Date.now() / 1000)
+): RouteSummary {
+  const cfg = AIRLINES[airline];
+  const cached = cfg
+    ? (db
+        .query(
+          `SELECT flight_number, seen_count AS times, duration_sec
+           FROM flight_routes
+           WHERE origin = ? AND destination = ? AND flight_number GLOB ?`
+        )
+        .all(origin, destination, `${cfg.iata}[0-9]*`) as Array<{
+        flight_number: string;
+        times: number;
+        duration_sec: number | null;
+      }>)
+    : [];
+  const liveQ = withAirline(
+    `SELECT flight_number, COUNT(*) AS times,
+            CAST(AVG(arrival_time - departure_time) AS INTEGER) AS duration_sec
+     FROM upcoming_flights
+     WHERE departure_airport = ? AND arrival_airport = ? AND flight_number IS NOT NULL`,
+    airline,
+    "",
+    [origin, destination]
+  );
+  const live = db.query(`${liveQ.sql} GROUP BY flight_number`).all(...liveQ.params) as Array<{
+    flight_number: string;
+    times: number;
+    duration_sec: number | null;
+  }>;
+
+  // Marketing numbers only, normalized the same way getSitemapFlights does.
+  // upcoming_flights also carries operating-carrier numbers (SKW4726 for a
+  // United Express leg); those have no /check-flight permalink, so rendering
+  // them would put broken internal links on every affected route page.
+  const marketing = cfg ? new RegExp(`^${cfg.iata}\\d+$`) : null;
+  const merged = new Map<string, { times: number; scheduled: number }>();
+  const add = (raw: string, times: number, scheduled: number) => {
+    if (!cfg || !marketing) return;
+    const fn = stripFlightNumberZeros(ensureAirlinePrefix(cfg, raw));
+    if (!marketing.test(fn)) return;
+    const prev = merged.get(fn);
+    merged.set(fn, {
+      times: (prev?.times ?? 0) + times,
+      scheduled: Math.max(prev?.scheduled ?? 0, scheduled),
+    });
+  };
+  for (const r of cached) add(r.flight_number, r.times, 0);
+  for (const r of live) add(r.flight_number, r.times, 1);
+  const flightNumbers = [...merged]
+    .map(([flight_number, v]) => ({ flight_number, ...v }))
+    .sort((a, b) => b.scheduled - a.scheduled || b.times - a.times);
+
+  const durations = [...cached, ...live]
+    .map((r) => r.duration_sec)
+    .filter((d): d is number => typeof d === "number" && d > 0)
+    .sort((a, b) => a - b);
+  const durationSec = durations.length ? durations[Math.floor(durations.length / 2)] : null;
+
+  const windowEnd = nowSec + DEPARTURE_WINDOW_HOURS * 3600;
+  const equippedQ = withAirline(
+    `SELECT COUNT(DISTINCT uf.flight_number || ':' || uf.departure_time) AS n${EQUIPPED_DEPARTURES_SQL}
+       AND uf.departure_airport = ? AND uf.arrival_airport = ?`,
+    airline,
+    "uf",
+    [nowSec, windowEnd, origin, destination]
+  );
+  const equippedDepartures = (db.query(equippedQ.sql).get(...equippedQ.params) as { n: number }).n;
+
+  const totalQ = withAirline(
+    `SELECT COUNT(DISTINCT uf.flight_number || ':' || uf.departure_time) AS n
+     FROM upcoming_flights uf
+     WHERE uf.departure_time >= ? AND uf.departure_time < ?
+       AND uf.departure_airport = ? AND uf.arrival_airport = ?`,
+    airline,
+    "uf",
+    [nowSec, windowEnd, origin, destination]
+  );
+  const totalDepartures = (db.query(totalQ.sql).get(...totalQ.params) as { n: number }).n;
+
+  return {
+    origin,
+    destination,
+    flightNumbers,
+    durationSec,
+    equippedDepartures,
+    totalDepartures,
+    windowLabel: `next ${DEPARTURE_WINDOW_HOURS} hours`,
+  };
+}
+
 export interface FlightRoutePair {
   departure_airport: string;
   arrival_airport: string;

--- a/src/database/reader.ts
+++ b/src/database/reader.ts
@@ -31,7 +31,9 @@ import {
   type RouteEntryRow,
   type RouteFlightRow,
   type RouteGraphEdge,
+  type RouteSummary,
   type SitemapFlight,
+  type SitemapRoute,
   type SubfleetPenetration,
   type VerificationObservation,
   type VerificationSource,
@@ -68,9 +70,11 @@ import {
   getRouteFlights,
   getRouteGraphEdges,
   getRouteStarlinkSchedule,
+  getRouteSummary,
   getRoutesForFlightVariants,
   getServedRoutePairs,
   getSitemapFlights,
+  getSitemapRoutes,
   getStarlinkPlaneByTail,
   getStarlinkPlanes,
   getSubfleetPenetration,
@@ -79,6 +83,7 @@ import {
   getVerificationObservations,
   getVerificationSummary,
   getWifiMismatches,
+  routeHasData,
 } from "./database";
 
 export type { Database };
@@ -106,6 +111,8 @@ export interface ScopedReader {
   getLastUpdatedRaw(): string | null;
   /** Flight permalinks worth advertising, with real per-flight lastmod; empty on the hub (permalinks are tenant pages). */
   getSitemapFlights(): SitemapFlight[];
+  /** Route permalinks worth advertising, with real per-route lastmod; empty on the hub (route pages are tenant pages). */
+  getSitemapRoutes(): SitemapRoute[];
   /** Meta keys are namespaced per-airline; null on the hub (no single namespace). */
   getMeta(key: string): string | null;
   /** Check-flight assignments without the verified_wifi filter (the core classifies tiers). */
@@ -153,6 +160,9 @@ export interface ScopedReader {
 
   // Flight-permalink SSR: existence gate + observed history + route census.
   flightNumberHasData(variants: string[]): boolean;
+  /** Existence gate for /route-planner/{origin}/{destination}; mirrors getSitemapRoutes. */
+  routeHasData(origin: string, destination: string): boolean;
+  getRouteSummary(origin: string, destination: string): RouteSummary;
   getFlightHistorySummary(variants: string[]): FlightHistorySummary;
   getFlightRoutePairs(variants: string[]): FlightRoutePair[];
 
@@ -277,6 +287,7 @@ function buildReader(db: Database, scope: Scope): ScopedReader {
         .sort()
         .at(-1) ?? null,
     getSitemapFlights: () => (scope === "ALL" ? [] : getSitemapFlights(db, scope)),
+    getSitemapRoutes: () => (scope === "ALL" ? [] : getSitemapRoutes(db, scope)),
     getMeta: (key) => (scope === "ALL" ? null : getMeta(db, key, scope)),
     getFlightAssignments: (v, s, e) => getFlightAssignments(db, v, s, e, airlines),
     getFleetPageData: () => getFleetPageData(db, airlines),
@@ -304,6 +315,8 @@ function buildReader(db: Database, scope: Scope): ScopedReader {
     getRoutesForFlightVariants: (v) => getRoutesForFlightVariants(db, v, airlines),
 
     flightNumberHasData: (v) => flightNumberHasData(db, v, airlines),
+    routeHasData: (o, d) => routeHasData(db, o, d, soleAirline()),
+    getRouteSummary: (o, d) => getRouteSummary(db, o, d, soleAirline()),
     getFlightHistorySummary: (v) => getFlightHistorySummary(db, v, airlines),
     getFlightRoutePairs: (v) => getFlightRoutePairs(db, v, airlines),
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -62,8 +62,10 @@ import FleetPage from "../components/fleet-page";
 import McpPage from "../components/mcp-page";
 import MethodologyPage, { hasMethodology } from "../components/methodology-page";
 import Page from "../components/page";
+import RoutePage, { routeVerdict } from "../components/route-page";
 import RoutePlannerPage from "../components/route-planner-page";
 import RoutesPage from "../components/routes-page";
+import { ROUTE_AIRPORT_RE, type RouteSummary } from "../database/database";
 import {
   COUNTERS,
   DISTRIBUTIONS,
@@ -1215,6 +1217,15 @@ const sitemap: Handler = ({ reader, site, tenant, getReader }) => {
           lastmod: f.last_touched ? new Date(f.last_touched * 1000).toISOString() : undefined,
         }))
       : [];
+  const routeEntries =
+    site.features.routePlannerPage && tenantConfig(tenant)
+      ? reader.getSitemapRoutes().map((r) => ({
+          path: `/route-planner/${r.origin}/${r.destination}`,
+          changefreq: "weekly",
+          priority: "0.6",
+          lastmod: r.last_touched ? new Date(r.last_touched * 1000).toISOString() : undefined,
+        }))
+      : [];
   // Each hub airline page's lastmod is that airline's own data freshness, not
   // the hub-wide max — an airline without a stamp yet omits lastmod rather
   // than borrowing another airline's. Same population as the hub homepage:
@@ -1236,6 +1247,7 @@ const sitemap: Handler = ({ reader, site, tenant, getReader }) => {
     })),
     ...airlineEntries,
     ...flightEntries,
+    ...routeEntries,
   ];
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -1772,10 +1784,68 @@ const checkFlightPage: Handler = (ctx) => {
   return renderSubPage(ctx, CheckFlightPage, "/check-flight", subPageMeta(ctx, "check-flight"));
 };
 
+/** `/route-planner/SFO/EWR` → `{ origin, destination }`; anything else → null. */
+export function parseRoutePath(pathname: string): { origin: string; destination: string } | null {
+  const rest = pathname.slice("/route-planner".length).replace(/^\/+|\/+$/g, "");
+  if (!rest) return null;
+  const parts = rest.split("/");
+  if (parts.length !== 2) return null;
+  const [origin, destination] = parts.map((p) => p.toUpperCase());
+  if (!ROUTE_AIRPORT_RE.test(origin) || !ROUTE_AIRPORT_RE.test(destination)) return null;
+  if (origin === destination) return null;
+  return { origin, destination };
+}
+
+function routePageMeta(ctx: RequestContext, cfg: AirlineConfig, route: RouteSummary): PageMeta {
+  const pair = `${route.origin} to ${route.destination}`;
+  const verdict = routeVerdict(route, cfg.name);
+  const numbers = route.flightNumbers.slice(0, 6).map((f) => f.flight_number);
+  return {
+    siteTitle: `${pair} Starlink WiFi — ${cfg.shortName} Flights`,
+    siteDescription: `Does ${cfg.name} fly Starlink on ${pair}? ${verdict}${
+      numbers.length ? ` Flight numbers on this route: ${numbers.join(", ")}.` : ""
+    }`,
+    keywords: `${route.origin} ${route.destination} starlink, ${pair} wifi, ${cfg.shortName.toLowerCase()} ${route.origin} ${route.destination} starlink`,
+    ogTitle: `${pair} — Starlink WiFi on ${cfg.shortName}`,
+    ogDescription: verdict,
+    pageJsonLd: jsonLdBlock({
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: `${cfg.name} flights on ${route.origin} → ${route.destination}`,
+      numberOfItems: route.flightNumbers.length,
+      itemListElement: route.flightNumbers.slice(0, 25).map((f, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        url: `https://${ctx.site.canonicalHost}/check-flight/${f.flight_number}`,
+        name: `${cfg.name} ${f.flight_number}`,
+      })),
+    }),
+  };
+}
+
 const routePlannerPage: Handler = (ctx) => {
   if (ctx.req.method !== "GET" && ctx.req.method !== "HEAD") return methodNotAllowed();
   if (!ctx.site.features.routePlannerPage) {
     return notFound(ctx.site);
+  }
+  // Per-route permalinks: /route-planner/{origin}/{destination}. The prefix used
+  // to swallow every sub-path and render the planner, so ~10k internal links off
+  // the flight permalinks all resolved to one duplicate page and Google logged
+  // them as soft 404s. Unknown pairs now 404 so the URL space stays bounded.
+  const trimmed = ctx.url.pathname.replace(/\/+$/, "");
+  if (trimmed !== "/route-planner") {
+    const parsed = parseRoutePath(ctx.url.pathname);
+    if (!parsed) return notFound(ctx.site);
+    const cfg = siteAirline(ctx.site);
+    if (!ctx.reader.routeHasData(parsed.origin, parsed.destination)) return notFound(ctx.site);
+    const route = ctx.reader.getRouteSummary(parsed.origin, parsed.destination);
+    return renderSubPage(
+      ctx,
+      RoutePage,
+      `/route-planner/${parsed.origin}/${parsed.destination}`,
+      routePageMeta(ctx, cfg, route),
+      { route }
+    );
   }
   return renderSubPage(ctx, RoutePlannerPage, "/route-planner", subPageMeta(ctx, "route-planner"));
 };

--- a/tests/route-pages.test.ts
+++ b/tests/route-pages.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Per-route permalinks at /route-planner/{origin}/{destination}.
+ *
+ * The prefix route used to swallow every sub-path and render the planner, so
+ * ~10k internal links off the flight permalinks resolved to one duplicate page
+ * (Google logged them as soft 404s). These tests pin the two invariants that
+ * replaced that: the URL space is bounded by real data, and the sitemap agrees
+ * with what the pages actually serve.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { SITES } from "../src/airlines/registry";
+import { getSitemapRoutes, routeHasData } from "../src/database/database";
+import { createApp, parseRoutePath } from "../src/server/app";
+import { openSnapshot, req } from "./helpers";
+
+let app: ReturnType<typeof createApp>;
+let db: ReturnType<typeof openSnapshot>;
+
+beforeAll(() => {
+  db = openSnapshot();
+  app = createApp(db);
+});
+
+const UA = SITES.united.canonicalHost;
+const get = (path: string, host = UA) =>
+  app.dispatch(req(path, host, { headers: { Accept: "text/html" } }));
+
+/** A route the snapshot actually backs, so the test survives data drift. */
+function someRoute() {
+  const routes = getSitemapRoutes(db, "UA");
+  if (routes.length === 0) throw new Error("snapshot has no routes — run bun run test:setup");
+  return routes[0];
+}
+
+describe("parseRoutePath", () => {
+  test("accepts a well-formed IATA pair, case-insensitively", () => {
+    expect(parseRoutePath("/route-planner/SFO/EWR")).toEqual({
+      origin: "SFO",
+      destination: "EWR",
+    });
+    expect(parseRoutePath("/route-planner/sfo/ewr")).toEqual({
+      origin: "SFO",
+      destination: "EWR",
+    });
+    expect(parseRoutePath("/route-planner/SFO/EWR/")).toEqual({
+      origin: "SFO",
+      destination: "EWR",
+    });
+  });
+
+  test("rejects everything that would open an unbounded URL space", () => {
+    for (const path of [
+      "/route-planner",
+      "/route-planner/",
+      "/route-planner/SFO",
+      "/route-planner/SFO/EWR/ORD",
+      "/route-planner/garbage/xyz",
+      "/route-planner/SF/EWR",
+      "/route-planner/SFOO/EWR",
+      "/route-planner/SFO/SFO",
+      "/route-planner/123/456",
+    ]) {
+      expect(parseRoutePath(path), path).toBeNull();
+    }
+  });
+});
+
+describe("/route-planner/{origin}/{destination}", () => {
+  test("the planner itself still renders", async () => {
+    const res = await get("/route-planner");
+    expect(res.status).toBe(200);
+  });
+
+  test("a data-backed pair renders its own page, not the planner", async () => {
+    const { origin, destination } = someRoute();
+    const res = await get(`/route-planner/${origin}/${destination}`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain(`${origin} to ${destination} Starlink WiFi`);
+    expect(body).toContain(
+      `<link rel="canonical" href="https://${UA}/route-planner/${origin}/${destination}"`
+    );
+  });
+
+  test("the page links out to the flight permalinks on the route", async () => {
+    const routes = getSitemapRoutes(db, "UA");
+    // Find a route the snapshot has flight numbers for; permalink cross-linking
+    // is the whole point of the page, but a sparse snapshot may not have one.
+    for (const r of routes.slice(0, 25)) {
+      const body = await (await get(`/route-planner/${r.origin}/${r.destination}`)).text();
+      const m = body.match(/href="\/check-flight\/(UA\d+)"/);
+      if (m) {
+        expect(body).toContain(`/check-flight/${m[1]}`);
+        return;
+      }
+    }
+    throw new Error("no route in the snapshot carried a flight number");
+  });
+
+  test("every permalink a route page links to actually resolves", async () => {
+    // upcoming_flights also carries operating-carrier numbers (SKW4726 for a
+    // United Express leg) which have no /check-flight permalink. Linking one
+    // would put a broken internal link on the page — the exact failure these
+    // route pages exist to clean up.
+    const seen = new Set<string>();
+    for (const r of getSitemapRoutes(db, "UA")) {
+      const body = await (await get(`/route-planner/${r.origin}/${r.destination}`)).text();
+      for (const m of body.matchAll(/href="\/check-flight\/([^"]+)"/g)) seen.add(m[1]);
+    }
+    expect(seen.size).toBeGreaterThan(0);
+    for (const fn of seen) {
+      expect(fn, "non-marketing flight number linked").toMatch(/^UA\d+$/);
+      expect((await get(`/check-flight/${fn}`)).status, `/check-flight/${fn}`).toBe(200);
+    }
+  });
+
+  test("unknown, malformed, and same-airport pairs 404", async () => {
+    for (const path of [
+      "/route-planner/QQQ/ZZZ",
+      "/route-planner/garbage/xyz",
+      "/route-planner/SFO/SFO",
+      "/route-planner/SFO/EWR/ORD",
+      "/route-planner/SFO",
+    ]) {
+      const res = await get(path);
+      expect(res.status, path).toBe(404);
+    }
+  });
+
+  test("route pages are tenant-only — the hub 404s", async () => {
+    const { origin, destination } = someRoute();
+    const res = await get(`/route-planner/${origin}/${destination}`, SITES.airline.canonicalHost);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("sitemap agrees with the pages", () => {
+  test("every advertised route resolves 200 and every route entry is well-formed", async () => {
+    const body = await (await app.dispatch(req("/sitemap.xml", UA))).text();
+    const advertised = [
+      ...body.matchAll(/<loc>[^<]*\/route-planner\/([A-Z]{3})\/([A-Z]{3})<\/loc>/g),
+    ];
+    expect(advertised.length).toBeGreaterThan(0);
+
+    for (const [, origin, destination] of advertised.slice(0, 20)) {
+      expect(routeHasData(db, origin, destination, "UA"), `${origin}-${destination}`).toBe(true);
+      const res = await get(`/route-planner/${origin}/${destination}`);
+      expect(res.status, `${origin}-${destination}`).toBe(200);
+    }
+  });
+
+  test("no route entry stamps request time as lastmod", async () => {
+    const body = await (await app.dispatch(req("/sitemap.xml", UA))).text();
+    const now = Date.now();
+    for (const m of body.matchAll(/<lastmod>([^<]+)<\/lastmod>/g)) {
+      expect(Date.parse(m[1])).toBeLessThanOrEqual(now);
+    }
+  });
+});
+
+describe("getSitemapRoutes", () => {
+  test("emits only IATA pairs and never a same-airport pair", () => {
+    for (const r of getSitemapRoutes(db, "UA")) {
+      expect(r.origin).toMatch(/^[A-Z]{3}$/);
+      expect(r.destination).toMatch(/^[A-Z]{3}$/);
+      expect(r.origin).not.toBe(r.destination);
+    }
+  });
+
+  test("is empty for an airline with no rows", () => {
+    expect(getSitemapRoutes(db, "NOPE")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the soft-404 trend and turns ~10,000 wasted internal links into a real indexable surface.

## The bug

`prefixRoutes` registered `/route-planner/` but [the handler ignored `ctx.url.pathname` entirely](https://github.com/martinamps/ua-starlink-tracker/blob/main/src/server/app.ts). Every sub-path rendered the planner byte-for-byte:

```
/route-planner/SFO/EWR      → 200, 27,278 bytes, canonical → /route-planner
/route-planner/ORD/MSP      → 200, 27,278 bytes, identical
/route-planner/garbage/xyz  → 200, 27,278 bytes, identical, index+follow
```

`check-flight-page.tsx:103` emits a `/route-planner/{origin}/{destination}` link on **every** flight permalink, so ~10k internal links pointed at that one page. Google followed them and logged soft 404s at an accelerating rate — **0 → 6 → 19** over the five weeks since the permalinks shipped.

## What each pair renders now

- Starlink share of scheduled departures on the route, over the live 48h window
- Block time, flight-number count, how many are currently scheduled
- **Every marketing flight number observed on the route, each linking to its `/check-flight` permalink**
- `ItemList` JSON-LD over those permalinks; reverse-leg cross-link

That last point matters beyond this page: the flight permalinks are currently **orphans** — the homepage, `/check-flight`, `/routes` and `/fleet` contain zero links to any of them. They're the one surface earning genuine non-branded organic traffic (12.3K impressions, 1000+ URLs) and they sit at average position 10.7 with no internal PageRank at all. This is the first thing on the site that links to them.

## Keeping the URL space bounded

Unknown, malformed, same-airport and over-long paths **404**. The gate is the same data test the sitemap uses — `getSitemapRoutes` / `routeHasData`, deliberately mirroring the existing `getSitemapFlights` / `flightNumberHasData` pair — so pages and sitemap can never disagree.

Two design choices worth flagging:

- **Anchored on `flight_routes`, not `upcoming_flights`.** The live window is only 48 hours; gating on it would add and drop thousands of sitemap URLs every couple of days. `flight_routes` is airline-agnostic (the PK carries the IATA prefix), so scoping is a GLOB on `flight_number` — the same trick `getSitemapFlights` uses.
- **IATA-only airport codes**, so one airport is exactly one URL. Rows carrying 4-letter ICAO codes are skipped by both the sitemap and the page gate, which keeps them in agreement.

## One bug caught while reviewing rendered output

The first render produced a link to `/check-flight/SKW4726`. `upcoming_flights` carries operating-carrier numbers for United Express legs, and those have **no permalink** — so the page would have shipped broken internal links, the exact failure this PR exists to clean up. Flight numbers now go through `ensureAirlinePrefix`/`stripFlightNumberZeros` and are filtered to marketing numbers (`SKW4726` → `UA4726`). There's a test pinning it.

## Testing

`tests/route-pages.test.ts` — 12 tests, derived from snapshot data so they survive drift:

- `parseRoutePath` accepts/rejects (9 malformed forms pinned)
- A data-backed pair renders its own page with its own canonical; `/route-planner` itself still renders
- **Every `/check-flight` link on every route page is a marketing number and returns 200**
- Every route URL advertised in the sitemap resolves 200 and passes `routeHasData`
- No route entry stamps request time as `lastmod`
- Route pages are tenant-only — the hub 404s

Full suite **768 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

Verified against the local snapshot: 66 route URLs, 136 total sitemap locs, zero non-marketing permalink links across all 66 pages.

## Note

Stacked conceptually on #76 but branched from `main` — no shared files beyond `database.ts`, so they merge in either order. #76 fixes which route a permalink *claims* to fly; this adds the pages those routes point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)