### PR TITLE
perf: index the serving-path queries; keep writes off the read path

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -620,7 +620,21 @@ function migrateMultiAirline(db: Database) {
     CREATE INDEX IF NOT EXISTS idx_uf_airline   ON united_fleet(airline, starlink_status);
     CREATE INDEX IF NOT EXISTS idx_upf_airline  ON upcoming_flights(airline, flight_number);
     CREATE INDEX IF NOT EXISTS idx_vlog_airline ON starlink_verification_log(airline, tail_number);
+    CREATE INDEX IF NOT EXISTS idx_vlog_flight  ON starlink_verification_log(flight_number, checked_at DESC);
+    CREATE INDEX IF NOT EXISTS idx_upf_tail     ON upcoming_flights(tail_number);
   `);
+
+  // The two indexes above exist for the serving path: getFlightHistorySummary
+  // runs three flight_number-filtered queries per permalink render and had only
+  // airline-leading indexes to use — on a one-airline 76k-row log that is a
+  // full-table range scan, measured at ~150ms of the permalink's 152ms. The
+  // EQUIPPED_DEPARTURES join likewise had no tail_number index on
+  // upcoming_flights. ANALYZE is NOT optional: without sqlite_stat1 the planner
+  // keeps choosing airline= (zero selectivity here) over flight_number IN — the
+  // new indexes sit unused. Measured with production cardinality: 14.6ms → 0.01ms
+  // and 103ms → 2.6ms, but only after ANALYZE. Runs at startup; ~76k rows
+  // analyze in well under a second.
+  db.exec("ANALYZE");
 
   const renamed = db
     .query("UPDATE meta SET key = 'UA:' || key WHERE key NOT LIKE '%:%'")
@@ -1273,7 +1287,7 @@ export function archivePastDepartures(
 ): number {
   const params: (string | number)[] = [now];
   if (tailNumber) params.push(tailNumber);
-  return db
+  const changes = db
     .query(
       `INSERT INTO departure_log (tail_number, airport, departed_at, airline)
        SELECT tail_number, departure_airport, departure_time, airline
@@ -1285,6 +1299,11 @@ export function archivePastDepartures(
          )`
     )
     .run(...params).changes;
+  // 30-day trim lives here with the other departure_log writes. It used to run
+  // inside getAirportDepartures — a DELETE taking a WAL write lock on every
+  // homepage render, ~4,200 write transactions/day on the read path.
+  db.query("DELETE FROM departure_log WHERE departed_at < ?").run(now - 30 * 86400);
+  return changes;
 }
 
 export function getUpcomingFlights(
@@ -4093,12 +4112,6 @@ export function getAirportDepartures(
   airline?: AirlineFilter,
   nowSec = Math.floor(Date.now() / 1000)
 ): AirportDepartures {
-  try {
-    db.query("DELETE FROM departure_log WHERE departed_at < ?").run(nowSec - 30 * 86400);
-  } catch {
-    // readonly DB (tests/snapshots) — trim is best-effort housekeeping
-  }
-
   const q = withAirline(
     `SELECT uf.departure_airport AS airport,
             COUNT(DISTINCT uf.flight_number || ':' || uf.departure_time) AS count${EQUIPPED_DEPARTURES_SQL}`,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1473,17 +1473,28 @@ function escapeHtmlAttr(s: string): string {
   );
 }
 
+/** The reader-derived stats buildBaseTemplateVars needs; a handler that has
+ * already fetched them for its own render passes them in instead of paying the
+ * same four queries twice. */
+interface BaseStatVars {
+  fleetStats: ReturnType<ScopedReader["getFleetStats"]>;
+  totalCount: number;
+  starlinkCount: number;
+  lastUpdated: string;
+}
+
 function buildBaseTemplateVars(
   ctx: RequestContext,
   reactHtml: string,
-  canonicalPath = "/"
+  canonicalPath = "/",
+  precomputed?: BaseStatVars
 ): Record<string, string> {
   const { reader, site } = ctx;
   const brand = site.brand;
 
-  const fleetStats = reader.getFleetStats();
-  const totalCount = reader.getTotalCount();
-  const starlinkCount = reader.getStarlinkPlanes().length;
+  const fleetStats = precomputed ? precomputed.fleetStats : reader.getFleetStats();
+  const totalCount = precomputed ? precomputed.totalCount : reader.getTotalCount();
+  const starlinkCount = precomputed ? precomputed.starlinkCount : reader.getStarlinkPlanes().length;
   const percentage = totalCount > 0 ? ((starlinkCount / totalCount) * 100).toFixed(2) : "0.00";
   const isoDate = new Date().toISOString();
 
@@ -1493,7 +1504,7 @@ function buildBaseTemplateVars(
     starlinkCount: starlinkCount.toString(),
     totalCount: starlinkCount.toString(),
     totalAircraftCount: totalCount.toString(),
-    lastUpdated: reader.getLastUpdated(),
+    lastUpdated: precomputed ? precomputed.lastUpdated : reader.getLastUpdated(),
     currentDate: new Date().toLocaleDateString(),
     isoDate,
     mainlineCount: (fleetStats?.mainline.starlink || 0).toString(),
@@ -2010,12 +2021,18 @@ const homePage: Handler = async (ctx) => {
   }
 
   const isHub = tenant === "ALL";
+  // Fetched once and shared with buildBaseTemplateVars below — these four were
+  // previously queried twice per homepage render (React tree + template vars).
+  const total = reader.getTotalCount();
+  const starlink = reader.getStarlinkPlanes();
+  const lastUpdated = reader.getLastUpdated();
+  const fleetStats = reader.getFleetStats();
   const reactHtml = ReactDOMServer.renderToString(
     React.createElement(Page, {
-      total: reader.getTotalCount(),
-      starlink: reader.getStarlinkPlanes(),
-      lastUpdated: reader.getLastUpdated(),
-      fleetStats: reader.getFleetStats(),
+      total,
+      starlink,
+      lastUpdated,
+      fleetStats,
       site,
       content,
       airlineByTail: reader.getAirlineByTail(),
@@ -2031,7 +2048,12 @@ const homePage: Handler = async (ctx) => {
   );
 
   const template = await getHtmlTemplate();
-  const baseVars = buildBaseTemplateVars(ctx, reactHtml);
+  const baseVars = buildBaseTemplateVars(ctx, reactHtml, "/", {
+    fleetStats,
+    totalCount: total,
+    starlinkCount: starlink.length,
+    lastUpdated,
+  });
   return new Response(
     renderHtml(template, {
       ...baseVars,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -29,7 +29,10 @@ function loadSnapshotDdl(): string[] {
   const src = openSnapshot();
   const rows = src
     .query(
-      "SELECT sql FROM sqlite_master WHERE type='table' AND sql IS NOT NULL AND name <> 'sqlite_sequence'"
+      // NOT LIKE 'sqlite_%', not just sqlite_sequence: setupTables now runs
+      // ANALYZE, which creates sqlite_stat1 — replaying any internal table's
+      // DDL into :memory: throws "reserved for internal use".
+      "SELECT sql FROM sqlite_master WHERE type='table' AND sql IS NOT NULL AND name NOT LIKE 'sqlite_%'"
     )
     .all() as { sql: string }[];
   src.close();

--- a/tests/query-plans.test.ts
+++ b/tests/query-plans.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Serving-path query plans.
+ *
+ * /check-flight permalinks spent 150ms of their 152ms inside SQLite: the three
+ * getFlightHistorySummary queries filter on flight_number, and the only usable
+ * indexes led with airline — on a one-airline 76k-row log that is a full range
+ * scan per query. The homepage's EQUIPPED_DEPARTURES join likewise had no
+ * tail_number index on upcoming_flights.
+ *
+ * Two things must both hold, and each alone is not enough:
+ *  - the indexes exist (idx_vlog_flight, idx_upf_tail)
+ *  - ANALYZE has populated sqlite_stat1 — without stats the planner keeps
+ *    choosing airline= (zero selectivity) and the new indexes sit unused.
+ *    Measured at production cardinality: 14.6ms → 0.01ms only after ANALYZE.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { makeSyntheticDb } from "./helpers";
+
+function seeded() {
+  const db = makeSyntheticDb();
+  // Production-shaped cardinality in miniature: one airline, many flight
+  // numbers — the distribution that makes the airline index worthless.
+  const ins = db.query(
+    `INSERT INTO starlink_verification_log
+       (tail_number, flight_number, checked_at, has_starlink, error, source, airline)
+     VALUES (?,?,?,?,NULL,'united','UA')`
+  );
+  for (let i = 0; i < 2000; i++) {
+    ins.run(
+      `N${100 + (i % 40)}AB`,
+      `UA${1 + (i % 400)}`,
+      1_700_000_000 + i * 60,
+      i % 3 === 0 ? 1 : 0
+    );
+  }
+  const upf = db.query(
+    `INSERT INTO upcoming_flights
+       (tail_number, flight_number, departure_airport, arrival_airport,
+        departure_time, arrival_time, last_updated, airline)
+     VALUES (?,?,?,?,?,?,?, 'UA')`
+  );
+  for (let i = 0; i < 500; i++) {
+    upf.run(
+      `N${100 + (i % 40)}AB`,
+      `UA${1 + (i % 200)}`,
+      "ORD",
+      "DEN",
+      1_700_000_000 + i * 100,
+      1_700_010_000 + i * 100,
+      1_700_000_000
+    );
+  }
+  db.exec("ANALYZE");
+  return db;
+}
+
+const planOf = (db: ReturnType<typeof seeded>, sql: string, params: (string | number)[]) =>
+  (db.query(`EXPLAIN QUERY PLAN ${sql}`).all(...params) as Array<{ detail: string }>)
+    .map((r) => r.detail)
+    .join(" | ");
+
+describe("hot-path query plans", () => {
+  test("both serving-path indexes exist after setupTables", () => {
+    const db = makeSyntheticDb();
+    const names = (
+      db.query("SELECT name FROM sqlite_master WHERE type='index'").all() as { name: string }[]
+    ).map((r) => r.name);
+    expect(names).toContain("idx_vlog_flight");
+    expect(names).toContain("idx_upf_tail");
+    db.close();
+  });
+
+  test("flight-history queries search by flight_number, not scan by airline", () => {
+    const db = seeded();
+    const plan = planOf(
+      db,
+      `SELECT COUNT(*) FROM starlink_verification_log
+       WHERE flight_number IN (?,?) AND source IN (?) AND error IS NULL AND airline = ?`,
+      ["UA1", "UAL1", "united", "UA"]
+    );
+    expect(plan).toContain("idx_vlog_flight");
+    expect(plan).not.toContain("idx_vlog_airline");
+    db.close();
+  });
+
+  test("the equipped-departures join seeks upcoming_flights by tail", () => {
+    const db = seeded();
+    const plan = planOf(
+      db,
+      `SELECT uf.departure_airport, COUNT(DISTINCT uf.flight_number || ':' || uf.departure_time)
+       FROM upcoming_flights uf
+       INNER JOIN starlink_planes sp ON uf.tail_number = sp.TailNumber
+       WHERE (sp.verified_wifi IS NULL OR sp.verified_wifi = 'Starlink')
+         AND uf.departure_time >= ? AND uf.departure_time < ? AND uf.airline = ?
+       GROUP BY uf.departure_airport`,
+      [1_700_000_000, 1_800_000_000, "UA"]
+    );
+    expect(plan).toContain("idx_upf_tail");
+    db.close();
+  });
+});
+
+describe("departure_log trim lives in the archive job, not the read path", () => {
+  test("archivePastDepartures removes rows older than 30 days", async () => {
+    const { archivePastDepartures } = await import("../src/database/database");
+    const db = makeSyntheticDb();
+    const now = 1_800_000_000;
+    db.query(
+      "INSERT INTO departure_log (tail_number, airport, departed_at, airline) VALUES (?,?,?,?)"
+    ).run("N1", "ORD", now - 40 * 86400, "UA");
+    db.query(
+      "INSERT INTO departure_log (tail_number, airport, departed_at, airline) VALUES (?,?,?,?)"
+    ).run("N2", "DEN", now - 5 * 86400, "UA");
+    archivePastDepartures(db, now);
+    const rows = db.query("SELECT tail_number FROM departure_log ORDER BY tail_number").all() as {
+      tail_number: string;
+    }[];
+    expect(rows.map((r) => r.tail_number)).toEqual(["N2"]);
+    db.close();
+  });
+
+  test("getAirportDepartures issues no writes", async () => {
+    const { getAirportDepartures } = await import("../src/database/database");
+    const db = makeSyntheticDb();
+    db.query(
+      "INSERT INTO departure_log (tail_number, airport, departed_at, airline) VALUES (?,?,?,?)"
+    ).run("N1", "ORD", 1, "UA");
+    getAirportDepartures(db, "UA", 1_800_000_000);
+    // The ancient row survives a read — the trim no longer piggybacks on it.
+    expect(db.query("SELECT COUNT(*) AS n FROM departure_log").get()).toEqual({ n: 1 });
+    db.close();
+  });
+});


### PR DESCRIPTION
The `db.time_ms` span tags from #83 showed **two routes carrying 97.7% of all SQLite time** (~1,200 s/day). This fixes both root causes.

## 1. `/check-flight` permalinks: 150 ms of a 152 ms render is SQL

The three `getFlightHistorySummary` queries filter on `flight_number` — and the only usable indexes led with `airline`. On a one-airline, 76,740-row verification log that's a full range scan, **three times per render**, at 4,294 renders/day.

## 2. `/` and `/routes`: the equipped-departures join had no usable index

`upcoming_flights ⋈ starlink_planes` on `tail_number` with neither side indexed on the join key → nested scans (526 × 4,300).

## The fix — and why ANALYZE is load-bearing

```sql
CREATE INDEX IF NOT EXISTS idx_vlog_flight ON starlink_verification_log(flight_number, checked_at DESC);
CREATE INDEX IF NOT EXISTS idx_upf_tail    ON upcoming_flights(tail_number);
ANALYZE;
```

**The indexes alone do nothing.** Without `sqlite_stat1`, the planner keeps choosing `airline=` (zero selectivity — every row is UA) over `flight_number IN`, and the new indexes sit unused. Verified with `EXPLAIN QUERY PLAN` at production-shaped cardinality (76k rows, one airline, 4k flight numbers):

| query | before | after index+ANALYZE |
|---|---|---|
| flight history | 14.6 ms | **0.01 ms** |
| equipped join | 103.2 ms | **2.6 ms** |

Expected production effect: `/check-flight` ~152 ms → single digits (−44% of total DB load), homepage SQL ~160 ms → ~15 ms. Directly measurable in the `db.time_ms` tag after deploy.

## Also in this PR

- **`getAirportDepartures` ran `DELETE FROM departure_log` on every homepage render** — ~4,200 write transactions/day taking a WAL lock on the read path. Moved into `archivePastDepartures` (the 5-min job) with the other `departure_log` writes.
- **`homePage` queried the same four reader calls twice** (React tree + `buildBaseTemplateVars`). Fetched once, shared via an optional precomputed param — subpage handlers unchanged.
- **Test-infra fix this change itself exposed:** `ANALYZE` creates the internal `sqlite_stat1` table; `makeSyntheticDb` replays the snapshot's DDL into `:memory:` and only excluded `sqlite_sequence`, so the suite blew up with 123 failures once the snapshot carried stats ("object name reserved for internal use"). The DDL filter is now `NOT LIKE 'sqlite_%'`. Suite run twice back-to-back to prove no order/state dependence.

## Testing

`tests/query-plans.test.ts` — 5 tests: the indexes exist after `setupTables`; the plan **uses `idx_vlog_flight` and does not use `idx_vlog_airline`** on a production-shaped seeded DB; the join seeks by tail; `archivePastDepartures` trims >30d; `getAirportDepartures` issues no writes (an ancient row survives a read).

Verified to fail against reverted code: dropping the indexes+ANALYZE fails 3, moving the DELETE back fails 1.

Full suite **824 pass / 0 fail**, twice. No new type errors vs `main`. Lint unchanged. ANALYZE on ~76k rows is well under a second, once per boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)