### PR TITLE
fix: publish the roster fleet total, not the sheet's inflated row sums

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -757,8 +757,14 @@ export function updateDatabase(
     setMeta(db, "totalAircraftCount", totalAircraftCount, airline);
     stampLastUpdated(db, airline, "sheet-scrape");
 
-    // Raw sheet tallies (pre-dedup, pre-verification). Display/API counts come
-    // from getStarlinkPlanes()/getFleetStats() — these meta keys are diagnostic.
+    // Raw sheet tallies. These are a FALLBACK floor, not the published number:
+    // refreshFleetMeta() below overwrites every total with roster-derived
+    // counts whenever united_fleet has rows for this airline. The sheet's own
+    // row sums are wrong as a denominator — its express tabs carry SkyWest's
+    // entire operation (their Delta/American/Alaska flying included), which
+    // inflated the published UA fleet to 1,818 against a real roster of ~1,641
+    // and United's own pipeline sheet's 1,623, understating coverage by ~3.5
+    // points (and express by ~18).
     for (const [fleetType, stats] of Object.entries(fleetStats)) {
       for (const [metric, value] of Object.entries(stats)) {
         const key = `${fleetType}${metric.charAt(0).toUpperCase() + metric.slice(1)}`;
@@ -870,6 +876,14 @@ export function updateDatabase(
       "DELETE FROM starlink_planes WHERE sheet_gid = 'discovery' AND verified_wifi IS NOT NULL AND verified_wifi != 'Starlink' AND airline = ?"
     ).run(airline);
   })();
+
+  // Overwrite the raw sheet tallies with roster-derived totals. united_fleet
+  // (FR24-sourced) agrees with United's own pipeline sheet to within ~1%; the
+  // community sheet's row sums do not (see the comment on the fallback writes
+  // above). No-ops when the airline has no roster rows, so airlines without an
+  // FR24 sync keep the sheet tallies. lastUpdated is safe: stampLastUpdated is
+  // ownership-gated and UA's owner is the scrape itself.
+  refreshFleetMeta(db, airline);
   return null;
 }
 
@@ -943,6 +957,9 @@ export function refreshFleetMeta(db: Database, airline: string): void {
   setMeta(db, "expressTotal", expressTotal, airline);
   setMeta(db, "expressStarlink", expressStarlink, airline);
   setMeta(db, "expressPercentage", pct(expressStarlink, expressTotal), airline);
+  // Ownership-gated: writes lastUpdated only for airlines whose configured
+  // owner is "fleet-meta" (the default). For UA the scrape owns the stamp, so
+  // the updateDatabase call below can never steal it.
   stampLastUpdated(db, airline, "fleet-meta");
 }
 

--- a/tests/fleet-denominator.test.ts
+++ b/tests/fleet-denominator.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The published fleet denominator comes from the roster, not the sheet.
+ *
+ * The hourly scrape counts every row of every sheet tab and wrote those sums
+ * straight into the meta keys that getTotalCount/getFleetStats serve. The
+ * community sheet's express tabs carry SkyWest's entire operation (their
+ * Delta/American/Alaska flying included), which inflated the published UA
+ * fleet to 1,818 against a real roster of ~1,641 — understating coverage by
+ * ~3.5 points overall and ~18 points on express. united_fleet (FR24-sourced)
+ * agrees with United's own pipeline sheet to within ~1%, so it wins whenever
+ * it has rows; the sheet tallies remain only as a fallback floor.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { getFleetStats, getTotalCount, updateDatabase } from "../src/database/database";
+import type { FleetStats } from "../src/types";
+import { addFleet, makeSyntheticDb } from "./helpers";
+
+const inflatedSheetStats: FleetStats = {
+  express: { total: 674, starlink: 342, unverified: 0, percentage: 50.7 },
+  mainline: { total: 1144, starlink: 184, unverified: 0, percentage: 16.1 },
+};
+
+const sheetRoster = [
+  { TailNumber: "N101UA", Aircraft: "E175", WiFi: "Starlink", fleet: "express" as const },
+  {
+    TailNumber: "N102UA",
+    Aircraft: "Boeing 737-900",
+    WiFi: "Starlink",
+    fleet: "mainline" as const,
+  },
+];
+
+describe("fleet denominator source of truth", () => {
+  test("a populated roster overrides the sheet's inflated tallies", () => {
+    const db = makeSyntheticDb();
+    // Roster: 3 express + 5 mainline = 8 aircraft the fleet sync actually saw.
+    for (let i = 0; i < 3; i++) addFleet(db, `N90${i}EX`, "confirmed");
+    for (let i = 0; i < 5; i++) addFleet(db, `N91${i}ML`, null);
+    db.query("UPDATE united_fleet SET fleet = 'express' WHERE tail_number LIKE 'N90%'").run();
+    db.query("UPDATE united_fleet SET fleet = 'mainline' WHERE tail_number LIKE 'N91%'").run();
+
+    const refusal = updateDatabase(db, 1818, sheetRoster, inflatedSheetStats);
+    expect(refusal).toBeNull();
+
+    // Published totals are the roster's 8, not the sheet's 1,818.
+    expect(getTotalCount(db, "UA")).toBe(8);
+    const stats = getFleetStats(db, "UA");
+    expect(stats.express.total).toBe(3);
+    expect(stats.mainline.total).toBe(5);
+    db.close();
+  });
+
+  test("with no roster rows the sheet tallies survive as the fallback", () => {
+    const db = makeSyntheticDb();
+    const refusal = updateDatabase(db, 1818, sheetRoster, inflatedSheetStats);
+    expect(refusal).toBeNull();
+    expect(getTotalCount(db, "UA")).toBe(1818);
+    expect(getFleetStats(db, "UA").express.total).toBe(674);
+    db.close();
+  });
+
+  test("the scrape's lastUpdated stamp survives the roster recompute", () => {
+    // stampLastUpdated is ownership-gated: UA's configured owner is the scrape,
+    // so refreshFleetMeta's own stamp attempt must be a no-op — lastUpdated
+    // must exist (the scrape wrote it) and stay a valid ISO timestamp.
+    const db = makeSyntheticDb();
+    addFleet(db, "N900EX", "confirmed");
+    updateDatabase(db, 1818, sheetRoster, inflatedSheetStats);
+    const stamped = db.query("SELECT value FROM meta WHERE key = 'UA:lastUpdated'").get() as {
+      value: string;
+    } | null;
+    expect(stamped).not.toBeNull();
+    expect(Number.isFinite(Date.parse(stamped?.value ?? ""))).toBe(true);
+    db.close();
+  });
+});


