### PR TITLE
chore: cut log ingestion ~80% by demoting per-item chatter

### DIFF
--- a/src/api/check-flight-core.ts
+++ b/src/api/check-flight-core.ts
@@ -25,7 +25,7 @@ import {
   predictFlight,
 } from "../scripts/starlink-predictor";
 import { type FlightDateWindow, flightDateWindow, matchesLocalDate } from "../utils/airport-tz";
-import { error as logError } from "../utils/logger";
+import { warn } from "../utils/logger";
 import { type FallbackSegment, lookupFlightTailVerdict } from "./flight-verdict";
 import { Fr24UnavailableError } from "./flightradar24-api";
 import { qatarEquipmentName } from "./qatar-status";
@@ -303,7 +303,12 @@ export async function resolveFlightVerdict(
       // Anything else (e.g. a DB error) must not masquerade as an outage.
       if (!(err instanceof Fr24UnavailableError)) throw err;
       fr24Error = true;
-      logError(`FR24 lookup failed for ${normalized} ${date}; degrading to prediction path`, err);
+      // warn, not error: this is the handled degradation the line above
+      // describes, and the caller surfaces FR24_OUTAGE_NOTE to the user. At
+      // ERROR it was 72 of the service's 81 logged errors — enough noise to
+      // make the error stream useless for spotting a real fault. The outage
+      // itself is still tracked as vendor.request{vendor:fr24,status:error}.
+      warn(`FR24 lookup failed for ${normalized} ${date}; degrading to prediction path`, err);
     }
     if (segments !== null) {
       const starlink = segments.filter((s) => s.hasStarlink);

--- a/src/api/flight-updater.ts
+++ b/src/api/flight-updater.ts
@@ -12,7 +12,7 @@ import { withSpan } from "../observability";
 import type { Aircraft, Flight } from "../types";
 import { FLIGHT_DATA_SOURCE } from "../utils/constants";
 import { type JobHandle, type JobRunContext, startJob } from "../utils/job-runner";
-import { error, info } from "../utils/logger";
+import { debug, error, info } from "../utils/logger";
 import { FlightAwareAPI } from "./flightaware-api";
 import { FlightRadar24API } from "./flightradar24-api";
 
@@ -69,7 +69,11 @@ async function updateFlightsForTailNumber(api: FlightAPI, tailNumber: string): P
       const db = initializeDatabase();
 
       try {
-        info(`Fetching upcoming flights for ${tailNumber}`);
+        // debug, not info: this trio fired 3x per tail on a 22.5s loop and was
+        // 69.5% of the service's entire log volume. The same facts are already
+        // in this span (tail_number, flights.count) and in
+        // starlink.data.freshness_seconds{job:flight_updater}.
+        debug(`Fetching upcoming flights for ${tailNumber}`);
         const flights = await api.getUpcomingFlights(tailNumber);
 
         span.setTag("flights.count", flights.length);
@@ -80,10 +84,10 @@ async function updateFlightsForTailNumber(api: FlightAPI, tailNumber: string): P
           );
           updateLastFlightCheck(db, tailNumber, false);
         } else {
-          info(`Found ${flights.length} upcoming flights for ${tailNumber}`);
+          debug(`Found ${flights.length} upcoming flights for ${tailNumber}`);
           updateFlights(db, tailNumber, flights);
           updateLastFlightCheck(db, tailNumber, true);
-          info(`Successfully updated ${flights.length} upcoming flights for ${tailNumber}`);
+          debug(`Successfully updated ${flights.length} upcoming flights for ${tailNumber}`);
           success = true;
         }
       } catch (err) {

--- a/src/scripts/adsb-sweep.ts
+++ b/src/scripts/adsb-sweep.ts
@@ -21,7 +21,7 @@ import {
 import type { AdsbObservationRecord } from "../types";
 import { BROWSER_USER_AGENT } from "../utils/constants";
 import { type JobHandle, createOutageBreaker, startJob } from "../utils/job-runner";
-import { info, error as logError, warn } from "../utils/logger";
+import { debug, info, error as logError, warn } from "../utils/logger";
 
 interface AdsbProvider {
   name: string;
@@ -296,7 +296,11 @@ export async function runAdsbSweepShadow(
             assignedFlight = classified.assignedFlight;
             counts[result]++;
             if (result === "mismatch") {
-              warn(
+              // debug: this re-fired every sweep for the same aircraft (top
+              // offender 43x/week) and was 11% of all log volume. The count is
+              // already carried by adsb_shadow.observations{result:mismatch},
+              // and the per-aircraft detail is written to adsb_observations.
+              debug(
                 `adsb-shadow: ${ac.tail} flying ${ac.callsign} but upcoming_flights says ${assignedFlight}`
               );
             }

--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -38,7 +38,7 @@ import { icaoToIata } from "../utils/airport-tz";
 import { extractFlightNumber, pickVerifiableFlight, unitedLookupDate } from "../utils/constants";
 import { pingIndexNow } from "../utils/indexnow";
 import { type JobHandle, startJob } from "../utils/job-runner";
-import { info, error as logError, warn } from "../utils/logger";
+import { debug, info, error as logError, warn } from "../utils/logger";
 import { notifyNewStarlinkPlane } from "../utils/notify";
 import type { StarlinkCheckResult } from "./united-starlink-checker";
 import { checkStarlinkStatusSubprocess } from "./united-starlink-checker-subprocess";
@@ -445,7 +445,9 @@ export async function runDiscoveryBatch(limit = 1): Promise<{
     const planes = getNextPlanesToVerify(db, limit);
 
     if (planes.length === 0) {
-      info("No planes need verification at this time");
+      // debug, matching starlink-verifier.ts which already logs the idle
+      // tick at debug — the two paths disagreed and this one ran every 90s.
+      debug("No planes need verification at this time");
       return stats;
     }
 
@@ -503,8 +505,14 @@ export function startFleetDiscovery(mode: "discovery" | "maintenance" = "mainten
           span.setTag("starlink", stats.starlink);
           span.setTag("errors", stats.errors);
 
-          if (stats.checked > 0) {
+          // Only worth an info line when something actually changed; half of
+          // these batches were "0 Starlink, 0/1 not, 0 errors".
+          if (stats.starlink > 0 || stats.errors > 0) {
             info(
+              `Batch complete: ${stats.starlink} Starlink, ${stats.notStarlink} not, ${stats.errors} errors`
+            );
+          } else if (stats.checked > 0) {
+            debug(
               `Batch complete: ${stats.starlink} Starlink, ${stats.notStarlink} not, ${stats.errors} errors`
             );
           }
@@ -515,11 +523,16 @@ export function startFleetDiscovery(mode: "discovery" | "maintenance" = "mainten
             const db = initializeDatabase();
             try {
               const fleetStats = getFleetDiscoveryStats(db, "UA");
-              info(
-                `Heartbeat: ${runCount} runs, Total: ${fleetStats.total_fleet} fleet, ` +
-                  `${fleetStats.verified_starlink} Starlink, ${fleetStats.verified_non_starlink} non-Starlink, ` +
-                  `${fleetStats.pending_verification} pending`
-              );
+              // Counters live in the data field, not the message: an
+              // incrementing runCount inside the string makes every line a
+              // distinct message and defeats Datadog pattern grouping.
+              info("Heartbeat: fleet-discovery scheduler healthy", {
+                runs: runCount,
+                fleet: fleetStats.total_fleet,
+                starlink: fleetStats.verified_starlink,
+                nonStarlink: fleetStats.verified_non_starlink,
+                pending: fleetStats.pending_verification,
+              });
 
               emitFleetSnapshot(db);
 

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -410,7 +410,9 @@ export function startStarlinkVerifier(): JobHandle {
     // Heartbeat log every 10 minutes to show scheduler is alive
     const now = Date.now();
     if (now - lastHeartbeat >= HEARTBEAT_INTERVAL_MS) {
-      verifierLog.info(`Heartbeat: ${runCount} runs completed, scheduler healthy`);
+      // See fleet-discovery: the counter belongs in the data field so the
+      // 2,950 heartbeat lines/week group as one pattern instead of 2,950.
+      verifierLog.info("Heartbeat: verifier scheduler healthy", { runs: runCount });
       lastHeartbeat = now;
     }
 
@@ -426,8 +428,13 @@ export function startStarlinkVerifier(): JobHandle {
         span.setTag("starlink", stats.starlink);
         span.setTag("errors", stats.errors);
 
-        if (stats.checked > 0) {
+        // See fleet-discovery: a no-change batch is a debug-level fact.
+        if (stats.starlink > 0 || stats.errors > 0) {
           verifierLog.info(
+            `Batch complete: ${stats.starlink} Starlink, ${stats.notStarlink} not, ${stats.errors} errors`
+          );
+        } else if (stats.checked > 0) {
+          verifierLog.debug(
             `Batch complete: ${stats.starlink} Starlink, ${stats.notStarlink} not, ${stats.errors} errors`
           );
         }

--- a/tests/log-levels.test.ts
+++ b/tests/log-levels.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Log-level policy.
+ *
+ * The ingestion reduction in the flight-updater / adsb-shadow / verifier paths
+ * rests on one property: DEBUG is written to the on-disk log but never to
+ * stdout/stderr in production, and Datadog ingests the console stream. If that
+ * ever changes, those call sites silently start costing again — so it is pinned
+ * here rather than left as a comment.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { logger } from "../src/utils/logger";
+
+let out: string[] = [];
+let err: string[] = [];
+let origLog: typeof console.log;
+let origErr: typeof console.error;
+let origEnv: string | undefined;
+
+beforeEach(() => {
+  out = [];
+  err = [];
+  origLog = console.log;
+  origErr = console.error;
+  origEnv = process.env.NODE_ENV;
+  console.log = (line: string) => out.push(String(line));
+  console.error = (line: string) => err.push(String(line));
+});
+
+afterEach(() => {
+  console.log = origLog;
+  console.error = origErr;
+  process.env.NODE_ENV = origEnv ?? "";
+});
+
+describe("debug suppression in production", () => {
+  test("debug does not reach the console when NODE_ENV=production", () => {
+    process.env.NODE_ENV = "production";
+    logger.debug("noisy per-tail line");
+    expect(out).toEqual([]);
+    expect(err).toEqual([]);
+  });
+
+  test("debug does reach the console outside production", () => {
+    process.env.NODE_ENV = "development";
+    logger.debug("noisy per-tail line");
+    expect(out.length + err.length).toBe(1);
+  });
+
+  test("info, warn and error are never suppressed", () => {
+    process.env.NODE_ENV = "production";
+    logger.info("kept");
+    logger.warn("kept");
+    logger.error("kept");
+    expect(out.length + err.length).toBe(3);
+  });
+
+  test("warn and error go to stderr, info to stdout", () => {
+    process.env.NODE_ENV = "production";
+    logger.info("i");
+    expect(out.length).toBe(1);
+    out = [];
+    logger.warn("w");
+    logger.error("e");
+    expect(err.length).toBe(2);
+    expect(out).toEqual([]);
+  });
+});
+
+describe("structured fields", () => {
+  test("counters passed as data stay out of the message so lines group", () => {
+    process.env.NODE_ENV = "production";
+    logger.info("Heartbeat: verifier scheduler healthy", { runs: 1234 });
+    const record = JSON.parse(out[0]) as { message: string; data?: Record<string, unknown> };
+    // The message must be constant across runs — an incrementing counter
+    // interpolated into it makes every line a distinct pattern in Datadog.
+    expect(record.message).not.toContain("1234");
+    expect(record.data).toMatchObject({ runs: 1234 });
+  });
+});


### PR DESCRIPTION
Eight message shapes were **87% of this service's entire log volume** (18.41 MB/day, 4th of 18 services in the org). Every top contributor is a per-item line whose facts are already carried by a metric or a span.

| Lines/7d | % | Shape | Already captured by |
|---:|---:|---|---|
| 26,877 | 23.6% | `Fetching upcoming flights for <tail>` | span `tail_number` |
| 24,382 | 21.4% | `Found N upcoming flights for <tail>` | span `flights.count` |
| 24,382 | 21.4% | `Successfully updated N ... for <tail>` | `data.freshness_seconds{job:flight_updater}` |
| 11,404 | 10.0% | `adsb-shadow: <tail> flying X but ... says Y` | `adsb_shadow.observations{result:mismatch}` + `adsb_observations` rows |
| 4,792 | 4.2% | `No planes need verification at this time` | — (verifier already logged this at debug) |

Estimated effect: **18.41 → ~3.6 MB/day**.

## Two shape fixes, not level changes

**Heartbeats defeated pattern grouping.** Both interpolated an incrementing `runCount` into the *message*, so 2,950 lines/week produced ~2,950 distinct message strings. The counter moves to the `data` field.

**The FR24 failure was logged at ERROR** despite being the handled degradation the adjacent comment describes ("FR24 outage ≠ no assignment published — never a confident no"). It was **72 of the service's 81 logged errors**, which makes the error stream useless for spotting a real fault. Now WARN. The outage is still counted as `vendor.request{vendor:fr24,status:error}`, so nothing is lost.

**"Batch complete"** fired even when nothing changed — half were `0 Starlink, 0/1 not, 0 errors`. INFO when something happened, debug otherwise.

## The load-bearing assumption, now pinned

All of this rests on DEBUG being written to `logs/app.log` but **never to the console** in production, with Datadog ingesting the console stream. That's a real property of `logger.ts` — `writeToFile` runs *before* the DEBUG/production check — so on-disk debugging is completely unaffected while stdout goes quiet.

That was a comment; it's now `tests/log-levels.test.ts` (5 tests), including that INFO/WARN/ERROR are never suppressed, that WARN/ERROR go to stderr, and that a counter passed as `data` stays out of the message.

## Deliberately not fixed

The FR24 line also fires **3–4× per logical failure** (three identical lines at the same millisecond in production) from repeated `resolveFlightVerdict` calls. That's a call-graph issue, not a logging one — a dedupe cache would hide it rather than fix it. Worth its own look.

Full suite **776 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)