### PR TITLE
fix: stop answering foreign flight numbers with United's model

### DIFF
--- a/src/airlines/flight-number.ts
+++ b/src/airlines/flight-number.ts
@@ -55,6 +55,23 @@ function iataExact(cfg: AirlineConfig): RegExp {
 }
 
 /**
+ * Does this flight number's carrier prefix belong to `cfg`?
+ *
+ * detectMarketingCarrier only recognises airlines we track, so an untracked
+ * carrier's number (DL100, B6100) looked prefix-less and got answered from the
+ * pinned carrier's model — B6100 was reported as 70% Starlink because
+ * inferSubfleet read "6100" as a United Express number. Bare digits stay true:
+ * they carry no carrier claim, so the pinned carrier owns them.
+ */
+export function prefixBelongsTo(cfg: AirlineConfig, flightNumber: string): boolean {
+  const fn = flightNumber.trim().toUpperCase();
+  const m = fn.match(/^([A-Z]+)\d+$/);
+  if (!m) return true;
+  const prefix = m[1];
+  return prefix === cfg.iata || prefix === cfg.icao || cfg.carrierPrefixes.includes(prefix);
+}
+
+/**
  * Normalize an operating-carrier flight number to the marketing-carrier code.
  * e.g. for UA: SKW5882 → UA5882, UAL544 → UA544, UA1234 → UA1234.
  */
