### PR TITLE
seo: link /routes rows to their route pages

### DIFF
--- a/src/components/routes-page.tsx
+++ b/src/components/routes-page.tsx
@@ -37,9 +37,12 @@ function RouteRows({ schedule }: { schedule: RouteSchedule }) {
           key={`${r.origin}-${r.destination}`}
           className="grid grid-cols-[1fr_auto_auto] sm:grid-cols-[7rem_1fr_auto_auto] gap-x-4 items-center text-sm"
         >
-          <span className="font-display font-semibold text-secondary tabular-nums">
+          <a
+            href={`/route-planner/${r.origin}/${r.destination}`}
+            className="font-display font-semibold text-secondary tabular-nums hover:text-accent transition-colors"
+          >
             {r.origin}–{r.destination}
-          </span>
+          </a>
           <span className="hidden sm:block h-2 bg-surface-elevated rounded overflow-hidden">
             <span
               className="block h-full bg-[var(--color-accent)] opacity-70"

--- a/tests/route-pages.test.ts
+++ b/tests/route-pages.test.ts
@@ -172,3 +172,37 @@ describe("getSitemapRoutes", () => {
     expect(getSitemapRoutes(db, "NOPE")).toEqual([]);
   });
 });
+
+describe("/routes links into the route corpus", () => {
+  // Route pages were reachable only from the sitemap and from each other — no
+  // hub page linked to any of them, so no authority flowed in. /routes is the
+  // semantic parent and already renders every row's O-D pair; it just rendered
+  // them as plain text.
+  //
+  // The snapshot's 48h schedule window can legitimately be empty, in which case
+  // /routes renders no rows at all. The invariant is conditional on rows
+  // existing: if a pair is rendered, it must be a link.
+  const bareLabelRe = /([A-Z]{3})<!-- -->\u2013<!-- -->([A-Z]{3})/g;
+  const linkRe = /href="\/route-planner\/([A-Z]{3})\/([A-Z]{3})"/g;
+
+  test("no O-D pair is rendered as bare text instead of a link", async () => {
+    const body = await (await get("/routes")).text();
+    const bare = [...body.matchAll(bareLabelRe)];
+    const links = [...body.matchAll(linkRe)];
+    // Whatever is rendered, none of it may be unlinked.
+    expect(bare.length, "unlinked O-D labels on /routes").toBe(0);
+    if (links.length === 0) return; // empty schedule window in this snapshot
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  test("every route /routes links to actually resolves", async () => {
+    const body = await (await get("/routes")).text();
+    const pairs = [
+      ...new Set([...body.matchAll(linkRe)].map((m) => `/route-planner/${m[1]}/${m[2]}`)),
+    ];
+    if (pairs.length === 0) return; // empty schedule window in this snapshot
+    for (const p of pairs.slice(0, 15)) {
+      expect((await get(p)).status, p).toBe(200);
+    }
+  });
+});


### PR DESCRIPTION
The single highest-ratio item from the crawl audit.

## The problem, measured

Links from each hub page **into** the programmatic corpus:

| Page | → flight permalinks | → route pages |
|---|---|---|
| `/` (1,738 hrefs) | **0** | **0** |
| `/fleet` (3,299 hrefs) | **0** | **0** |
| `/routes` | **0** | **0** |
| `/check-flight` | **0** | **0** |
| `/route-planner` | **0** | **0** |
| `/methodology` | **0** | **0** |

Identical on Alaska. **8,753 programmatic pages have zero inbound internal links** — the only edges are permalink↔permalink. None of the homepage's authority reaches them, which is consistent with the SERP finding that only our *homepages* rank while `starlinkflights.com/flight/UA3521` and `/routes/ORD-BDL` surface for the deep queries.

Meanwhile the homepage carries 1,704 outbound FlightAware links and `/fleet` 1,641 — all correctly `nofollow`, so nothing leaks. But nothing flows inward either.

## The fix

`/routes` is the semantic parent of the route corpus and **already renders all 60 rows' O-D pairs — as plain text**. Verified in production: 60 labels, **0** route links, 4 anchors on the entire page. All 60 corresponding `/route-planner/{O}/{D}` pages return 200.

Wrapping the label in an anchor is a one-component change that creates 60 dofollow links from an already-ranking page.

## Testing

The test asserts the **invariant**, not a count: *no O-D pair may render as bare text*. The snapshot's 48h schedule window can legitimately be empty (it is, locally), in which case `/routes` renders no rows — so the resolve check is conditional rather than pinning a number that would break on data drift.

Full suite passing. Lint unchanged.

## Not in this PR

Two bigger items from the same audit, both needing more thought than a one-liner:

- **~43% of sitemapped route pages are empty-state.** I sampled 40 live and 17 render *"No United Airlines departures are in the schedule window"*. That's a defect in my #77 gating: `routeHasData` correctly gates on durable data (`flight_routes` ∪ `upcoming_flights`), but the page *leads* with the 48-hour window, so a route with real history but no flight in the next two days renders as a negative. Either the page should lead with its durable content or those URLs should drop out of the sitemap — worth deciding deliberately.
- **The homepage's 1,704 flight pills** — 566 are already `UA####`/`UAL####` and map straight to `/check-flight/{fn}`; the other 1,138 are operating-carrier callsigns needing the mapping the codebase already has in `flight-number.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)