### PR DESCRIPTION
**This changes the site's headline number.** Today: "526 of 1,818 (28.9%)". After: **"526 of ~1,641 (~32%)"**, express 50.7% → ~68%.

## Why the published number is wrong

The hourly scrape sums **every row of every community-sheet tab** (`expressTotal += rows.length`, `utils.ts`) and `updateDatabase` writes those sums into the meta keys that `getTotalCount`/`getFleetStats` serve. A comment in the writer literally calls them *"diagnostic"* — but they are the homepage, `/api/data`, MCP, and `llms.txt` numbers.

The sheet's express tabs carry **SkyWest's entire operation** — their Delta, American, and Alaska flying included. Reconstruction: 1,066 UAL mainline (10-K) + SkyWest's whole 517-aircraft fleet + Republic/Mesa 126 + CommuteAir 53 + GoJet 54 = **1,816 ≈ our 1,818**. Only 239 of SkyWest's 517 fly for United.

## Why the roster is right

| Source | UA total | Express |
|---|---|---|
| published (sheet tallies) | 1,818 | 674 (50.7%) |
| `united_fleet` roster (FR24) | **1,641** | **504 (67.9%)** |
| United's own pipeline sheet | 1,623 | 491 (**69.0%**) |

The roster agrees with United's own sheet to ~1%. And our `/fleet` page **already renders 1,641 tails under a headline saying 1,818** — this PR makes the site agree with itself.

## The fix

`refreshFleetMeta` (roster-derived) already computed the right numbers — but ran only on the **daily** fleet sync, and the hourly scrape overwrote it every time. It now runs at the end of `updateDatabase`, so roster totals win hourly. The raw sheet tallies remain as a **fallback floor**: `refreshFleetMeta` no-ops on an empty roster, so an airline with no FR24 sync keeps the sheet numbers.

`lastUpdated` ownership is untouched — `stampLastUpdated` is ownership-gated and UA's owner is the scrape itself. (I initially added a `stamp=false` param, then removed it on finding the existing gate already guarantees this; the test pins it.)

## Testing

`tests/fleet-denominator.test.ts` — 3 tests: a populated roster overrides inflated tallies; an empty roster keeps the sheet fallback; the scrape's `lastUpdated` stamp survives. Verified to fail with the `refreshFleetMeta` call reverted.

Full suite **827 pass / 0 fail**. No new type errors vs `main`.

## What this deliberately does not do

- No pruning of stale roster tails (the roster only grows; if FR24 keeps retired tails, 1,641 is itself a slight overcount vs United's 1,623 — a separate, smaller problem).
- No change to the SEC-anchors display on `/fleet`.
- The MCP live-stats paragraph self-corrects since it reads `getFleetStats()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)