### PR TITLE
fix: retire stale predictor constants and silent-zero harnesses

### DIFF
--- a/src/airlines/content/ua.tsx
+++ b/src/airlines/content/ua.tsx
@@ -138,12 +138,13 @@ export const content: AirlineContent = {
                 a hub can beat a direct mainline flight.
               </p>
               <p>
-                For example: DEN→ORD direct is mainline (~2%), but DEN→ASE→ORD is ~90% Starlink on
-                both legs.
+                For example: DEN→ORD direct is mainline (~
+                {fleetStats?.mainline.percentage.toFixed(0)}%), but DEN→ASE→ORD is express on both
+                legs.
               </p>
             </>
           ),
-          ld: "Use the Route Planner to compare direct flights and 1-stop connections ranked by Starlink probability. Express flights (UA3000-6999, regional jets) have much higher coverage than mainline — a connection through a hub can beat a direct mainline flight. For example: DEN→ORD direct is ~2%, but DEN→ASE→ORD is ~90% Starlink on both legs.",
+          ld: "Use the Route Planner to compare direct flights and 1-stop connections ranked by Starlink probability. Express flights (UA3000-6999, regional jets) have much higher coverage than mainline — a connection through a hub can beat a direct mainline flight. For example: DEN→ORD direct is mainline, but DEN→ASE→ORD is express on both legs.",
         },
       ],
     },

--- a/src/api/mcp-server.ts
+++ b/src/api/mcp-server.ts
@@ -256,9 +256,9 @@ function buildTools(scope: Scope) {
     },
     {
       name: "predict_flight_starlink",
-      description: `Use when the user asks "will my flight have Starlink?" for a date too far out for a confirmed assignment, or with no date at all. Returns the probability that a ${carrier} flight number gets a Starlink plane, from historical observations. Reliability varies: high-confidence (5+ obs) ~85%+ accurate; low-confidence (0-1 obs) is just the fleet prior.${
+      description: `Use when the user asks "will my flight have Starlink?" for a date too far out for a confirmed assignment, or with no date at all. Returns the probability that a ${carrier} flight number gets a Starlink plane, from historical observations. Reliability varies: high-confidence (5+ obs) is the most reliable tier but is not a guarantee; low-confidence (0-1 obs) is just the fleet prior.${
         scope === "UA" || scope === "ALL"
-          ? " UA1-2999 (mainline) are almost always NOT Starlink (~2% fleet coverage)."
+          ? " UA1-2999 (mainline) has materially lower coverage than UA3000-6999 (express) — call get_fleet_stats for the current split rather than assuming a rate."
           : ""
       }`,
       inputSchema: {
@@ -936,9 +936,12 @@ function buildAlternativesBlock(
       // lookup itself.
       const directEdge = reader.getDirectRouteEdge(r.origin, r.destination);
 
+      // Was hardcoded 0.02 while the live mainline rate is ~0.157 — a 7.8x
+      // understatement on the row an LLM is told to render verbatim, which
+      // systematically pushed users off the nonstop and onto connections.
       const directProb = directEdge
         ? predictFlight(reader, ensureAirlinePrefix(cfg, directEdge.flight_number)).probability
-        : 0.02;
+        : mainlineBaseline(reader);
 
       const durH = directEdge ? directEdge.dur_sec / 3600 : (r.duration_hours ?? null);
       rows.push({
@@ -1283,7 +1286,7 @@ function toolPlanStarlinkItinerary(
       content: [
         {
           type: "text",
-          text: `No Starlink routings found from ${orig} to ${dest} within ${maxStops} stops.\n\nNo path through the Starlink route graph connects these airports. This may be a mainline-only route (~2% Starlink fleet-wide).\n\n**Fallbacks**: (1) \`search_starlink_flights\` with just \`destination="${dest}"\` or \`origin="${orig}"\` — confirmed near-term assignments may exist even when historical probability is low; (2) if the user has a specific flight, \`predict_flight_starlink\` for a per-flight estimate; (3) otherwise advise booking the nonstop — no Starlink routing meaningfully improves odds on mainline-only routes.`,
+          text: `No Starlink routings found from ${orig} to ${dest} within ${maxStops} stops.\n\nNo path through the Starlink route graph connects these airports. This may be a mainline-only route, where fleet-wide coverage is much lower than on express.\n\n**Fallbacks**: (1) \`search_starlink_flights\` with just \`destination="${dest}"\` or \`origin="${orig}"\` — confirmed near-term assignments may exist even when historical probability is low; (2) if the user has a specific flight, \`predict_flight_starlink\` for a per-flight estimate; (3) otherwise advise booking the nonstop — no Starlink routing meaningfully improves odds on mainline-only routes.`,
         },
       ],
     };