@@ -75,8 +92,13 @@ export function normalizeAirlineFlightNumber(cfg: AirlineConfig, flightNumber: s
  */
 export function ensureAirlinePrefix(cfg: AirlineConfig, flightNumber: string): string {
   const normalized = normalizeAirlineFlightNumber(cfg, flightNumber.trim().toUpperCase());
-  if (iataExact(cfg).test(normalized)) return normalized;
-  if (/^\d+$/.test(normalized)) return `${cfg.iata}${normalized}`;
+  // Zero-padding is stripped here, not just at the permalink layer: boarding
+  // passes and GDS itineraries print UA0100, the verification log stores UA100
+  // (the DB writer strips too), so a padded query silently missed every row and
+  // fell through to the fleet prior. buildFlightLookupVariants re-adds every
+  // padding width for the DB lookup, so canonicalizing first is lossless.
+  if (iataExact(cfg).test(normalized)) return stripFlightNumberZeros(normalized);
+  if (/^\d+$/.test(normalized)) return `${cfg.iata}${normalized.replace(/^0+(?=\d)/, "")}`;
   return normalized;
 }
 

--- a/src/api/check-flight-core.ts
+++ b/src/api/check-flight-core.ts
@@ -14,6 +14,7 @@ import {
   buildAirlineFlightNumberVariants,
   detectMarketingCarrier,
   ensureAirlinePrefix,
+  prefixBelongsTo,
 } from "../airlines/flight-number";
 import { type AirlineConfig, enabledAirlines, publicAirlines } from "../airlines/registry";
 import type { FlightAssignmentRow, QatarScheduleRow } from "../database/database";
@@ -86,11 +87,31 @@ export function decideCarrier(
     if (marketing && marketing.code !== pinnedCfg.code) {
       return { outcome: "not_tracked", pinnedCfg, tracked: PUBLIC_AIRLINES };
     }
+    // An unrecognised carrier prefix is not this carrier's flight either.
+    // Without this, untracked carriers (DL, AA, B6) fell through to the pinned
+    // airline's model and were answered with its priors.
+    if (!marketing && !prefixBelongsTo(pinnedCfg, flightNumber)) {
+      return { outcome: "not_tracked", pinnedCfg, tracked: PUBLIC_AIRLINES };
+    }
     return { outcome: "resolved", cfg: pinnedCfg, pinned: true };
   }
   const cfg = detectMarketingCarrier(flightNumber, PUBLIC_AIRLINES);
   if (!cfg) return { outcome: "not_tracked", pinnedCfg: null, tracked: PUBLIC_AIRLINES };
   return { outcome: "resolved", cfg, pinned: false };
+}
+
+/**
+ * Is this a shape a real flight number could take for `cfg`?
+ *
+ * Exactly `{IATA}` + 1-4 digits. An unbounded number would let callers drive
+ * arbitrary FR24 lookups through the public surfaces, and a trailing-letter
+ * form (UA4680A) parsed as subfleet "unknown" and returned the express/mainline
+ * midpoint for a string that is not a flight number. Shared by the verdict path
+ * and /api/predict-flight so the two cannot drift.
+ */
+export function isPlausibleFlightNumber(cfg: AirlineConfig, normalized: string): boolean {
+  const m = normalized.match(/^([A-Z]+)(\d{1,4})$/);
+  return m !== null && m[1] === cfg.iata;
 }
 
 /** The reader a resolved decision answers from: the pinned scope's own, or a
@@ -242,10 +263,7 @@ export async function resolveFlightVerdict(
   if (!window) return { kind: "invalid_date" };
 
   const normalized = ensureAirlinePrefix(cfg, flightNumber);
-  // Real flight numbers are 1-4 digits; an unbounded number would let callers
-  // drive arbitrary FR24 lookups through the public surfaces.
-  const numPart = normalized.match(/(\d+)$/)?.[1];
-  if (!numPart || numPart.length > 4) {
+  if (!isPlausibleFlightNumber(cfg, normalized)) {
     return { kind: "invalid_flight_number", normalized };
   }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -44,6 +44,7 @@ import {
   SWAP_DEGRADED_NOTE,
   carrierReader,
   decideCarrier,
+  isPlausibleFlightNumber,
   negativeWifi,
   resolveFlightVerdict,
   scheduledFlights,
@@ -711,8 +712,12 @@ const apiCheckFlight: Handler = async ({ req, url, reader, getReader, tenant }) 
     }
     case "prediction": {
       // No assignment anywhere — tails aren't published until ~2 days out, so
-      // serve the historical probability. hasStarlink stays false (the extension
-      // contract is boolean and means "firm assignment"); prediction is additive.
+      // serve the historical probability. hasStarlink is null, not false: false
+      // is reserved for a *verified* negative (scheduled_no / fr24_no), and
+      // returning it here asserted "no Starlink" for flights the model puts at
+      // 99%. Matches the carrier-agnostic prediction branch below. The extension
+      // reads `hasStarlink || false` so null is behaviourally identical for it,
+      // and null is already part of this contract (no_model, type branches).
       const pred = verdict.pred;
       recordPrediction(pred, cfg.code);
       const pct = Math.round(pred.probability * 100);
@@ -723,7 +728,7 @@ const apiCheckFlight: Handler = async ({ req, url, reader, getReader, tenant }) 
         : `Aircraft assignment not yet published — ${cfg.name} assigns aircraft ~2 days before departure.`;
       return new Response(
         JSON.stringify({
-          hasStarlink: false,
+          hasStarlink: null,
           ...hubAirline,
           confidence: "predicted",
           prediction: {
@@ -915,6 +920,14 @@ const apiPredictFlight: Handler = ({ req, url, reader, getReader, tenant }) => {
   const carrier = resolveCarrier(tenant, flightNumber, reader, getReader);
   if (carrier instanceof Response) return carrier;
   const { cfg } = carrier;
+  // Same shape gate resolveFlightVerdict applies — /api/predict-flight had none,
+  // so UA4680A and UA00004680 returned a fleet prior for a non-flight-number.
+  if (!isPlausibleFlightNumber(cfg, ensureAirlinePrefix(cfg, flightNumber))) {
+    return new Response(JSON.stringify({ error: "Invalid flight number" }), {
+      status: 400,
+      headers: SECURITY_HEADERS.api,
+    });
+  }
   if (!cfg.flightHistoryModel) {
     // No flight-history model for this carrier — answer from the registry
     // (subfleet penetration / type story), mirroring check-flight's no_model.

--- a/tests/carrier-guard.test.ts
+++ b/tests/carrier-guard.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Carrier and flight-number gating on the public prediction surfaces.
+ *
+ * Three defects this pins:
+ *  - decideCarrier only refused *registered* carriers, so DL100/AA100/B6100 were
+ *    answered from the pinned airline's model. B6100 came back 70% Starlink
+ *    because inferSubfleet read "6100" as a United Express number.
+ *  - ensureAirlinePrefix did not strip zero-padding, so UA0100 (the spelling on
+ *    boarding passes and GDS itineraries) matched no log row and fell through to
+ *    the fleet prior while UA100 answered from 7 observations.
+ *  - /api/predict-flight had no shape gate, so UA4680A and UA00004680 returned a
+ *    fleet prior for strings that are not flight numbers.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { ensureAirlinePrefix, prefixBelongsTo } from "../src/airlines/flight-number";
+import { AIRLINES } from "../src/airlines/registry";
+import { decideCarrier, isPlausibleFlightNumber } from "../src/api/check-flight-core";
+import { createApp } from "../src/server/app";
+import { openSnapshot, req } from "./helpers";
+
+const UA = AIRLINES.UA;
+let app: ReturnType<typeof createApp>;
+
+beforeAll(() => {
+  app = createApp(openSnapshot());
+});
+
+const predict = async (fn: string) => {
+  const res = await app.dispatch(
+    req(`/api/predict-flight?flight_number=${encodeURIComponent(fn)}`, "unitedstarlinktracker.com")
+  );
+  return { status: res.status, body: await res.json() };
+};
+
+describe("prefixBelongsTo", () => {
+  test("accepts the carrier's own marketing, ICAO and operating prefixes", () => {
+    for (const fn of ["UA100", "UAL100", "SKW4680", "OO4680"]) {
+      expect(prefixBelongsTo(UA, fn), fn).toBe(true);
+    }
+  });
+
+  test("accepts bare digits — they carry no carrier claim", () => {
+    expect(prefixBelongsTo(UA, "100")).toBe(true);
+  });
+
+  test("rejects other carriers, tracked or not", () => {
+    for (const fn of ["DL100", "AA100", "B6100", "AS100", "WN2100"]) {
+      expect(prefixBelongsTo(UA, fn), fn).toBe(false);
+    }
+  });
+});
+
+describe("decideCarrier refuses foreign flight numbers on a pinned host", () => {
+  test("untracked carriers are not answered from the pinned airline's model", () => {
+    for (const fn of ["DL100", "AA100", "B6100"]) {
+      expect(decideCarrier(UA, fn).outcome, fn).toBe("not_tracked");
+    }
+  });
+
+  test("the pinned carrier's own numbers still resolve", () => {
+    for (const fn of ["UA100", "SKW4680", "100"]) {
+      const d = decideCarrier(UA, fn);
+      expect(d.outcome, fn).toBe("resolved");
+    }
+  });
+});
+
+describe("zero-padding canonicalizes to one spelling", () => {
+  test("ensureAirlinePrefix strips padding on prefixed and bare forms", () => {
+    expect(ensureAirlinePrefix(UA, "UA0100")).toBe("UA100");
+    expect(ensureAirlinePrefix(UA, "UA00004680")).toBe("UA4680");
+    expect(ensureAirlinePrefix(UA, "0100")).toBe("UA100");
+    expect(ensureAirlinePrefix(UA, "UA100")).toBe("UA100");
+  });
+
+  test("a padded number gets the same answer as its canonical spelling", async () => {
+    const padded = await predict("UA0100");
+    const plain = await predict("UA100");
+    expect(padded.status).toBe(200);
+    expect(plain.status).toBe(200);
+    // Same flight → same everything. Before the fix these diverged: the padded
+    // form matched nothing and returned the fleet prior.
+    expect(padded.body).toEqual(plain.body);
+  });
+});
+
+describe("isPlausibleFlightNumber", () => {
+  test("accepts 1-4 digits with the carrier's own prefix", () => {
+    for (const fn of ["UA1", "UA100", "UA4680"]) {
+      expect(isPlausibleFlightNumber(UA, fn), fn).toBe(true);
+    }
+  });
+
+  test("rejects trailing letters, over-long numbers and foreign prefixes", () => {
+    for (const fn of ["UA4680A", "UA00004680", "UA", "B6100", "UA12345"]) {
+      expect(isPlausibleFlightNumber(UA, fn), fn).toBe(false);
+    }
+  });
+});
+
+describe("/api/predict-flight gating", () => {
+  test("foreign carriers are refused, not priced with United's priors", async () => {
+    for (const fn of ["DL100", "AA100", "B6100"]) {
+      const { body } = await predict(fn);
+      expect(body, fn).toHaveProperty("error");
+      expect(JSON.stringify(body), fn).not.toContain("fleet_prior");
+    }
+  });
+
+  test("non-flight-number shapes 400 instead of returning a prior", async () => {
+    for (const fn of ["UA4680A", "UA"]) {
+      const { status, body } = await predict(fn);
+      expect(status, fn).toBe(400);
+      expect(body, fn).toHaveProperty("error");
+    }
+  });
+
+  test("a real flight number still answers", async () => {
+    const { status, body } = await predict("UA100");
+    expect(status).toBe(200);
+    expect(body).toHaveProperty("probability");
+    expect(body).toHaveProperty("method");
+  });
+});

--- a/tests/check-flight-core.test.ts
+++ b/tests/check-flight-core.test.ts
@@ -463,8 +463,9 @@ describe("/api/check-flight boundary + contract through dispatch (synthetic DB)"
     // Far-future date keeps FR24 out of its lookup window — no network.
     const res = await get("/api/check-flight?flight_number=UA111&date=2027-06-10");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { hasStarlink: boolean; flights: unknown[] };
-    expect(body.hasStarlink).toBe(false);
+    const body = (await res.json()) as { hasStarlink: boolean | null; flights: unknown[] };
+    // Prediction branch → null (unknown), not false (verified negative).
+    expect(body.hasStarlink).toBe(null);
     expect(Array.isArray(body.flights)).toBe(true);
     expect(body.flights.length).toBe(0);
   });

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -98,7 +98,12 @@ describe("/api/check-flight contract", () => {
       "message",
       "prediction",
     ]);
-    expect(body.hasStarlink).toBe(false);
+    // null, not false: false is reserved for a *verified* negative
+    // (scheduled_no / fr24_no). On the prediction branch there is no assignment
+    // to verify, and false asserted "no Starlink" for flights the model puts
+    // near-certain. The key set above — the actual wire contract — is unchanged,
+    // and the extension reads `hasStarlink || false`, so null is inert for it.
+    expect(body.hasStarlink).toBe(null);
     expect(body.flights).toEqual([]);
     expect(body.confidence).toBe("predicted");
     expect(body.prediction.probability).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Four defects on the public prediction surfaces, all found by probing production and each reproduced before fixing.

## 1. The contract contradicted itself

```json
GET /api/check-flight?flight_number=UA5300&date=2026-08-16
{"hasStarlink": false,
 "prediction": {"probability": 0.9920, "confidence": "high", "n_observations": 31}}
```

`false` next to a 99.2% high-confidence call. CLAUDE.md pins this shape as a frozen contract, so I checked before touching it — and the two prediction branches **already disagreed**: the carrier-agnostic one returns `hasStarlink: null` with the comment *"rather than a confident 'No Starlink'"*, while the UA one returned `false`. Genuine negatives (`scheduled_no`, `fr24_no`) correctly use `false`.

Now both prediction branches return `null`. Safe for the extension: `content.js:50` reads `response.data.hasStarlink || false`, so `null` is behaviourally identical, and `null` was already part of this contract (`no_model` and `type` branches). **The wire key set is unchanged** — the test that pins it still passes untouched.

## 2. JetBlue was priced with United's Express prior

```
DL100   → 0.156  fleet_prior_mainline
AA100   → 0.156  fleet_prior_mainline
B6100   → 0.701  fleet_prior_express     ← JetBlue
```

`decideCarrier` only refused *registered* carriers (AS100 correctly errored). Anything else fell through to the pinned airline's model, and `inferSubfleet`'s `/(\d+)$/` read `6100` out of `B6100` straight into United Express's 3000–6999 band. New `prefixBelongsTo` refuses any prefix that isn't the carrier's IATA, ICAO, or an operating prefix. Bare digits still resolve — they carry no carrier claim — and `SKW4680`/`OO4680` still normalize to `UA4680`.

## 3. Zero-padded numbers silently lost their history

```
UA100  → 0%      7 observations   flight_history_smoothed
UA0100 → 15.6%   0 observations   fleet_prior_mainline
```

Boarding passes and GDS itineraries print the padded form. `stripFlightNumberZeros` already existed and was used by the permalink path and the DB *writer* — so the log stores `UA100` and a padded query could never match — but `ensureAirlinePrefix`, which both the check-flight and predict paths go through, didn't call it. It does now. `buildFlightLookupVariants` re-adds every padding width for the DB lookup, so canonicalizing first is lossless.

## 4. `/api/predict-flight` had no shape gate

`UA4680A` → `0.429 fleet_prior_unknown`, `UA00004680` → `0.701`. `resolveFlightVerdict` had a 1–4 digit guard; predict-flight didn't. Extracted to a shared `isPlausibleFlightNumber` so the two can't drift.

## Testing

New `tests/carrier-guard.test.ts` — 12 tests. **Each was verified to fail against the un-fixed code:**

| Reverted fix | Tests that fail |
|---|---|
| `prefixBelongsTo` → `true` | 2 |
| zero-strip removed | 2 |
| `hasStarlink: null` → `false` | 3 |

Full suite **783 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

Three existing assertions were updated from `false` to `null` on the prediction branch, with the reasoning inline. `integration.test.ts:599` asserts a *verified* negative and correctly still expects `false` — left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)