### PR TITLE
fix: count every request, name the crawlers, cache 404s

### DIFF
--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -115,12 +115,31 @@ export function normalizeProbeOutcome(raw: string | null | undefined): string {
   return PROBE_OUTCOMES.has(raw) ? raw : "other";
 }
 
-// Bounded user-agent classification (≤6 buckets, never the raw UA).
+// Bounded user-agent classification, most-specific first. Still a fixed enum —
+// never the raw UA — but the named crawlers are split out: collapsing every
+// crawler into one `bot` bucket meant no metric could see a single engine's
+// behaviour change, so a Bingbot surge that was a third of all traffic was
+// invisible to every dashboard and monitor.
 const BOT_UA = /bot|spider|crawler|curl|wget|python-requests|go-http-client|headless|httpclient/i;
+
+/** Order matters: GoogleOther/Google-Extended must be tested before Googlebot. */
+const NAMED_CRAWLERS: ReadonlyArray<readonly [string, RegExp]> = [
+  ["claude", /Claude-User|ClaudeBot|anthropic/i],
+  ["googleother", /GoogleOther|Google-Extended/i],
+  ["googlebot", /Googlebot|Storebot-Google|Google-InspectionTool/i],
+  ["bingbot", /bingbot|adidxbot|BingPreview/i],
+  ["gptbot", /GPTBot|OAI-SearchBot|ChatGPT-User/i],
+  ["perplexity", /PerplexityBot|Perplexity-User/i],
+  ["seo-crawler", /AhrefsBot|SemrushBot|DotBot|MJ12bot|PetalBot|DataForSeoBot|BLEXBot/i],
+  ["social", /facebookexternalhit|meta-externalagent|Twitterbot|Slackbot|Discordbot/i],
+];
+
 export function classifyUserAgent(ua: string | null | undefined): string {
   if (!ua) return "unknown";
-  if (/Claude-User|ClaudeBot|anthropic/i.test(ua)) return "claude";
   if (/UA-Starlink-Extension|starlink-tracker-ext/i.test(ua)) return "extension";
+  for (const [bucket, re] of NAMED_CRAWLERS) {
+    if (re.test(ua)) return bucket;
+  }
   if (BOT_UA.test(ua)) return "bot";
   if (/Mozilla|AppleWebKit|Gecko|Chrome|Safari|Firefox/i.test(ua)) return "browser";
   return "unknown";

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -155,6 +155,12 @@ export function renderHtml(template: string, variables: Record<string, string>):
 const notFound = (site: SiteConfig): Response =>
   new Response(getNotFoundHtml(site.brand), { status: 404, headers: SECURITY_HEADERS.notFound });
 
+/** Bounded `route` tag for HTTP_REQUEST — unmatched paths collapse to "/*". */
+function metricRoute(m: { route: string } | null): string {
+  if (!m) return "/*";
+  return m.route === "/static" ? "/static/*" : m.route;
+}
+
 function methodNotAllowed(json = false): Response {
   return json
     ? new Response(JSON.stringify({ error: "Method not allowed" }), {
@@ -351,7 +357,7 @@ function serveFavicon(tenantCode: string, urlPath: string): Response | null {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const apiData: Handler = ({ req, reader }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
 
   const totalCount = reader.getTotalCount();
   const starlinkPlanes = reader.getStarlinkPlanes();
@@ -378,7 +384,7 @@ const apiData: Handler = ({ req, reader }) => {
 // Per-airline rollout summary — used by the OG image generator and any
 // cross-airline UI. Cheap to compute per-request.
 const apiFleetSummary: Handler = ({ req, getReader }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const airlines = publicAirlines().map((cfg) => {
     const r = getReader(cfg.code);
     const installed = r.getStarlinkPlanes().length;
@@ -405,7 +411,7 @@ const apiFleetSummary: Handler = ({ req, getReader }) => {
 };
 
 const apiRoutes: Handler = ({ req, site, reader }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   if (!site.features.routesPage) {
     return new Response(JSON.stringify({ error: "Not found" }), {
       status: 404,
@@ -567,7 +573,7 @@ function resolveCarrier(
 }
 
 const apiCheckFlight: Handler = async ({ req, url, reader, getReader, tenant }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
 
   const flightNumber = url.searchParams.get("flight_number");
   const date = url.searchParams.get("date");
@@ -756,7 +762,7 @@ const hubOnly = (tenant: RequestContext["tenant"]): Response | null =>
       });
 
 const apiCheckAnyFlight: Handler = async ({ req, url, reader, getReader, tenant }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const guard = hubOnly(tenant);
   if (guard) return guard;
 
@@ -879,7 +885,7 @@ const apiCheckAnyFlight: Handler = async ({ req, url, reader, getReader, tenant 
 };
 
 const apiCompareRoute: Handler = ({ req, url, getReader, tenant }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const guard = hubOnly(tenant);
   if (guard) return guard;
 
@@ -904,7 +910,7 @@ const apiCompareRoute: Handler = ({ req, url, getReader, tenant }) => {
 };
 
 const apiPredictFlight: Handler = ({ req, url, reader, getReader, tenant }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const flightNumber = url.searchParams.get("flight_number");
   if (!flightNumber) {
     return new Response(JSON.stringify({ error: "Missing flight_number" }), {
@@ -953,7 +959,7 @@ const apiPredictFlight: Handler = ({ req, url, reader, getReader, tenant }) => {
 };
 
 const apiPlanRoute: Handler = ({ req, url, reader, tenant }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const cfg = tenantConfig(tenant);
   // Hub: fail closed like the disabled route-planner page (routePlannerPage is
   // false there). planItinerary is the UA-trained model — running it over the
@@ -998,7 +1004,7 @@ const apiPlanRoute: Handler = ({ req, url, reader, tenant }) => {
 };
 
 const apiMismatches: Handler = ({ req, reader }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const summary = reader.getVerificationSummary();
   const mismatches = reader.getWifiMismatches();
   const response = {
@@ -1017,7 +1023,7 @@ const apiMismatches: Handler = ({ req, reader }) => {
 };
 
 const apiFleetDiscovery: Handler = ({ req, reader }) => {
-  if (req.method !== "GET") return methodNotAllowed(true);
+  if (req.method !== "GET" && req.method !== "HEAD") return methodNotAllowed(true);
   const stats = reader.getFleetDiscoveryStats();
   const spreadsheetCache = getSpreadsheetCacheTails();
   const cacheInfo = getSpreadsheetCacheInfo();
@@ -2314,15 +2320,13 @@ export function createApp(db: Database): App {
     // visible in dashboards; just not worth a full trace span.
     if (req.method === "OPTIONS" && (url.pathname.startsWith("/api/") || url.pathname === "/mcp")) {
       const response = corsPreflight(url.pathname);
-      if (m) {
-        metrics.increment(COUNTERS.HTTP_REQUEST, {
-          method: req.method,
-          route: m.route === "/static" ? "/static/*" : m.route,
-          status_code: response.status,
-          tenant: tenantScope(tenant),
-          client_class: classifyUserAgent(req.headers.get("user-agent")),
-        });
-      }
+      metrics.increment(COUNTERS.HTTP_REQUEST, {
+        method: req.method,
+        route: metricRoute(m),
+        status_code: response.status,
+        tenant: tenantScope(tenant),
+        client_class: classifyUserAgent(req.headers.get("user-agent")),
+      });
       return response;
     }
 
@@ -2349,19 +2353,26 @@ export function createApp(db: Database): App {
         if (onStarlinkIp) span.setTag("starlink_ip", true);
         const ua = req.headers.get("user-agent");
         if (ua) span.setTag("http.useragent", ua);
+        // The requested path, not just the matched route. Without it "which
+        // URLs are 404ing" is unanswerable — the span only carried the matched
+        // prefix, and an unmatched path carried "/*". Pathname only: query
+        // strings can hold caller-supplied values and this tag is high-volume.
+        span.setTag("http.url", url.pathname);
 
         const response = m ? await m.handler(ctx) : notFound(site);
 
         span.setTag("http.status_code", response.status);
-        if (m) {
-          metrics.increment(COUNTERS.HTTP_REQUEST, {
-            method: req.method,
-            route: m.route === "/static" ? "/static/*" : m.route,
-            status_code: response.status,
-            tenant: tenantScope(tenant),
-            client_class: classifyUserAgent(ua),
-          });
-        }
+        // Emitted for unmatched paths too. Gating this on `m` hid every 404 on a
+        // path that matched no route — measured at ~82% of all 404s, i.e. a 5.4x
+        // undercount — from every metric-backed dashboard and monitor. `route`
+        // stays a bounded allowlist: unmatched collapses to "/*".
+        metrics.increment(COUNTERS.HTTP_REQUEST, {
+          method: req.method,
+          route: metricRoute(m),
+          status_code: response.status,
+          tenant: tenantScope(tenant),
+          client_class: classifyUserAgent(ua),
+        });
         return response;
       },
       { "span.type": "web" }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -112,6 +112,13 @@ export const SECURITY_HEADERS = {
   notFound: {
     ...BASE_RESPONSE_HEADERS,
     "Content-Type": "text/html",
+    // The 404 body is brand-static — no per-visitor content, so unlike the html
+    // variant it is safe at the edge. Retiring a large URL space (the
+    // pre-route-page /route-planner/* duplicates) sends crawlers back over
+    // thousands of dead URLs; without this every repeat 404 re-rendered at
+    // origin. s-maxage only: shared caches absorb it, browsers keep revalidating
+    // so a path that starts existing isn't stuck 404ing for a user.
+    "Cache-Control": "public, s-maxage=3600, max-age=0, must-revalidate",
     "Content-Security-Policy":
       "default-src 'self'; style-src 'unsafe-inline' https://fonts.googleapis.com; " +
       "font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;",

--- a/tests/request-instrumentation.test.ts
+++ b/tests/request-instrumentation.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Request-level instrumentation: metric coverage, crawler classification, and
+ * the 404/HEAD contracts.
+ *
+ * Three defects this pins:
+ *  - HTTP_REQUEST was gated on a matched route, so any path matching no route
+ *    emitted no metric at all. Measured in production: 163 counted 404s against
+ *    880 real ones, ~82% invisible to every metric-backed dashboard.
+ *  - classifyUserAgent collapsed every crawler into one `bot` bucket, so a
+ *    Bingbot surge that was ~40% of all traffic could not be seen in metrics.
+ *  - 404s carried no Cache-Control, so retiring a large URL space sent every
+ *    repeat crawler 404 to origin.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { classifyUserAgent, metrics } from "../src/observability/metrics";
+import { createApp } from "../src/server/app";
+import { openSnapshot, req } from "./helpers";
+
+const UA = "unitedstarlinktracker.com";
+const app = createApp(openSnapshot());
+
+/** metrics is a plain object literal, so it can be spied without a prod seam. */
+function captureIncrements(): { calls: Array<{ name: string; tags: Record<string, unknown> }> } {
+  const calls: Array<{ name: string; tags: Record<string, unknown> }> = [];
+  const original = metrics.increment;
+  metrics.increment = (name, tags) => {
+    calls.push({ name, tags: (tags ?? {}) as Record<string, unknown> });
+    original(name, tags);
+  };
+  restore = () => {
+    metrics.increment = original;
+  };
+  return { calls };
+}
+let restore: (() => void) | null = null;
+afterEach(() => {
+  restore?.();
+  restore = null;
+});
+
+describe("classifyUserAgent", () => {
+  test("splits the named crawlers instead of collapsing them to `bot`", () => {
+    const cases: Array<[string, string]> = [
+      ["Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", "googlebot"],
+      ["Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)", "bingbot"],
+      ["Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)", "gptbot"],
+      ["Mozilla/5.0 (compatible; PerplexityBot/1.0)", "perplexity"],
+      ["Mozilla/5.0 (compatible; AhrefsBot/7.0)", "seo-crawler"],
+      ["facebookexternalhit/1.1", "social"],
+      ["Mozilla/5.0 (compatible; ClaudeBot/1.0)", "claude"],
+    ];
+    for (const [ua, want] of cases) {
+      expect(classifyUserAgent(ua), ua).toBe(want);
+    }
+  });
+
+  test("GoogleOther is not misread as Googlebot", () => {
+    expect(classifyUserAgent("Mozilla/5.0 (compatible; GoogleOther)")).toBe("googleother");
+    expect(classifyUserAgent("Mozilla/5.0 (compatible; Google-Extended)")).toBe("googleother");
+  });
+
+  test("existing buckets still resolve", () => {
+    expect(classifyUserAgent("UA-Starlink-Extension/1.4.0")).toBe("extension");
+    expect(classifyUserAgent("curl/8.4.0")).toBe("bot");
+    expect(classifyUserAgent("Mozilla/5.0 (Macintosh) AppleWebKit/537 Chrome/120")).toBe("browser");
+    expect(classifyUserAgent(null)).toBe("unknown");
+    expect(classifyUserAgent("")).toBe("unknown");
+  });
+
+  test("stays a bounded enum — no raw UA ever becomes a tag", () => {
+    const allowed = new Set([
+      "claude",
+      "googleother",
+      "googlebot",
+      "bingbot",
+      "gptbot",
+      "perplexity",
+      "seo-crawler",
+      "social",
+      "extension",
+      "bot",
+      "browser",
+      "unknown",
+    ]);
+    for (const ua of [
+      "totally made up agent",
+      "<script>alert(1)</script>",
+      "Mozilla/5.0 (compatible; SomeNewBot/9.9)",
+      "x".repeat(500),
+    ]) {
+      expect(allowed.has(classifyUserAgent(ua)), ua).toBe(true);
+    }
+  });
+});
+
+describe("http.request metric coverage", () => {
+  const httpCalls = (calls: Array<{ name: string; tags: Record<string, unknown> }>) =>
+    calls.filter((c) => c.name === "http.request");
+
+  test("an unmatched path emits the metric, tagged route:/*", async () => {
+    const { calls } = captureIncrements();
+    await app.dispatch(req("/definitely-not-a-route-xyz", UA));
+    const http = httpCalls(calls);
+    expect(http.length).toBe(1);
+    expect(http[0].tags.route).toBe("/*");
+    expect(http[0].tags.status_code).toBe(404);
+  });
+
+  test("a matched path still reports its own route, not /*", async () => {
+    const { calls } = captureIncrements();
+    await app.dispatch(req("/api/data", UA));
+    const http = httpCalls(calls);
+    expect(http.length).toBe(1);
+    expect(http[0].tags.route).toBe("/api/data");
+    expect(http[0].tags.status_code).toBe(200);
+  });
+
+  test("the crawler bucket reaches the metric tags", async () => {
+    const { calls } = captureIncrements();
+    await app.dispatch(
+      req("/definitely-not-a-route-xyz", UA, {
+        headers: { "User-Agent": "Mozilla/5.0 (compatible; bingbot/2.0)" },
+      })
+    );
+    expect(httpCalls(calls)[0].tags.client_class).toBe("bingbot");
+  });
+});
+
+describe("404 responses", () => {
+  const get = (path: string) => app.dispatch(req(path, UA, { headers: { Accept: "text/html" } }));
+
+  test("an unmatched path 404s and is edge-cacheable but not browser-cacheable", async () => {
+    const res = await get("/definitely-not-a-route-xyz");
+    expect(res.status).toBe(404);
+    const cc = res.headers.get("cache-control") ?? "";
+    // Shared caches absorb the repeat crawl...
+    expect(cc).toContain("s-maxage=");
+    expect(cc).toContain("public");
+    // ...but a browser revalidates, so a path that starts existing is not stuck.
+    expect(cc).toContain("max-age=0");
+  });
+
+  test("200 HTML is still never edge-cached (renders vary by client IP)", async () => {
+    const res = await get("/");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("no-store");
+  });
+});
+
+describe("HEAD is allowed wherever GET is", () => {
+  const head = (path: string) => app.dispatch(req(path, UA, { method: "HEAD" }));
+
+  test("/api/* accepts HEAD instead of 405ing", async () => {
+    for (const path of ["/api/data", "/api/fleet-summary"]) {
+      const res = await head(path);
+      expect(res.status, path).not.toBe(405);
+    }
+  });
+
+  test("a genuinely unsupported method still 405s", async () => {
+    const res = await app.dispatch(req("/api/data", UA, { method: "DELETE" }));
+    expect(res.status).toBe(405);
+  });
+});


### PR DESCRIPTION
Five instrumentation gaps, found while trying to answer *"which URLs are crawlers 404ing on"* and discovering the data doesn't exist.

## 1. ~82% of 404s were invisible to metrics

`metrics.increment(HTTP_REQUEST)` was gated on a matched route, so any path matching no route emitted nothing. Measured in production over one 12h window: **metric = 163 404s, spans = 880**. A 404 flood or scanner sweep was invisible to every metric-backed dashboard and monitor.

The `route` tag stays a bounded allowlist — unmatched collapses to `"/*"` — so cardinality is unchanged. Both emit sites (main dispatch and the CORS preflight path) now share a `metricRoute()` helper.

## 2. The requested path was recorded nowhere

Spans carried `http.route` (the matched prefix) and nothing else, so *"which URLs are 404ing"* and *"is a crawler re-fetching the same URL"* were unanswerable — which is exactly what blocked the Bingbot triage. Adds `http.url` with the **pathname only**; query strings can carry caller-supplied values and this is a high-volume tag.

## 3. Every crawler was one `bot` bucket

Googlebot, Bingbot, GPTBot, AhrefsBot, Meta — all collapsed. A Bingbot surge that reached **~40% of all traffic** could not be seen in any metric.

Now splits the named crawlers, still as a fixed enum and never the raw UA. **GoogleOther/Google-Extended is tested before Googlebot** so the AI-training crawler isn't misfiled — it currently out-crawls Googlebot **3.3:1** and targets the slowest pages, which is worth being able to see.

## 4. 404s were uncacheable

No `Cache-Control` header at all, `cf-cache-status: DYNAMIC`. Retiring a URL space (the pre-route-page `/route-planner/*` duplicates) sends crawlers back over thousands of dead URLs, and every repeat hit re-rendered at origin.

`public, s-maxage=3600, max-age=0, must-revalidate` — shared caches absorb the repeat, browsers still revalidate so a path that *starts* existing isn't stuck 404ing for a user. **The 200 HTML path is untouched** and keeps `private, no-store`; those renders vary by client IP for the passenger probe.

## 5. HEAD 405'd on /api/*

Ten API handlers rejected HEAD while every page handler allowed it.

## Testing

New `tests/request-instrumentation.test.ts` — 11 tests, including a metric spy (`metrics` is a plain object literal, so no production seam was needed). Verified against the un-fixed code:

| Reverted fix | Result |
|---|---|
| metric back inside `if (m)` | fails — asserts exactly 1 emit tagged `route:"/*"` on an unmatched path; the guard emits zero |
| crawler split removed | 3 fail |
| 404 `Cache-Control` removed | 1 fail |

Also pinned: `classifyUserAgent` stays a bounded enum against adversarial UA strings (injection-ish, 500 chars, unknown bots), and 200 HTML must still be `no-store`.

Full suite **782 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)