### PR TITLE
chore: change-gate verifier logging; count rate-limited responses

### DIFF
--- a/src/scripts/fleet-discovery.ts
+++ b/src/scripts/fleet-discovery.ts
@@ -61,6 +61,9 @@ const verdictLog = {
   warn: (m: string) => {
     warn(m);
   },
+  debug: (m: string) => {
+    debug(m);
+  },
 };
 
 // Discovery-mode metric tags per verdict category. The mode difference vs
@@ -200,7 +203,7 @@ export async function verifyPlane(
           // Warn once at the parked threshold; after that it's weekly backoff and repeats are noise.
           warn(`${plane.tail_number}: ${failures} consecutive no-flights — likely parked/stored`);
         } else {
-          info(`No upcoming flights for ${plane.tail_number}, skipping`);
+          debug(`No upcoming flights for ${plane.tail_number}, skipping`);
         }
         span.setTag("result", "no_flights");
         metrics.increment(COUNTERS.FLEET_CHECK_SKIPPED, {
@@ -392,7 +395,7 @@ export async function verifyPlane(
         } else if (result.hasStarlink) {
           info(`${plane.tail_number} confirmed Starlink (${result.wifiProvider})`);
         } else {
-          info(`${plane.tail_number} no Starlink (${result.wifiProvider || "unknown"})`);
+          debug(`${plane.tail_number} no Starlink (${result.wifiProvider || "unknown"})`);
         }
 
         return result;

--- a/src/scripts/starlink-verifier.ts
+++ b/src/scripts/starlink-verifier.ts
@@ -54,6 +54,9 @@ const verdictLog = {
   warn: (m: string) => {
     verifierLog.warn(m);
   },
+  debug: (m: string) => {
+    verifierLog.debug(m);
+  },
 };
 
 // Verification-mode metric tags per verdict category. The mode difference vs
@@ -185,7 +188,7 @@ export async function verifyPlaneStarlink(
       span.setTag("flight_number", `UA${flightNumber}`);
       span.setTag("route", `${origin}-${destination}`);
 
-      verifierLog.info(
+      verifierLog.debug(
         `Checking ${tailNumber} via UA${flightNumber} ${origin}-${destination} on ${departureDate}`
       );
 
@@ -229,7 +232,9 @@ export async function verifyPlaneStarlink(
             `Flight ${flightNumber} aircraft: ${resolvedTail} (${result.wifiProvider || "unknown"})`
           );
         } else if (result.hasStarlink) {
-          verifierLog.info(
+          // debug: overwhelmingly re-confirmations. The state CHANGE line
+          // (verified_wifi → X in united-verdict) stays at info.
+          verifierLog.debug(
             `✓ ${tailNumber} confirmed Starlink (${result.wifiProvider} via ${result.providerSource})`
           );
         } else if (result.error) {
@@ -238,7 +243,7 @@ export async function verifyPlaneStarlink(
             result.debugFile ? { debugFile: result.debugFile } : undefined
           );
         } else {
-          verifierLog.info(
+          verifierLog.debug(
             `✗ ${tailNumber} no Starlink (${
               result.wifiProvider
                 ? `${result.wifiProvider} via ${result.providerSource}`
@@ -313,7 +318,7 @@ export async function runVerificationBatch(
       return stats;
     }
 
-    verifierLog.info(`${toVerify.length} plane(s) need verification`);
+    verifierLog.debug(`${toVerify.length} plane(s) need verification`);
 
     for (let i = 0; i < toVerify.length; i++) {
       const { plane, flight, recheckHours } = toVerify[i];
@@ -343,7 +348,7 @@ export async function runVerificationBatch(
 
     // Log verification stats
     const dbStats = getVerificationStats(db);
-    verifierLog.info(
+    verifierLog.debug(
       `Stats: ${dbStats.total_checks} total checks, ${dbStats.last_24h_checks} in last 24h`
     );
   } finally {

--- a/src/scripts/united-verdict.ts
+++ b/src/scripts/united-verdict.ts
@@ -22,7 +22,7 @@ import {
   logVerification,
   updateVerifiedWifi,
 } from "../database/database";
-import { info, warn } from "../utils/logger";
+import { debug, info, warn } from "../utils/logger";
 import type { StarlinkCheckResult } from "./united-starlink-checker";
 
 export const UNITED_SOURCE = verifierSourceTag(AIRLINES.UA);
@@ -35,9 +35,11 @@ export const UNITED_SOURCE = verifierSourceTag(AIRLINES.UA);
 export interface VerdictLog {
   info: (msg: string) => void;
   warn: (msg: string) => void;
+  /** Optional: callers without a debug channel fall back to info. */
+  debug?: (msg: string) => void;
 }
 
-const ownLog: VerdictLog = { info: (m) => info(m), warn: (m) => warn(m) };
+const ownLog: VerdictLog = { info: (m) => info(m), warn: (m) => warn(m), debug: (m) => debug(m) };
 
 /**
  * One category per matrix cell; callers map category → mode-specific metric
@@ -259,8 +261,22 @@ function settleConsensus(
   const consensus = computeWifiConsensus(db, tail, { sources: OBSERVED_WIFI_SOURCES });
   const status = consensusToFleetStatus(consensus.verdict);
   if (status !== null) {
+    // Change-gated: a re-confirmation of the value already on file is a debug
+    // fact, a transition is the event worth an info line. The un-gated version
+    // re-logged every settle and was a top log-volume shape (~80/day of
+    // "verified_wifi → Starlink" for tails that were already Starlink).
+    // Read starlink_planes, NOT united_fleet: updateVerifiedWifi writes
+    // starlink_planes.verified_wifi, and the two tables both carry the column.
+    const prev =
+      (
+        db.query("SELECT verified_wifi FROM starlink_planes WHERE TailNumber = ?").get(tail) as {
+          verified_wifi: string | null;
+        } | null
+      )?.verified_wifi ?? null;
     updateVerifiedWifi(db, tail, consensus.verdict);
-    log.info(`${tail}${tag}: verified_wifi → ${consensus.verdict} (${consensus.reason})`);
+    const line = `${tail}${tag}: verified_wifi → ${consensus.verdict} (${consensus.reason})`;
+    if (prev === consensus.verdict) (log.debug ?? log.info)(line);
+    else log.info(line);
     // Discovery is the sole united_fleet status writer; queue a re-check when
     // its row disagrees so the verifier/swap path can't leave it stale.
     if (getFleetEntryByTail(db, tail)?.starlink_status !== status) {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2350,7 +2350,22 @@ export function createApp(db: Database): App {
     const ip = clientIp(req);
     if (meterClass) {
       if (rateLimited(ip, meterClass, Date.now())) {
-        metrics.increment(COUNTERS.HTTP_RATE_LIMITED, { route, tenant: tenantScope(tenant) });
+        // metricRoute, not the span route: the span form is "/*", and Datadog
+        // strips '*' from tag values (see metricRoute). Also counted in
+        // HTTP_REQUEST — this early return previously bypassed the
+        // count-every-request emit, so 429s were invisible in the request
+        // metric (357 fired in one incident, zero appeared).
+        metrics.increment(COUNTERS.HTTP_RATE_LIMITED, {
+          route: metricRoute(m),
+          tenant: tenantScope(tenant),
+        });
+        metrics.increment(COUNTERS.HTTP_REQUEST, {
+          method: req.method,
+          route: metricRoute(m),
+          status_code: 429,
+          tenant: tenantScope(tenant),
+          client_class: classifyUserAgent(req.headers.get("user-agent")),
+        });
         return new Response(JSON.stringify({ error: "rate limit exceeded" }), {
           status: 429,
           headers: { ...SECURITY_HEADERS.api, "Retry-After": "60" },

--- a/tests/log-noise.test.ts
+++ b/tests/log-noise.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Log-noise pass 2: the verifier family was 36.5% of all log volume after #81.
+ *
+ * Two behaviors pinned here:
+ *  - The verified_wifi transition line is change-gated: a settle that writes
+ *    the value already on file logs at debug; an actual transition logs info.
+ *  - The rate limiter's early return emits HTTP_REQUEST (status 429). It used
+ *    to bypass the count-every-request emit entirely — one incident fired 357
+ *    rate-limit responses and zero appeared in the request metric.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { metrics } from "../src/observability/metrics";
+import { type UnitedVerdict, applyUnitedObservation } from "../src/scripts/united-verdict";
+import { createApp } from "../src/server/app";
+import { addFleet, addPlane, makeSyntheticDb, openSnapshot, req } from "./helpers";
+
+const starlinkVerdict = (tail: string): UnitedVerdict => ({
+  expectedTail: tail,
+  resolvedTail: tail,
+  category: "starlink",
+  tailMismatch: false,
+  tailUnknown: false,
+  untrustedNonStarlink: false,
+  trusted: true,
+  wifiProvider: "Starlink",
+  observation: { has_starlink: true, wifi_provider: "Starlink", tail_confirmed: 1, error: null },
+  swapCapture: null,
+});
+
+describe("verified_wifi transition logging is change-gated", () => {
+  test("first settle (a transition) logs info; re-confirmations log debug", () => {
+    const db = makeSyntheticDb();
+    // The settle writes starlink_planes.verified_wifi, so the tail must exist
+    // there; united_fleet rides along for the discovery-priority path.
+    addPlane(db, "N777UA", null);
+    addFleet(db, "N777UA", null, { verifiedWifi: null });
+    const infoLines: string[] = [];
+    const debugLines: string[] = [];
+    const log = {
+      info: (m: string) => infoLines.push(m),
+      warn: () => {},
+      debug: (m: string) => debugLines.push(m),
+    };
+
+    for (let i = 0; i < 3; i++) {
+      applyUnitedObservation(db, starlinkVerdict("N777UA"), {
+        flightNumber: "UA100",
+        aircraftType: "B737-900",
+        log,
+      });
+    }
+
+    const transitions = infoLines.filter((m) => m.includes("verified_wifi →"));
+    const reconfirms = debugLines.filter((m) => m.includes("verified_wifi →"));
+    // Call 1 cannot settle (consensus needs 2 recent obs); call 2 is the real
+    // transition (null → Starlink); call 3 re-writes the value already on file.
+    expect(transitions.length).toBe(1);
+    expect(reconfirms.length).toBe(1);
+    db.close();
+  });
+});
+
+describe("rate-limited responses are counted", () => {
+  let app: ReturnType<typeof createApp>;
+  beforeAll(() => {
+    app = createApp(openSnapshot());
+  });
+
+  test("a 429 emits HTTP_REQUEST with status_code 429 and a real route tag", async () => {
+    const calls: Array<{ name: string; tags: Record<string, unknown> }> = [];
+    const original = metrics.increment;
+    metrics.increment = (name, tags) => {
+      calls.push({ name, tags: (tags ?? {}) as Record<string, unknown> });
+      original(name, tags);
+    };
+    try {
+      // Dedicated source IP so the flood cannot poison other tests' buckets.
+      const headers = { "cf-connecting-ip": "203.0.113.99" };
+      let sawLimit = false;
+      for (let i = 0; i < 130 && !sawLimit; i++) {
+        const res = await app.dispatch(req("/api/data", "unitedstarlinktracker.com", { headers }));
+        sawLimit = res.status === 429;
+      }
+      expect(sawLimit).toBe(true);
+      const limited = calls.filter((c) => c.name === "http.request" && c.tags.status_code === 429);
+      expect(limited.length).toBeGreaterThan(0);
+      expect(limited[0].tags.route).toBe("/api/data");
+      expect(String(limited[0].tags.route)).not.toContain("*");
+    } finally {
+      metrics.increment = original;
+    }
+  });
+});


### PR DESCRIPTION
Log-noise pass 2 plus the last metric blind spot.

## The verifier became the top log source

After #81, `starlink-verifier` + `fleet-discovery` per-check lines were **36.5% of all log volume** — untouched by that pass.

**The `verified_wifi →` transition line is now change-gated.** It re-logged on *every* consensus settle, including ~80/day that rewrote the value already on file. A transition (the actual event: null→Starlink, Viasat→Starlink) logs **info**; a re-confirmation logs **debug**.

One subtlety the test caught before I did: the previous value must be read from **`starlink_planes`**, not `united_fleet` — `updateVerifiedWifi` writes `starlink_planes.verified_wifi`, and *both* tables carry a `verified_wifi` column. My first version read the wrong one and the gate never engaged.

**Demoted to debug** (all already covered by metrics/spans): `Checking TAIL via UA…`, `✓ confirmed Starlink` (re-verifications — the change event has its own info line now), `✗ no Starlink (…)`, `N plane(s) need verification`, `Stats: N total checks`, discovery's `No upcoming flights, skipping` and per-tail negatives. Errors, warns, and startup lines stay.

## 429s were invisible in the request metric

The rate limiter's early return bypassed the count-every-request emit — one incident fired **357** rate-limited responses and **zero** appeared in `http.request`. The 429 path now emits `HTTP_REQUEST{status_code:429}`.

Bonus: the existing `HTTP_RATE_LIMITED` emit tagged `route` with the *span* form `"/*"` — which Datadog strips to `"/"`, the same wildcard bug as #84. Both emits now use `metricRoute()`.

## Testing

`tests/log-noise.test.ts` — the change-gate (3 settles → exactly 1 info transition + 1 debug re-confirmation; the first call can't settle since consensus needs 2 recent obs), and a real in-process flood from a dedicated `cf-connecting-ip` that asserts the 429 lands in `http.request` with a clean route tag. Both verified to fail against reverted code.

Full suite **826 pass / 0 fail**. No new type errors. Lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)