### PR TITLE
fix: route tag must not contain '*' — Datadog strips it and merges series

### DIFF
--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -156,10 +156,19 @@ export function renderHtml(template: string, variables: Record<string, string>):
 const notFound = (site: SiteConfig): Response =>
   new Response(getNotFoundHtml(site.brand), { status: 404, headers: SECURITY_HEADERS.notFound });
 
-/** Bounded `route` tag for HTTP_REQUEST — unmatched paths collapse to "/*". */
+/**
+ * Bounded `route` tag for HTTP_REQUEST.
+ *
+ * No `*` in the value: Datadog STRIPS `*` from tag values, so "/*" arrived as
+ * "/" and silently merged every unmatched-path request into the homepage series
+ * (measured: 1,811 of the homepage's 404s in 24h were never homepage requests),
+ * and "/static/*" arrived as "/static/". Counting them was the point — merging
+ * them into a real route is worse than the original bug of not counting them at
+ * all, because it corrupts a series someone reads.
+ */
 function metricRoute(m: { route: string } | null): string {
-  if (!m) return "/*";
-  return m.route === "/static" ? "/static/*" : m.route;
+  if (!m) return "unmatched";
+  return m.route === "/static" ? "/static" : m.route;
 }
 
 function methodNotAllowed(json = false): Response {

--- a/tests/request-instrumentation.test.ts
+++ b/tests/request-instrumentation.test.ts
@@ -98,22 +98,32 @@ describe("http.request metric coverage", () => {
   const httpCalls = (calls: Array<{ name: string; tags: Record<string, unknown> }>) =>
     calls.filter((c) => c.name === "http.request");
 
-  test("an unmatched path emits the metric, tagged route:/*", async () => {
+  test("an unmatched path emits the metric, tagged route:unmatched", async () => {
     const { calls } = captureIncrements();
     await app.dispatch(req("/definitely-not-a-route-xyz", UA));
     const http = httpCalls(calls);
     expect(http.length).toBe(1);
-    expect(http[0].tags.route).toBe("/*");
+    expect(http[0].tags.route).toBe("unmatched");
     expect(http[0].tags.status_code).toBe(404);
   });
 
-  test("a matched path still reports its own route, not /*", async () => {
+  test("a matched path still reports its own route, not the unmatched bucket", async () => {
     const { calls } = captureIncrements();
     await app.dispatch(req("/api/data", UA));
     const http = httpCalls(calls);
     expect(http.length).toBe(1);
     expect(http[0].tags.route).toBe("/api/data");
     expect(http[0].tags.status_code).toBe(200);
+  });
+
+  test("no route tag value contains '*' — Datadog strips it and merges series", async () => {
+    const { calls } = captureIncrements();
+    for (const p of ["/", "/api/data", "/definitely-not-a-route-xyz", "/static/og.webp"]) {
+      await app.dispatch(req(p, UA));
+    }
+    const routes = httpCalls(calls).map((c) => String(c.tags.route));
+    expect(routes.length).toBeGreaterThan(0);
+    for (const r of routes) expect(r, r).not.toContain("*");
   });
 
   test("the crawler bucket reaches the metric tags", async () => {


### PR DESCRIPTION
Follow-up defect in my own #79.

#79 tagged unmatched-path requests `route:"/*"` so they'd finally be counted. **Datadog strips `*` from tag values**, so the tag arrives as `route:"/"` — and every unmatched request got silently merged into the homepage series.

Measured in production over 24h:

```
sum:starlink.http.request{status_code:404} by {route}
  route:/                1811   ← unmatched-path 404s, merged onto the homepage
  route:/route-planner    203
  route:/check-flight      65
  route:/static/            2   ← "/static/*", also stripped
```

There is no `/*` series at all. **1,811 of the homepage's 404s were requests that never touched the homepage.**

This is worse than the bug #79 set out to fix. Not counting them left the homepage series *correct but incomplete*; counting them under a stripped tag makes it *complete and wrong*, and corrupts a series people actually read on a dashboard.

Uses `route:"unmatched"` and `route:"/static"`, neither of which Datadog rewrites. The tag stays a bounded allowlist.

Adds a test asserting **no route tag value ever contains `*`**, across matched, unmatched, static and homepage paths — so this can't return by another route.

Note the related trap for anyone querying this: `{route:"/*"}` used as a *filter* is interpreted as a glob and matches every route, returning the grand total. That's how it initially looked like the fix was working.

Full suite **817 pass / 0 fail**. Lint unchanged at the 4 pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)