### PR TITLE
fix: attribute SQL time to spans; log FR24 outages once per failure

### DIFF
--- a/src/api/check-flight-core.ts
+++ b/src/api/check-flight-core.ts
@@ -26,7 +26,6 @@ import {
   predictFlight,
 } from "../scripts/starlink-predictor";
 import { type FlightDateWindow, flightDateWindow, matchesLocalDate } from "../utils/airport-tz";
-import { warn } from "../utils/logger";
 import { type FallbackSegment, lookupFlightTailVerdict } from "./flight-verdict";
 import { Fr24UnavailableError } from "./flightradar24-api";
 import { qatarEquipmentName } from "./qatar-status";
@@ -320,13 +319,13 @@ export async function resolveFlightVerdict(
       // FR24 outage ≠ "no assignment published" — never a confident no.
       // Anything else (e.g. a DB error) must not masquerade as an outage.
       if (!(err instanceof Fr24UnavailableError)) throw err;
+      // Not logged here. cachedFlightAssignments caches a rejection for
+      // ASSIGNMENT_FAILURE_TTL and replays it to every request in that window,
+      // and concurrent requests await the same promise — so a consumer-side log
+      // fired 3-4 times per real failure. It is logged once, at the producer,
+      // in flight-verdict.ts. The degradation is still visible to the caller
+      // via fr24Error -> FR24_OUTAGE_NOTE.
       fr24Error = true;
-      // warn, not error: this is the handled degradation the line above
-      // describes, and the caller surfaces FR24_OUTAGE_NOTE to the user. At
-      // ERROR it was 72 of the service's 81 logged errors — enough noise to
-      // make the error stream useless for spotting a real fault. The outage
-      // itself is still tracked as vendor.request{vendor:fr24,status:error}.
-      warn(`FR24 lookup failed for ${normalized} ${date}; degrading to prediction path`, err);
     }
     if (segments !== null) {
       const starlink = segments.filter((s) => s.hasStarlink);

--- a/src/api/flight-verdict.ts
+++ b/src/api/flight-verdict.ts
@@ -10,6 +10,7 @@
 import { OBSERVED_WIFI_SOURCES } from "../airlines/registry";
 import type { ScopedReader } from "../database/reader";
 import { matchesLocalDate } from "../utils/airport-tz";
+import { warn } from "../utils/logger";
 import { FlightRadar24API } from "./flightradar24-api";
 
 const fr24 = new FlightRadar24API();
@@ -72,10 +73,17 @@ export function cachedFlightAssignments(
     (result) => {
       if (result.length === 0) assignmentCache.delete(key);
     },
-    () => {
+    (err) => {
       if (assignmentCache.get(key) === entry) {
         entry.failedAt = now;
       }
+      // Logged here — where the failure is PRODUCED — not in the consumer.
+      // A rejection is cached for ASSIGNMENT_FAILURE_TTL and replayed to every
+      // request in that window, and concurrent requests all await this same
+      // promise, so logging at the consumer produced 3-4 identical lines per
+      // real failure (observed: three at the same millisecond). This handler
+      // runs exactly once per actual fetch.
+      warn(`FR24 assignment lookup failed for ${flightNumber}; degrading to prediction path`, err);
     }
   );
   return promise;

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -11,6 +11,7 @@ import {
   looksLikeValidTailNumber,
   verifierSourceTag,
 } from "../airlines/registry";
+import { instrumentDatabase } from "../observability/db-timing";
 import {
   COUNTERS,
   metrics,
@@ -99,6 +100,9 @@ export function initializeDatabase() {
   db.exec("PRAGMA busy_timeout = 5000"); // Wait up to 5s if database is locked
 
   setupTables(db);
+  // Folds each query's duration into whatever span is already open, so page
+  // latency can be attributed to SQL. No new spans — see db-timing.ts.
+  instrumentDatabase(db);
   return db;
 }
 

--- a/src/observability/db-timing.ts
+++ b/src/observability/db-timing.ts
@@ -1,0 +1,106 @@
+/**
+ * SQLite timing attribution.
+ *
+ * APM had no visibility into the query layer at all: dd-trace runs with
+ * `plugins: false` and bun:sqlite has no dd-trace plugin regardless, so page
+ * latency could not be attributed to SQL. Answering "did this query regress"
+ * meant reading the diff and guessing.
+ *
+ * The obvious fix — a span per query — was rejected: this service already emits
+ * 72% of the org's APM ingest, the background jobs run tens of thousands of
+ * queries a day, and a span each would multiply that for signal nobody reads
+ * most of the time.
+ *
+ * Instead each query's duration is folded into the span that is ALREADY open
+ * (web.request for a page, the job span for a background tick) as two tags:
+ *
+ *   db.query_count — how many queries this request/tick ran
+ *   db.time_ms     — how long it spent inside SQLite
+ *
+ * Zero new spans, and it answers both questions that mattered: what share of a
+ * request is SQL, and is a handler running an N+1 (a query_count that scales
+ * with result size rather than staying flat).
+ */
+
+import { type Span, getActiveSpan } from "./tracer";
+
+export type { Span };
+
+/** Per-span accumulator. Weak so a finished span is collectable. */
+const perSpan = new WeakMap<Span, { n: number; ms: number }>();
+
+/** Which span to attribute to. Injectable so this is testable: with tracing
+ * disabled (tests, local dev) the tracer is a no-op and getActiveSpan() is
+ * always null, which would make the whole path unobservable. */
+export type SpanSource = () => Span | null;
+
+function record(elapsedMs: number, spanFor: SpanSource): void {
+  const span = spanFor();
+  if (!span) return;
+  const acc = perSpan.get(span) ?? { n: 0, ms: 0 };
+  acc.n += 1;
+  acc.ms += elapsedMs;
+  perSpan.set(span, acc);
+  // Re-set on every query: last write wins, so the span carries the running
+  // total and needs no end-of-request hook to finalize it.
+  span.setTag("db.query_count", acc.n);
+  span.setTag("db.time_ms", Math.round(acc.ms * 1000) / 1000);
+}
+
+type AnyFn = (...args: unknown[]) => unknown;
+const TIMED_METHODS = ["all", "get", "run", "values", "iterate"] as const;
+
+/** Wrap a prepared statement so its execution methods report their duration. */
+function timeStatement<T extends object>(stmt: T, spanFor: SpanSource): T {
+  for (const name of TIMED_METHODS) {
+    const original = (stmt as Record<string, unknown>)[name];
+    if (typeof original !== "function") continue;
+    (stmt as Record<string, unknown>)[name] = function timed(this: unknown, ...args: unknown[]) {
+      const started = performance.now();
+      try {
+        return (original as AnyFn).apply(this, args);
+      } finally {
+        record(performance.now() - started, spanFor);
+      }
+    };
+  }
+  return stmt;
+}
+
+interface QueryableDb {
+  query: (sql: string) => unknown;
+}
+
+/**
+ * Instrument a database handle in place.
+ *
+ * Wraps `query()` so the statement it returns reports execution time. bun:sqlite
+ * caches prepared statements per SQL string, so a statement can be handed back
+ * more than once — wrapping is therefore idempotent per statement object, and
+ * re-instrumenting the same handle is a no-op.
+ */
+export function instrumentDatabase<T extends QueryableDb>(
+  db: T,
+  spanFor: SpanSource = getActiveSpan
+): T {
+  const flag = db as unknown as { __dbTimingInstrumented?: boolean };
+  if (flag.__dbTimingInstrumented) return db;
+  flag.__dbTimingInstrumented = true;
+
+  const originalQuery = db.query.bind(db);
+  const wrapped = new WeakSet<object>();
+  db.query = (sql: string) => {
+    const stmt = originalQuery(sql);
+    if (stmt && typeof stmt === "object" && !wrapped.has(stmt)) {
+      wrapped.add(stmt);
+      timeStatement(stmt, spanFor);
+    }
+    return stmt;
+  };
+  return db;
+}
+
+/** Test-only view of what a span accumulated. */
+export function dbStatsForSpan(span: Span): { n: number; ms: number } | undefined {
+  return perSpan.get(span);
+}

--- a/tests/db-timing.test.ts
+++ b/tests/db-timing.test.ts
@@ -1,0 +1,125 @@
+/**
+ * SQLite timing attribution.
+ *
+ * dd-trace runs with `plugins: false` and bun:sqlite has no plugin, so page
+ * latency could not be attributed to SQL at all. Rather than a span per query
+ * — this service already emits 72% of the org's APM ingest, and the background
+ * jobs run tens of thousands of queries a day — each query's duration is folded
+ * into the span that is already open, as db.query_count / db.time_ms.
+ *
+ * Tests inject their own span source: with tracing disabled the real tracer is
+ * a no-op whose active span is always null.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { type Span, dbStatsForSpan, instrumentDatabase } from "../src/observability/db-timing";
+import { makeSyntheticDb } from "./helpers";
+
+/** Minimal stand-in for a dd-trace span that records the tags it is given. */
+function fakeSpan() {
+  const tags: Record<string, unknown> = {};
+  const span = {
+    setTag(k: string, v: unknown) {
+      tags[k] = v;
+    },
+  } as unknown as Span;
+  return { span, tags };
+}
+
+const instrumented = (span: Span | null) => instrumentDatabase(makeSyntheticDb(), () => span);
+
+describe("instrumentDatabase", () => {
+  test("counts queries and accumulates time onto the active span", () => {
+    const { span, tags } = fakeSpan();
+    const db = instrumented(span);
+    db.query("SELECT 1").get();
+    db.query("SELECT 2").get();
+    db.query("SELECT COUNT(*) AS n FROM starlink_planes").get();
+
+    expect(dbStatsForSpan(span)?.n).toBe(3);
+    expect(tags["db.query_count"]).toBe(3);
+    expect(typeof tags["db.time_ms"]).toBe("number");
+    expect(tags["db.time_ms"] as number).toBeGreaterThanOrEqual(0);
+    db.close();
+  });
+
+  test("all/get/run are each timed", () => {
+    const { span } = fakeSpan();
+    const db = instrumented(span);
+    db.query("SELECT * FROM starlink_planes LIMIT 1").all();
+    db.query("SELECT 1").get();
+    db.query("CREATE TEMP TABLE t_timing (x INTEGER)").run();
+    expect(dbStatsForSpan(span)?.n).toBe(3);
+    db.close();
+  });
+
+  test("queries outside any span are a no-op, not a crash", () => {
+    const db = instrumented(null);
+    expect(() => db.query("SELECT 1").get()).not.toThrow();
+    db.close();
+  });
+
+  test("results are unchanged by the wrapper", () => {
+    const plain = makeSyntheticDb();
+    const before = plain.query("SELECT 7 AS v").get();
+    const { span } = fakeSpan();
+    const db = instrumentDatabase(plain, () => span);
+    expect(db.query("SELECT 7 AS v").get()).toEqual(before);
+    db.close();
+  });
+
+  test("instrumenting twice does not double-count", () => {
+    const { span } = fakeSpan();
+    const once = instrumentDatabase(makeSyntheticDb(), () => span);
+    const twice = instrumentDatabase(once, () => span);
+    twice.query("SELECT 1").get();
+    expect(dbStatsForSpan(span)?.n).toBe(1);
+    twice.close();
+  });
+
+  test("a query that throws during EXECUTION still records its time", () => {
+    const { span } = fakeSpan();
+    const db = instrumented(span);
+    db.query("CREATE TEMP TABLE t_fail (x INTEGER NOT NULL)").run();
+    expect(() => db.query("INSERT INTO t_fail (x) VALUES (NULL)").run()).toThrow();
+    // The CREATE plus the failed INSERT — the failure is inside .run(), so the
+    // finally block still records it.
+    expect(dbStatsForSpan(span)?.n).toBe(2);
+    db.close();
+  });
+
+  test("a PREPARE failure is not counted — nothing executed", () => {
+    // bun:sqlite prepares inside db.query(), so a bad statement throws before a
+    // statement object exists to wrap. Documenting the boundary rather than
+    // pretending the wrapper sees it.
+    const { span } = fakeSpan();
+    const db = instrumented(span);
+    expect(() => db.query("SELECT * FROM no_such_table").all()).toThrow();
+    expect(dbStatsForSpan(span)).toBeUndefined();
+    db.close();
+  });
+
+  test("separate spans accumulate separately", () => {
+    const a = fakeSpan();
+    const b = fakeSpan();
+    let current: Span = a.span;
+    const db = instrumentDatabase(makeSyntheticDb(), () => current);
+    db.query("SELECT 1").get();
+    current = b.span;
+    db.query("SELECT 1").get();
+    db.query("SELECT 2").get();
+    expect(dbStatsForSpan(a.span)?.n).toBe(1);
+    expect(dbStatsForSpan(b.span)?.n).toBe(2);
+    db.close();
+  });
+
+  test("a repeated SQL string is wrapped once, not layered", () => {
+    // bun:sqlite caches prepared statements per SQL string; double-wrapping the
+    // same statement object would count one execution twice.
+    const { span } = fakeSpan();
+    const db = instrumented(span);
+    for (let i = 0; i < 5; i++) db.query("SELECT 1").get();
+    expect(dbStatsForSpan(span)?.n).toBe(5);
+    db.close();
+  });
+});

--- a/tests/fr24-failure-logging.test.ts
+++ b/tests/fr24-failure-logging.test.ts
@@ -1,0 +1,71 @@
+/**
+ * FR24 outage logging fires once per real failure.
+ *
+ * cachedFlightAssignments caches a rejected promise for ASSIGNMENT_FAILURE_TTL
+ * and replays it to every request in that window, and concurrent requests all
+ * await the same promise. Logging at the consumer therefore produced 3-4
+ * identical lines per real failure (observed in production: three at the same
+ * millisecond). The log lives at the producer's rejection handler instead,
+ * which runs exactly once per fetch.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cachedFlightAssignments, setAssignmentFetcher } from "../src/api/flight-verdict";
+import { Fr24UnavailableError } from "../src/api/flightradar24-api";
+
+let lines: string[] = [];
+let origErr: typeof console.error;
+
+beforeEach(() => {
+  lines = [];
+  origErr = console.error;
+  console.error = (l: string) => lines.push(String(l));
+});
+
+afterEach(() => {
+  console.error = origErr;
+  setAssignmentFetcher(null);
+});
+
+const fr24Lines = () => lines.filter((l) => l.includes("FR24 assignment lookup failed"));
+
+describe("FR24 failure logging", () => {
+  test("logs once per real fetch, not once per awaiting request", async () => {
+    let fetches = 0;
+    setAssignmentFetcher(async () => {
+      fetches++;
+      throw new Fr24UnavailableError("FR24 down");
+    });
+    const now = 1_700_000_000;
+    // Three concurrent requests for the same flight+date share one promise.
+    await Promise.allSettled([
+      cachedFlightAssignments("UA2666", now, now),
+      cachedFlightAssignments("UA2666", now, now),
+      cachedFlightAssignments("UA2666", now, now),
+    ]);
+    // Two more inside the failure-cache window replay the same rejection.
+    await Promise.allSettled([
+      cachedFlightAssignments("UA2666", now, now + 10),
+      cachedFlightAssignments("UA2666", now, now + 20),
+    ]);
+    expect(fetches).toBe(1);
+    expect(fr24Lines().length).toBe(1);
+  });
+
+  test("a genuinely new failure after the window logs again", async () => {
+    setAssignmentFetcher(async () => {
+      throw new Fr24UnavailableError("FR24 down");
+    });
+    const now = 1_700_000_000;
+    await Promise.allSettled([cachedFlightAssignments("UA777", now, now)]);
+    await Promise.allSettled([cachedFlightAssignments("UA777", now, now + 3600)]);
+    expect(fr24Lines().length).toBe(2);
+  });
+
+  test("a successful lookup logs nothing", async () => {
+    setAssignmentFetcher(async () => []);
+    const now = 1_700_000_000;
+    await cachedFlightAssignments("UA1", now, now);
+    expect(fr24Lines().length).toBe(0);
+  });
+});


### PR DESCRIPTION
Two follow-ups from the observability review.

## 1. FR24 outages logged 3–4× per real failure

The cause isn't a retry ladder. `cachedFlightAssignments` caches a **rejected promise** for `ASSIGNMENT_FAILURE_TTL` (60s) and replays it to every request in that window — and concurrent requests all `await` the same promise. So a log at the *consumer* runs once per request, not once per failure. That's why production showed three identical lines at the same millisecond.

Moved to the producer's existing rejection handler, which runs exactly once per fetch. Nothing else changes: callers still see the degradation via `fr24Error` → `FR24_OUTAGE_NOTE`, and it's still counted as `vendor.request{vendor:fr24,status:error}`.

## 2. SQL was invisible to APM

`dd-trace` runs with `plugins: false` and `bun:sqlite` has no plugin, so page latency couldn't be attributed to the query layer at all — the "did the PR #76 query regress" question was answered by reading the diff and end-to-end span latency, not by measurement.

**A span per query is the obvious fix and the wrong one here.** This service already emits ~72% of the org's APM ingest, and the background jobs run tens of thousands of queries a day; a span each multiplies that for signal nobody reads most of the time.

Instead each query's duration folds into the span that is **already open** — `web.request` for a page, the job span for a background tick:

```
db.query_count — how many queries this request/tick ran
db.time_ms     — how long it spent inside SQLite
```

**Zero new spans**, and it answers both questions that mattered: what share of a request is SQL, and whether a handler is running an N+1 (a `query_count` that scales with result size rather than staying flat).

Wrapped once at `initializeDatabase()` rather than at 108 call sites. Idempotent per statement object and per handle, since `bun:sqlite` caches prepared statements per SQL string and double-wrapping would count one execution twice.

## Testing

- `tests/fr24-failure-logging.test.ts` (3) — five requests across the failure window produce **one** log and **one** fetch; a genuinely new failure after the window logs again; success logs nothing. **Verified to fail** with the producer log removed.
- `tests/db-timing.test.ts` (9) — counting, per-method coverage, no-active-span, result equality, idempotence, per-span isolation, and repeated SQL strings.

One boundary the tests taught me and now pin explicitly: `bun:sqlite` prepares inside `db.query()`, so a **prepare** failure throws before a statement exists to wrap and is *not* counted, while an **execution** failure (constraint violation inside `.run()`) is. My first test asserted the wrong one.

**Coverage gap I'm not papering over:** the db-timing tests instrument explicitly, so they cover the wrapper's behavior but not the one-line wiring into `initializeDatabase()`. That's verified by reading, not by test.

The span source is injectable because with tracing disabled the tracer is a no-op whose active span is always null — the whole path would otherwise be untestable.

Full suite **816 pass / 0 fail**. `tsc --noEmit` diffed against `main` — no new errors. Lint back to the 4 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)