### PR TITLE
fix: stop adsb_sweep overrunning its interval; keep 90d of observations

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -4004,7 +4004,18 @@ export function getFleetTailsWithStatus(
     .all(airline) as Array<{ tail_number: string; starlink_status: string }>;
 }
 
-const ADSB_OBSERVATION_RETENTION_DAYS = 7;
+/**
+ * 90 days, matching the sweep aggregates.
+ *
+ * These rows are the only unbiased flight-number-to-tail record the project
+ * has: the ADS-B sweep covers the whole fleet, whereas starlink_verification_log
+ * only holds tails the verifier chose to check (Starlink-suspected ones), which
+ * is the selection bias the predictor's global priors exist to paper over. At
+ * ~56k no_assignment observations a week there is far more signal here than in
+ * the verification log, and at 7 days it was all being discarded before it
+ * could be used. Raised now so the history accumulates.
+ */
+const ADSB_OBSERVATION_RETENTION_DAYS = 90;
 const ADSB_SWEEP_RETENTION_DAYS = 90;
 
 /** Persist one shadow sweep + its observations and prune old audit rows. */

--- a/src/scripts/adsb-sweep.ts
+++ b/src/scripts/adsb-sweep.ts
@@ -30,7 +30,17 @@ interface AdsbProvider {
   maxRegsPerRequest: number;
 }
 
