### PR TITLE
seo: fix the copy and routing defects the crawl audit surfaced

### DIFF
--- a/src/components/atoms.tsx
+++ b/src/components/atoms.tsx
@@ -375,7 +375,14 @@ export function RouteComparePanel() {
         className="mt-3 text-[10px] font-mono text-muted leading-relaxed hidden"
       >
         Carrier missing? It only shows up once one of its Starlink planes has flown here.{" "}
-        <a id="hub-compare-rp" href="/route-planner" className="text-accent hover:underline">
+        {/* Static href must be a real page: /route-planner 404s on the hub, and
+            crawlers see this SSR value — client JS only rewrites it to the
+            per-route URL after a comparison runs. */}
+        <a
+          id="hub-compare-rp"
+          href={`https://${SITES.united.canonicalHost}/route-planner`}
+          className="text-accent hover:underline"
+        >
           Route Planner →
         </a>
       </div>

--- a/src/components/route-page.tsx
+++ b/src/components/route-page.tsx
@@ -16,16 +16,35 @@ export function formatDuration(sec: number | null): string | null {
 
 /** The one-line answer the page exists to give. */
 export function routeVerdict(route: RouteSummary, airlineName: string): string {
+  const pair = `${route.origin} → ${route.destination}`;
   if (route.totalDepartures === 0) {
-    return `No ${airlineName} departures are in the schedule window for ${route.origin} → ${route.destination} right now. Aircraft assignments publish about two days out.`;
+    // Lead with what we durably know. The schedule window is only 48h, so a
+    // route with real history spends most of its life "empty" — opening on the
+    // negative made ~43% of the corpus read as a no-data page (and gave every
+    // one of them a near-identical meta description).
+    const fns = route.flightNumbers;
+    if (fns.length > 0) {
+      const sample = fns
+        .slice(0, 3)
+        .map((f) => f.flight_number)
+        .join(", ");
+      return `${airlineName} flies ${pair} — ${fns.length} flight number${fns.length === 1 ? "" : "s"} on record (${sample}). No departures are in the next-48h assignment window yet; aircraft assignments publish about two days out.`;
+    }
+    return `No ${airlineName} departures are in the schedule window for ${pair} right now. Aircraft assignments publish about two days out.`;
+  }
+  // "All 1 scheduled departures" shipped on ~10% of route pages.
+  if (route.totalDepartures === 1) {
+    return route.equippedDepartures === 1
+      ? `The only scheduled ${pair} departure in the ${route.windowLabel} is on a Starlink-equipped aircraft.`
+      : `The only scheduled ${pair} departure in the ${route.windowLabel} is not on a Starlink-equipped aircraft.`;
   }
   if (route.equippedDepartures === 0) {
-    return `None of the ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on a Starlink-equipped aircraft.`;
+    return `None of the ${route.totalDepartures} scheduled ${pair} departures in the ${route.windowLabel} are on a Starlink-equipped aircraft.`;
   }
   if (route.equippedDepartures === route.totalDepartures) {
-    return `All ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
+    return `All ${route.totalDepartures} scheduled ${pair} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
   }
-  return `${route.equippedDepartures} of ${route.totalDepartures} scheduled ${route.origin} → ${route.destination} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
+  return `${route.equippedDepartures} of ${route.totalDepartures} scheduled ${pair} departures in the ${route.windowLabel} are on Starlink-equipped aircraft.`;
 }
 
 function FlightNumbers({ route, airlineName }: { route: RouteSummary; airlineName: string }) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1099,7 +1099,14 @@ const mcp: Handler = async (ctx) => {
   // HEAD always takes the page branch (like every other page handler — /mcp is
   // sitemap-advertised, so link checkers must not see 405): the MCP protocol
   // has no HEAD method, and HEAD clients (curl -I) don't send Accept: text/html.
-  if (req.method === "HEAD" || (req.method === "GET" && accept.includes("text/html"))) {
+  // Page branch for HEAD and for any GET that is not an MCP-protocol request.
+  // The protocol's only GET is the SSE handshake (Accept: text/event-stream);
+  // JSON-RPC rides POST. Gating the page on Accept: text/html made every other
+  // GET — curl, sitemap validators, generic link checkers — see a 405 on a
+  // sitemap-advertised URL.
+  const mcpProtocolGet =
+    accept.includes("text/event-stream") || accept.includes("application/json");
+  if (req.method === "HEAD" || (req.method === "GET" && !mcpProtocolGet)) {
     if (!site.features.mcpPage) {
       return notFound(site);
     }
@@ -1590,7 +1597,7 @@ function subPageMeta(
   if (page === "check-flight")
     return {
       siteTitle: `Does My ${short} Flight Have Starlink? Check Any Flight — Live`,
-      siteDescription: `Does my flight have Starlink? Enter a ${short} flight number and date for a live answer — verified within ~2 days of departure, predicted from 12,000+ past flights.`,
+      siteDescription: `Does my flight have Starlink? Enter ${/^[aeiou]/i.test(short) ? "an" : "a"} ${short} flight number and date for a live answer — verified within ~2 days of departure, predicted from 12,000+ past flights.`,
       keywords: `does my flight have starlink, does my ${short.toLowerCase()} flight have starlink, check ${cfg?.iata ?? "airline"} flight starlink, ${name} wifi check`,
       ogTitle: `Does My ${short} Flight Have Starlink?`,
       ogDescription: `Check any ${short} flight by number and date — live answer for whether your aircraft has free Starlink WiFi.`,
@@ -1612,12 +1619,17 @@ function subPageMeta(
       ogDescription:
         "Find direct flights and smart connections with the highest Starlink probability.",
     };
+  // On the hub there is no carrier, and "${short} Fleet" degenerated to
+  // "Tracked Fleets Fleet"; "every ${name} aircraft" likewise read "every
+  // tracked airlines aircraft".
+  const fleetLead = cfg ? `${short} Fleet` : "Tracked Fleets";
+  const fleetOf = cfg ? `${name} aircraft` : "aircraft from every tracked airline";
   return {
-    siteTitle: `${short} Fleet Starlink Rollout — Every Tail Number, Every WiFi Provider`,
-    siteDescription: `See every ${name} aircraft at once, colored by WiFi provider. Track which aircraft types are done and how many Starlink planes are in the air right now.`,
+    siteTitle: `${fleetLead} Starlink Rollout — Every Tail Number, Every WiFi Provider`,
+    siteDescription: `See every ${fleetOf} at once, colored by WiFi provider. Track which aircraft types are done and how many Starlink planes are in the air right now.`,
     keywords: `${name} fleet starlink, wifi by aircraft, starlink rollout progress, tail number wifi`,
-    ogTitle: `${short} Fleet Starlink Rollout`,
-    ogDescription: `Every ${name} tail number, colored by WiFi provider.`,
+    ogTitle: `${fleetLead} Starlink Rollout`,
+    ogDescription: "Every tail number, colored by WiFi provider.",
   };
 }
 
@@ -1877,6 +1889,13 @@ const routePlannerPage: Handler = (ctx) => {
   if (trimmed !== "/route-planner") {
     const parsed = parseRoutePath(ctx.url.pathname);
     if (!parsed) return notFound(ctx.site);
+    // One spelling per route: lowercase and trailing-slash variants 301 to the
+    // canonical uppercase form, mirroring /check-flight. They used to 200 with
+    // a self-correcting canonical — duplicate crawl surface.
+    const canonicalPath = `/route-planner/${parsed.origin}/${parsed.destination}`;
+    if (ctx.url.pathname !== canonicalPath) {
+      return Response.redirect(`https://${ctx.site.canonicalHost}${canonicalPath}`, 301);
+    }
     const cfg = siteAirline(ctx.site);
     if (!ctx.reader.routeHasData(parsed.origin, parsed.destination)) return notFound(ctx.site);
     const route = ctx.reader.getRouteSummary(parsed.origin, parsed.destination);

--- a/tests/seo-copy.test.ts
+++ b/tests/seo-copy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * SEO copy and routing defects found live in production:
+ *  - "All 1 scheduled ABQ → PDX departures" on ~10% of route pages
+ *  - "Enter a Alaska flight number" in the AS check-flight description
+ *  - "Tracked Fleets Fleet Starlink Rollout" on the hub /fleet title
+ *  - the hub homepage's only broken internal link (href="/route-planner",
+ *    which 404s on the hub host)
+ *  - /mcp answering 405 to any GET without Accept: text/html, despite being
+ *    sitemap-advertised
+ *  - /route-planner case/trailing-slash variants answering 200 instead of 301
+ *  - ~43% of route pages leading with the 48h-window negative even when the
+ *    route has durable history
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { SITES } from "../src/airlines/registry";
+import { routeVerdict } from "../src/components/route-page";
+import { getSitemapRoutes } from "../src/database/database";
+import type { RouteSummary } from "../src/database/database";
+import { createApp } from "../src/server/app";
+import { openSnapshot, req } from "./helpers";
+
+let app: ReturnType<typeof createApp>;
+let db: ReturnType<typeof openSnapshot>;
+beforeAll(() => {
+  db = openSnapshot();
+  app = createApp(db);
+});
+
+const UA = SITES.united.canonicalHost;
+const HUB = SITES.airline.canonicalHost;
+const AS = SITES.alaska.canonicalHost;
+
+const summary = (over: Partial<RouteSummary>): RouteSummary => ({
+  origin: "ABQ",
+  destination: "PDX",
+  flightNumbers: [],
+  durationSec: null,
+  equippedDepartures: 0,
+  totalDepartures: 0,
+  windowLabel: "next 48 hours",
+  ...over,
+});
+
+describe("routeVerdict", () => {
+  test("a single departure is never pluralized", () => {
+    const one = summary({ totalDepartures: 1, equippedDepartures: 1 });
+    expect(routeVerdict(one, "United Airlines")).toContain("The only scheduled");
+    expect(routeVerdict(one, "United Airlines")).not.toContain("All 1");
+    const none = summary({ totalDepartures: 1, equippedDepartures: 0 });
+    expect(routeVerdict(none, "United Airlines")).toContain("is not on a Starlink-equipped");
+    expect(routeVerdict(none, "United Airlines")).not.toContain("None of the 1");
+  });
+
+  test("an empty window with history leads with the history, not the negative", () => {
+    const v = routeVerdict(
+      summary({
+        flightNumbers: [
+          { flight_number: "UA123", times: 9, scheduled: 0 },
+          { flight_number: "UA456", times: 3, scheduled: 0 },
+        ],
+      }),
+      "United Airlines"
+    );
+    expect(v).toMatch(/^United Airlines flies ABQ → PDX/);
+    expect(v).toContain("UA123");
+    expect(v).not.toMatch(/^No United Airlines departures/);
+  });
+
+  test("an empty window with no history keeps the honest no-data copy", () => {
+    expect(routeVerdict(summary({}), "United Airlines")).toMatch(/^No United Airlines departures/);
+  });
+
+  test("plural branches unchanged", () => {
+    expect(
+      routeVerdict(summary({ totalDepartures: 4, equippedDepartures: 4 }), "United Airlines")
+    ).toContain("All 4 scheduled");
+    expect(
+      routeVerdict(summary({ totalDepartures: 4, equippedDepartures: 2 }), "United Airlines")
+    ).toContain("2 of 4 scheduled");
+  });
+});
+
+describe("page copy", () => {
+  test("AS check-flight description uses 'an Alaska', not 'a Alaska'", async () => {
+    const body = await (
+      await app.dispatch(req("/check-flight", AS, { headers: { Accept: "text/html" } }))
+    ).text();
+    expect(body).not.toContain("Enter a Alaska");
+    expect(body).toContain("Enter an Alaska");
+  });
+
+  test("hub /fleet title does not read 'Fleets Fleet'", async () => {
+    const body = await (
+      await app.dispatch(req("/fleet", HUB, { headers: { Accept: "text/html" } }))
+    ).text();
+    expect(body).not.toContain("Fleets Fleet");
+    expect(body).not.toContain("every tracked airlines aircraft");
+  });
+
+  test("the hub homepage has no relative /route-planner link (it 404s there)", async () => {
+    const body = await (
+      await app.dispatch(req("/", HUB, { headers: { Accept: "text/html" } }))
+    ).text();
+    expect(body).not.toContain('href="/route-planner"');
+  });
+});
+
+describe("/mcp content negotiation", () => {
+  test("plain GET (curl, link checkers) gets the page, not 405", async () => {
+    const res = await app.dispatch(req("/mcp", UA, { headers: { Accept: "*/*" } }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/html");
+  });
+
+  test("an MCP-protocol GET still reaches the protocol handler", async () => {
+    const res = await app.dispatch(req("/mcp", UA, { headers: { Accept: "text/event-stream" } }));
+    expect((res.headers.get("content-type") ?? "").includes("text/html")).toBe(false);
+  });
+});
+
+describe("/route-planner canonical spelling", () => {
+  test("lowercase and trailing-slash variants 301 to the canonical form", async () => {
+    const r = getSitemapRoutes(db, "UA")[0];
+    const canonical = `https://${UA}/route-planner/${r.origin}/${r.destination}`;
+    const lower = await app.dispatch(
+      req(`/route-planner/${r.origin.toLowerCase()}/${r.destination.toLowerCase()}`, UA)
+    );
+    expect(lower.status).toBe(301);
+    expect(lower.headers.get("location")).toBe(canonical);
+    const slash = await app.dispatch(req(`/route-planner/${r.origin}/${r.destination}/`, UA));
+    expect(slash.status).toBe(301);
+    expect(slash.headers.get("location")).toBe(canonical);
+  });
+
+  test("the canonical spelling still renders 200 directly", async () => {
+    const r = getSitemapRoutes(db, "UA")[0];
+    const res = await app.dispatch(req(`/route-planner/${r.origin}/${r.destination}`, UA));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Seven production defects from the crawl audit, each verified live before fixing.

## Copy

- **"All 1 scheduled ABQ → PDX departures"** — shipped in the title/description of ~10% of UA and ~20% of AS route pages (~355 pages). Singular now reads singular.
- **Empty-window route pages led with a negative.** ~43% of the route corpus renders while no flight is inside the 48h assignment window, and every one of them opened with *"No departures are in the schedule window"* — a no-data page with a near-identical description, even when the route has real history. They now lead with what we durably know: `"United Airlines flies ABQ → PDX — 4 flight numbers on record (UA123, …)"`. This is the cheap half of the empty-state fix; whether those URLs belong in the sitemap at all is a separate decision.
- **"Enter a Alaska flight number"** → "an Alaska".
- **Hub `/fleet`: "Tracked Fleets Fleet Starlink Rollout"** and *"every tracked airlines aircraft"* — the template assumed a carrier `shortName` the hub doesn't have.

## Routing

- **The hub's only broken internal link**: the compare widget's static `href="/route-planner"` 404s on the hub host (that page is UA-only); crawlers see the SSR value. Now points at the UA tracker absolutely; client JS still rewrites it per-route after a comparison runs.
- **`/mcp` answered 405 to `GET` with `Accept: */*`** — curl, sitemap validators, link checkers — despite being sitemap-advertised. The page now serves for any GET that isn't an MCP-protocol request. The protocol's only GET is the SSE handshake (`Accept: text/event-stream`), which still reaches the protocol handler — pinned by test.
- **`/route-planner/sfo/lax` and trailing-slash variants returned 200** with a self-correcting canonical — duplicate crawl surface, asymmetric with `/check-flight`'s 301s. Now 301 to the canonical spelling.

## Testing

`tests/seo-copy.test.ts` — 11 tests covering all seven. The article, `/mcp`, and 301 fixes were each verified to fail against reverted code (1 failure each).

Full suite **835 pass / 0 fail**. No new type errors vs `main`. Lint back to pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)