@@ -1300,7 +1303,7 @@ function toolPlanStarlinkItinerary(
   const renderLeg = (leg: (typeof itineraries)[number]["legs"][number]): string => {
     if (leg.flight_number === "(any)") {
       const [from, to] = leg.route.split("-");
-      return `position ${from}→${to} (mainline, ~2% Starlink, duration unknown)`;
+      return `position ${from}→${to} (mainline, ~${(leg.probability * 100).toFixed(0)}% Starlink, duration unknown)`;
     }
     const pct = (leg.probability * 100).toFixed(0);
     const fleetTag = inferSubfleet(cfg, leg.flight_number) === "mainline" ? " [Mainline]" : "";
@@ -1355,7 +1358,7 @@ ${fullItins.map(renderItin).join("\n\n")}`);
   if (partialItins.length > 0) {
     const header =
       fullItins.length === 0
-        ? `**No all-Starlink path found within ${maxStops} stops.** Partial coverage options (one positioning leg ~2% Starlink, one Starlink leg):\n`
+        ? `**No all-Starlink path found within ${maxStops} stops.** Partial coverage options (one low-probability positioning leg, one Starlink leg):\n`
         : "**Baseline: 1-stop positioning + Starlink connection** (for comparison — what a 'normal' routing gets you):\n";
     sections.push(`${header}
 ${partialItins.map((it, i) => renderItin(it, fullItins.length + i)).join("\n\n")}`);
@@ -1543,6 +1546,21 @@ ${lines.join("\n")}`;
     .join("\n\n");
 
   return { content: [{ type: "text", text }] };
+}
+
+/**
+ * Live mainline install rate, for the "direct — baseline" comparison row.
+ *
+ * Replaces a hardcoded 0.02 that dated from an earlier phase of the rollout;
+ * mainline is now ~15.6% and climbing ~4.5pp/month, so the frozen number
+ * understated the nonstop by an order of magnitude on the exact row an LLM is
+ * instructed to render verbatim. Falls back to the model default only when the
+ * scope has no fleet stats (hub).
+ */
+function mainlineBaseline(reader: ScopedReader): number {
+  const stats = reader.getFleetStats();
+  if (!stats || stats.mainline.total <= 0) return 0.02;
+  return stats.mainline.starlink / stats.mainline.total;
 }
 
 function toolListStarlinkAircraft(

--- a/src/scripts/precision-backtest.ts
+++ b/src/scripts/precision-backtest.ts
@@ -175,6 +175,15 @@ if (import.meta.main) {
 
   const anchorIso = new Date(r.anchor * 1000).toISOString().slice(0, 16).replace("T", " ");
   console.log(`\n=== Firm-call precision · ${days}d window ending ${anchorIso} ===`);
+  // An empty sample used to print "precision=0.00%" and "North-star bar: FAIL",
+  // which reads as a real regression rather than "there is no data here" — the
+  // exact failure mode you hit running this against an empty local DB.
+  if (r.yes.n === 0 && r.no.n === 0) {
+    console.error(
+      `\n  NO DATA: no firm calls in the ${days}d window (db=${dbPath}). Nothing was measured — this is not a precision result.\n`
+    );
+    process.exit(2);
+  }
   console.log(fmt(r.yes, "YES"));
   console.log(fmt(r.no, "NO"));
   console.log(`  (no firm call possible: ${r.noFirmCall} obs — first sighting of tail)`);

--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -65,7 +65,11 @@ type PredictionMethod =
   | "flight_history_smoothed"
   | "fleet_prior_express"
   | "fleet_prior_mainline"
-  | "fleet_prior_unknown";
+  | "fleet_prior_unknown"
+  /** Priced from a confirmed same-day assignment, discounted by the swap rate —
+   * not from history or a prior. Route-planner legs only. Additive: these legs
+   * previously omitted `method` entirely, so no consumer can be relying on it. */
+  | "confirmed_assignment";
 
 interface Prediction {
   flight_number: string;
@@ -450,6 +454,15 @@ export function backtest(
 
   console.log(`\n=== Backtest: holdout=${holdoutHours}h ===`);
   console.log(`Train: ${trainObs.length} obs | Test: ${testObs.length} obs`);
+  // Zero observations used to print "Accuracy: 0.0%" and "Brier score: 0.0000",
+  // which look like measurements. Fail loudly instead.
+  if (testObs.length === 0 || trainObs.length === 0) {
+    console.error(
+      "\nNO DATA: the train or test split is empty — nothing was measured. " +
+        "Point --db at a populated database.\n"
+    );
+    process.exit(2);
+  }
   console.log(
     `Smoothing priors: express=${derivedConfig.expressSmoothingPrior.toFixed(3)}, mainline=${derivedConfig.mainlineSmoothingPrior.toFixed(3)}`
   );
@@ -646,7 +659,7 @@ export function predictRoute(
   const routeDesc = orig && dest ? `${orig}→${dest}` : orig ? `from ${orig}` : `to ${dest}`;
   const coverage_note =
     flights.length === 0
-      ? `Route ${routeDesc} is UNOBSERVED — no Starlink-equipped aircraft has flown it in our ~65-day history. Distinct from "0% observed": unobserved means no data. The fleet-prior baseline applies (mainline routes ~2%, express higher — see get_fleet_stats for current numbers).`
+      ? `Route ${routeDesc} is UNOBSERVED — no Starlink-equipped aircraft has flown it in the observed history. Distinct from "0% observed": unobserved means no data. The fleet-prior baseline applies — mainline is materially lower than express; call get_fleet_stats for the current rates.`
       : `Found ${flights.length} flight number(s) ${routeDesc} operated by Starlink-equipped aircraft in our history. These probabilities reflect how often each flight number gets a Starlink plane assigned.`;
 
   return { origin: orig, destination: dest, flights, coverage_note };
@@ -1064,10 +1077,19 @@ const MIN_LEG_PROBABILITY = 0.3;
 // Probability for confirmed near-term Starlink assignments (same-day in
 // upcoming_flights, verified-Starlink tail). Discount = observed aircraft-swap
 // rate from our own verification log ('Aircraft mismatch' errors).
-// Mainline rotates far more freely (~35% swap rate) than express (~9%).
+//
+// Re-measured from verification.check{result:aircraft_mismatch} by fleet:
+//   30d  express 381/4,233 = 9.00%   mainline 261/5,235 = 4.99%
+//   90d  express 971/12,178 = 7.97%  mainline 760/13,685 = 5.56%
+// Corroborated by adsb_shadow.observations at 8.4% overall.
+//
+// The old mainline value (0.65, from an assumed ~35% swap rate) was ~30 points
+// too low and had the ordering backwards — mainline now swaps LESS than
+// express. It sits between MIN_LEG_PROBABILITY and the 0.7 strong-direct gate,
+// so it was materially changing which itineraries got shown.
 const CONFIRMED_PROB = {
-  express: 0.9, // 1 - 9.1% observed swap rate
-  mainline: 0.65, // 1 - 35.5% observed swap rate
+  express: 0.9, // 1 - ~9% observed swap rate
+  mainline: 0.95, // 1 - ~5% observed swap rate
 };
 
 export type ItineraryLeg = BasePrediction & {
@@ -1149,6 +1171,9 @@ function buildRouteGraph(
   for (const r of rows) {
     const dep = r.departure_airport;
     const arr = r.arrival_airport;
+    // A row whose origin equals its destination is bad upstream data; letting
+    // it into the graph is what let the planner emit self-loop legs.
+    if (!dep || !arr || dep === arr) continue;
     const uaNum = uaPrefix(r.flight_number);
     const confirmedFleet = confirmedEdges.get(`${r.flight_number}|${dep}|${arr}`);
 
@@ -1166,6 +1191,9 @@ function buildRouteGraph(
               flight_number: uaNum,
               probability: confirmedP,
               confidence: "high",
+              // Was omitted, which tsc flags: BasePrediction requires it and
+              // the field was simply missing from the wire response.
+              method: "confirmed_assignment",
               n_observations: 1,
             };
     } else {
@@ -1218,12 +1246,23 @@ function computeItinerary(legs: ItineraryLeg[], coverage: "full" | "partial"): I
   };
 }
 
-function makePositioningLeg(route: string): ItineraryLeg {
+/**
+ * A leg we have no Starlink data for, priced at the carrier's live mainline
+ * cold prior.
+ *
+ * Was hardcoded to DEFAULT_CONFIG.mainlineColdPrior (0.02) — the *fallback*
+ * constant, not the derived one — while the live value is ~0.157. That is 7.8x
+ * low, and it propagates into joint_probability on every partial itinerary.
+ * `method` was also missing, which is a real type error the compiler already
+ * flags on this literal.
+ */
+function makePositioningLeg(route: string, config: ModelConfig = DEFAULT_CONFIG): ItineraryLeg {
   return {
     flight_number: "(any)",
     route,
-    probability: DEFAULT_CONFIG.mainlineColdPrior,
+    probability: config.mainlineColdPrior,
     confidence: "low",
+    method: "fleet_prior_mainline",
     n_observations: 0,
     duration_hours: null,
   };
@@ -1341,7 +1380,9 @@ export function planItinerary(
     // Direction "in": (any) orig→hub, then Starlink hub→dest
     for (const [hub, edges] of graph.entries()) {
       const leg = edges.get(dest);
-      if (!leg || leg.probability < minLegProb || hub === orig) continue;
+      // hub === dest as well as hub === orig: without the former the planner
+      // emitted a MIA-MIA self-loop leg ("fly ORD->MIA, then fly MIA->MIA").
+      if (!leg || leg.probability < minLegProb || hub === orig || hub === dest) continue;
       if (!hubOnPath(hub) || !isServed(orig, hub)) continue;
       if (itineraries.some((it) => it.via.length === 1 && it.via[0] === hub)) continue;
       candidates.push({ starlinkLeg: leg, hub, direction: "in" });

--- a/tests/golden/mcp-tools-list.json
+++ b/tests/golden/mcp-tools-list.json
@@ -69,7 +69,7 @@
       },
       {
         "name": "predict_flight_starlink",
-        "description": "Use when the user asks \"will my flight have Starlink?\" for a date too far out for a confirmed assignment, or with no date at all. Returns the probability that a United Airlines flight number gets a Starlink plane, from historical observations. Reliability varies: high-confidence (5+ obs) ~85%+ accurate; low-confidence (0-1 obs) is just the fleet prior. UA1-2999 (mainline) are almost always NOT Starlink (~2% fleet coverage).",
+        "description": "Use when the user asks \"will my flight have Starlink?\" for a date too far out for a confirmed assignment, or with no date at all. Returns the probability that a United Airlines flight number gets a Starlink plane, from historical observations. Reliability varies: high-confidence (5+ obs) is the most reliable tier but is not a guarantee; low-confidence (0-1 obs) is just the fleet prior. UA1-2999 (mainline) has materially lower coverage than UA3000-6999 (express) — call get_fleet_stats for the current split rather than assuming a rate.",
         "inputSchema": {
           "type": "object",
           "properties": {


### PR DESCRIPTION
Constants that were correct at a lower equipage rate and are now wrong, plus two evaluation harnesses that reported confident numbers on no data.

## `CONFIRMED_PROB.mainline` 0.65 → 0.95

The comment claimed a **~35.5% mainline swap rate**. Re-measured from `verification.check{result:aircraft_mismatch}` by fleet:

| Window | express | mainline |
|---|---|---|
| 30d | 381 / 4,233 = **9.00%** | 261 / 5,235 = **4.99%** |
| 90d | 971 / 12,178 = **7.97%** | 760 / 13,685 = **5.56%** |

Corroborated by `adsb_shadow.observations` at 8.4% overall. Express (0.9) was right; **mainline now swaps *less* than express**, the reverse of what the constant encoded. At 0.65 it sat between `MIN_LEG_PROBABILITY` and the 0.7 strong-direct gate, so being 30 points low materially changed which itineraries got shown.

## Six hardcoded "~2% mainline", against a live 15.65%

Mainline is climbing ~4.5pp/month, so a frozen number drifts further wrong every week. The worst one:

**`mcp-server.ts` direct-baseline fallback** — the "direct — baseline" row an LLM is *instructed to render verbatim*. At `0.02` it understated every nonstop by ~13.6 points and systematically pushed users onto unnecessary connections. Now derived from live fleet stats.

Also: the `predict_flight_starlink` tool description, three prose strings, the predictor's unobserved-route note, and `ua.tsx`'s FAQ copy **plus its JSON-LD** — which asserted *"DEN→ORD direct is mainline (~2%)"* while the site's own planner prices that route at **75%**.

Two more stale claims dropped: the description's *"~85%+ accurate"* for high-confidence calls (measured **71%**) and *"~65-day history"* (`getVerificationObservations` has no time bound at all).

## Route planner bugs

- **`hub === dest` was unguarded**, so the planner emitted a `MIA-MIA` self-loop leg — "fly ORD→MIA, then fly MIA→MIA"
- `buildRouteGraph` accepted rows whose origin equals their destination
- **Two leg literals omitted `method`** — a type error `tsc` already flags on `main`, shipped anyway. Adds `"confirmed_assignment"` to `PredictionMethod`. Additive: these legs previously had **no** `method` at all
- `makePositioningLeg` priced from `DEFAULT_CONFIG` (the *fallback* constant) instead of the derived config

## Harnesses that couldn't say "no data"

```
$ bun run precision        →  YES n=0 precision=0.00% ... North-star bar (YES ≥95%): FAIL
$ bun run predict-backtest →  Accuracy: 0.0% (base rate: 0.0%)  Brier score: 0.0000
```

Both now exit 2 with a NO DATA message. This is how a model whose 0.7 probability bucket resolves at 0.25 in reality could sit behind a dashboard reading PASS.

## Notes

**Golden fixture**: moves for the `predict_flight_starlink` **description only** — no tool name, input schema, or result shape changed. The pinned-fixture test firing here is it working as designed.

**Type errors**: this branch *removes* 4 pre-existing ones and adds none (verified by diffing `tsc --noEmit` against `main`).

Full suite **771 pass / 0 fail**. Lint back to the 4 pre-existing warnings.

## Not in this PR

The type-conditioned prior — capping predictions by aircraft-family penetration so a 0%-penetration type (CRJ-200, ERJ-145: 152 airframes) can't return 0.996. That's the change with the real measured impact (**Brier 0.2017 → 0.0721**), but it's a modelling change that deserves its own review and a backtest against real data, which the empty local DB can't provide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)