+// Order is failover order, and it is measured, not alphabetical: over 24h in
+// production airplanes.live and adsb.lol failed on essentially every sweep
+// (~1,470 failures/day between them) while adsb.fi served it. Trying the two
+// dead ones first meant every sweep paid both timeouts before doing any work.
+// The others stay as fallbacks — they are free when adsb.fi answers.
 const PROVIDERS: AdsbProvider[] = [
+  {
+    name: "adsb.fi",
+    buildUrl: (regs) => `https://opendata.adsb.fi/api/v2/registration/${regs.join(",")}`,
+    maxRegsPerRequest: 100,
+  },
   {
     name: "airplanes.live",
     buildUrl: (regs) => `https://api.airplanes.live/v2/reg/${regs.join(",")}`,
@@ -41,14 +51,13 @@ const PROVIDERS: AdsbProvider[] = [
     buildUrl: (regs) => `https://api.adsb.lol/v2/reg/${regs.join(",")}`,
     maxRegsPerRequest: 100,
   },
-  {
-    name: "adsb.fi",
-    buildUrl: (regs) => `https://opendata.adsb.fi/api/v2/registration/${regs.join(",")}`,
-    maxRegsPerRequest: 100,
-  },
 ];
 
 const PROVIDER_RATE_GAP_MS = 1100;
+/** Per-request ceiling. Failover is serial across three providers and each may
+ * page through the fleet, so an unbounded request is what let one slow upstream
+ * push a whole sweep past its 5-minute interval. */
+const PROVIDER_REQUEST_TIMEOUT_MS = 20_000;
 
 export interface AdsbAircraft {
   tail: string;
@@ -81,6 +90,10 @@ async function queryProvider(
     const chunk = tails.slice(i, i + provider.maxRegsPerRequest);
     const res = await fetcher(provider.buildUrl(chunk), {
       headers: { "User-Agent": BROWSER_USER_AGENT, Accept: "application/json" },
+      // Without this a hung upstream parked the whole sweep. Failover is serial,
+      // so one unresponsive provider could push a sweep past its own interval
+      // and then past the 15-minute job watchdog.
+      signal: AbortSignal.timeout(PROVIDER_REQUEST_TIMEOUT_MS),
     });
     requests++;
     if (!res.ok) throw new Error(`${provider.name} HTTP ${res.status}`);
@@ -107,11 +120,16 @@ async function queryProvider(
 /** One full sweep with provider failover. */
 export async function sweepAdsbProviders(
   tails: string[],
-  fetcher: typeof fetch = fetch
+  fetcher: typeof fetch = fetch,
+  airlineTag = "unmapped"
 ): Promise<{ aircraft: AdsbAircraft[]; stats: AdsbSweepStats }> {
   let lastErr: unknown = null;
+  // Timed around the whole failover, not around the winning provider. The old
+  // placement reported only the successful attempt, so a sweep that burned two
+  // provider timeouts before succeeding reported the last leg's few seconds —
+  // p95 read 22.9s while the real sweep span was 319.8s, past its own interval.
+  const started = Date.now();
   for (const provider of PROVIDERS) {
-    const started = Date.now();
     try {
       const { aircraft, requests } = await queryProvider(provider, tails, fetcher);
       return {
@@ -120,6 +138,16 @@ export async function sweepAdsbProviders(
       };
     } catch (err) {
       lastErr = err;
+      // Per-provider failures previously emitted only a warn, so the metric a
+      // monitor watches (vendor.request{vendor:adsb,status:error}) fired only on
+      // a total blackout — ~1,470 real failures/day read as zero.
+      metrics.increment(COUNTERS.VENDOR_REQUEST, {
+        vendor: "adsb",
+        type: "provider",
+        status: "error",
+        provider: provider.name,
+        airline: airlineTag,
+      });
       warn(`adsb-sweep: ${provider.name} failed, trying next provider`, err);
     }
   }
@@ -238,7 +266,7 @@ export async function runAdsbSweepShadow(
       // double-counted as a vendor error.
       let swept: Awaited<ReturnType<typeof sweepAdsbProviders>>;
       try {
-        swept = await sweepAdsbProviders(tails, fetcher);
+        swept = await sweepAdsbProviders(tails, fetcher, airlineTag);
       } catch (err) {
         logError("adsb-shadow sweep failed", err);
         metrics.increment(COUNTERS.VENDOR_REQUEST, {
@@ -378,6 +406,13 @@ export function startAdsbSweepJob(db: Database): JobHandle {
     name: "adsb_sweep",
     intervalMs: 5 * 60 * 1000,
     initialDelayMs: 2 * 60 * 1000,
+    // A sweep now has a bounded worst case: 3 providers x their paging, each
+    // request capped at PROVIDER_REQUEST_TIMEOUT_MS. The default 15-minute
+    // watchdog fired twice in 24h and abandons without aborting, leaving an
+    // orphaned run writing alongside its successor — the exact overlap the
+    // runner exists to prevent. Sized above the real worst case, not the
+    // observed p95, so it only trips on a genuine hang.
+    stuckTimeoutMs: 8 * 60 * 1000,
     run: async () => {
       if (breaker.shouldSkip()) return;
       const result = await runAdsbSweepShadow(db);

--- a/tests/adsb-sweep.test.ts
+++ b/tests/adsb-sweep.test.ts
@@ -2,11 +2,13 @@
 // Shadow only: nothing here may touch the serving tables.
 
 import { describe, expect, test } from "bun:test";
+import { metrics } from "../src/observability/metrics";
 import {
   callsignMatchesAssignment,
   classifyObservation,
   deriveCallsignFlight,
   runAdsbSweepShadow,
+  sweepAdsbProviders,
 } from "../src/scripts/adsb-sweep";
 import { addFleet, addFlight, makeSyntheticDb } from "./helpers";
 
@@ -129,5 +131,87 @@ describe("runAdsbSweepShadow", () => {
     const result = await runAdsbSweepShadow(db, fetcher);
     expect(result.outcome).toBe("error");
     expect(db.query("SELECT COUNT(*) AS n FROM adsb_sweeps").get()).toEqual({ n: 0 });
+  });
+});
+
+describe("provider failover", () => {
+  // Fetcher that fails for the named providers (matched on host) and serves an
+  // empty-but-valid payload otherwise, recording the order it was called in.
+  function fetcherFailing(failHosts: string[], order: string[]): typeof fetch {
+    return (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const host = new URL(url).host;
+      order.push(host);
+      if (failHosts.some((h) => host.includes(h))) {
+        return new Response("nope", { status: 503 });
+      }
+      return new Response(JSON.stringify({ ac: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+  }
+
+  test("adsb.fi is tried first — the two that fail in production come after", async () => {
+    const order: string[] = [];
+    const res = await sweepAdsbProviders(["N12345"], fetcherFailing([], order));
+    expect(order[0]).toContain("adsb.fi");
+    expect(res.stats.provider).toBe("adsb.fi");
+  });
+
+  test("falls over to the next provider and reports the one that answered", async () => {
+    const order: string[] = [];
+    const res = await sweepAdsbProviders(["N12345"], fetcherFailing(["adsb.fi"], order));
+    expect(res.stats.provider).toBe("airplanes.live");
+    expect(order.length).toBe(2);
+  });
+
+  test("emits a per-provider error metric, not just a warn", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const original = metrics.increment;
+    metrics.increment = (name, tags) => {
+      if (name === "vendor.request") calls.push((tags ?? {}) as Record<string, unknown>);
+      original(name, tags);
+    };
+    try {
+      await sweepAdsbProviders(["N12345"], fetcherFailing(["adsb.fi", "airplanes.live"], []));
+    } finally {
+      metrics.increment = original;
+    }
+    // The monitor watches vendor:adsb + status:error. Before this, only a total
+    // blackout emitted it, so ~1,470 real failures/day read as zero.
+    const failures = calls.filter((t) => t.vendor === "adsb" && t.status === "error");
+    expect(failures.length).toBe(2);
+    expect(failures.map((t) => t.provider).sort()).toEqual(["adsb.fi", "airplanes.live"]);
+    expect(failures.every((t) => t.type === "provider")).toBe(true);
+  });
+
+  test("latencyMs spans the whole failover, not just the winning provider", async () => {
+    const slow = (async (input: RequestInfo | URL) => {
+      const host = new URL(String(input)).host;
+      if (host.includes("adsb.fi")) {
+        await new Promise((r) => setTimeout(r, 60));
+        return new Response("nope", { status: 503 });
+      }
+      return new Response(JSON.stringify({ ac: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const res = await sweepAdsbProviders(["N12345"], slow);
+    expect(res.stats.provider).toBe("airplanes.live");
+    // Must include the 60ms burned on the failed first provider.
+    expect(res.stats.latencyMs).toBeGreaterThanOrEqual(55);
+  });
+
+  test("throws only when every provider fails", async () => {
+    const order: string[] = [];
+    await expect(
+      sweepAdsbProviders(
+        ["N12345"],
+        fetcherFailing(["adsb.fi", "airplanes.live", "adsb.lol"], order)
+      )
+    ).rejects.toThrow(/all ADS-B providers failed/);
+    expect(order.length).toBe(3);
   });
 });


### PR DESCRIPTION
## The bug

```
p95 span duration   319.8 s   >   intervalMs: 5 * 60 * 1000  (300 s)
"skipping tick — previous run still in progress"    23× / 24h
"run stuck for 15min — abandoning it"                2× / 24h
```

Each abandon leaves an **orphaned run executing alongside its successor** — the exact overlap the job runner exists to prevent. `adsb_sweep` was also the only job not overriding the default 15-minute watchdog, despite being the one that needed to.

## Root cause

Serial provider failover with **no per-request timeout**. Over 24h in production, `airplanes.live` and `adsb.lol` failed on essentially every sweep (**~1,470 failures/day** between them) while `adsb.fi` served it — so every sweep paid two full failures before doing any work.

Three changes:
- **Per-request `AbortSignal.timeout`** so one hung upstream can't park a sweep
- **Provider order is now measured, not incidental** — `adsb.fi` first. The other two stay as fallbacks; they're free when the first answers
- **Explicit `stuckTimeoutMs`**, sized above the now-bounded worst case rather than the observed p95, so it trips only on a genuine hang

## Two instrumentation bugs in the same code

**The monitor could not fire.** Per-provider failures emitted only a `warn()`, so `vendor.request{vendor:adsb,status:error}` — which monitor 20509671 watches — fired only on a *total* blackout. ~1,470 real failures/day read as **zero**; the monitor needed 7 total blackouts in an hour to trip. Now emits per provider with `type:provider` and a `provider` tag.

**Latency under-reported 14×.** `latencyMs` was stamped inside the provider loop, timing only the *winning* attempt. A sweep that burned two timeouts reported the last leg's few seconds — p95 read **22.9 s** against a real **319.8 s**.

## Retention: 7 → 90 days

`ADSB_OBSERVATION_RETENTION_DAYS` 7 → 90, matching the sweep aggregates.

These rows are the only **unbiased** flight-number-to-tail record the project has: the ADS-B sweep covers the whole fleet, whereas `starlink_verification_log` only holds tails the verifier *chose* to check (Starlink-suspected ones) — which is the selection bias the predictor's global priors exist to paper over. At **~56,000 `no_assignment` observations per week** — 165× the verification log's clean checks — it was all being discarded at 7 days before it could be used. Raised now so the history accumulates while the modelling work is scheduled.

## Testing

5 new tests in `tests/adsb-sweep.test.ts`. Verified against the un-fixed code:

| Reverted fix | Result |
|---|---|
| per-provider metric removed | 1 fails |
| latency timed around winner only | 1 fails |

Also pinned: `adsb.fi` is tried first, failover reports the provider that actually answered, and a total blackout still throws after trying all three.

Full suite **776 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

## Follow-up not in this PR

Monitor 20509671 needs rescoping to `type:provider` in Datadog to actually use the new metric — that's a console change, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)