### PR TITLE
perf: compile Tailwind at build time; drop unpkg browser JIT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,5 @@ logs/
 docs/
 tests/
 do_not_commit/
+# Host-built CSS never enters the image; `RUN bun run build:css` produces it.
+static/tailwind.css

--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,13 @@ plane-data.production.sqlite*
 tsconfig.tsbuildinfo
 patches/
 
+# Compiled from src/styles/tailwind.css by `bun run build:css`. Deliberately not
+# committed — a checked-in stylesheet goes stale the moment a branch adding new
+# markup merges after it, and nothing in the test suite can see unstyled HTML.
+static/tailwind.css
+
 # internal
 ops/
 CLAUDE.local.md
 .claude/
 tsconfig.review.tsbuildinfo
-.citation-cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,6 @@ bun run test:setup             # Snapshot DB → .test-snapshot.sqlite (run befo
 bun run test                   # Integration tests (49, against readonly snapshot)
 bun run db-status              # Database overview (--full for details)
 bun run scrape                 # Fetch fleet data from Google Sheets
-bun run verify-citations       # Fetch every rollout-facts source and check the claim's tokens are in it (network, opt-in)
 bun run lint / format          # Biome
 ```
 
@@ -49,4 +48,4 @@ Bun + SQLite + server-rendered React. `server.ts` serves pages/APIs and starts b
 - **Logging** — `import { info, error, debug } from "./utils/logger"` (auto-tags filename, writes console + `logs/app.log`)
 - **Metrics** — route every metric tag through the normalizers in `src/observability/metrics.ts`; always set the `airline` tag
 - **Upstream citizenship** — public endpoints serve from the DB; never proxy live scraping to callers
-- **Citations** — a claim in `src/airlines/rollout-facts.ts` may say only what the page at its `source.url` says. Adding or editing one means running `bun run verify-citations` (a machine must find the claim's numbers and names in the source's bytes); a source no client can read gets a `source.mirror`, and only then an entry in `scripts/citations/allowlist.ts`
+- **Tailwind is compiled, not JIT** — `bun run build:css` emits gitignored `static/tailwind.css`; a class only works if the scanner finds it verbatim in `index.html` or `src/`, so never build one at runtime (`` `text-${x}-500` ``). `tests/stylesheet.test.ts` enforces it

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,11 @@ RUN bunx playwright install chromium
 
 COPY . .
 
+# Tailwind is compiled here rather than committed: the CSS is derived from the
+# markup in this image, so a branch that adds a page can never ship without the
+# utilities it uses. server.ts refuses to boot in production if this is missing.
+RUN bun run build:css
+
 EXPOSE 3000
 
 ARG SOURCE_COMMIT=unknown

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,7 @@
       "do_not_commit",
       ".playwright-browsers",
       "tmp",
-      ".citation-cache"
+      "static/tailwind.css"
     ]
   },
   "linter": {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@tailwindcss/cli": "4.3.3",
         "@types/bun": "^1.2.22",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
@@ -64,6 +65,16 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.2", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
@@ -112,6 +123,64 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.121.0", "", {}, "sha512-CGtOARQb9tyv7ECgdAlFxi0Fv7lmzvmlm2rpD/RdijOO9rfk/JvB1CjT8EnoD+tjna/IYgKKw3IV7objRb+aYw=="],
 
+    "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.1", "", { "os": "android", "cpu": "arm64" }, "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
+
+    "@tailwindcss/cli": ["@tailwindcss/cli@4.3.3", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "enhanced-resolve": "^5.24.1", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.3" }, "bin": { "tailwindcss": "./dist/index.mjs" } }, "sha512-ZvS/n1ZHOBKcVlhkt8l5NNr1EDXk1NboYO5CYDOs6NUmvT9z6bzkwsosaJftY57T/3gWNzWMJzIXLodZC8ssdw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.3", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.3", "@tailwindcss/oxide-darwin-arm64": "4.3.3", "@tailwindcss/oxide-darwin-x64": "4.3.3", "@tailwindcss/oxide-freebsd-x64": "4.3.3", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3", "@tailwindcss/oxide-linux-arm64-musl": "4.3.3", "@tailwindcss/oxide-linux-x64-gnu": "4.3.3", "@tailwindcss/oxide-linux-x64-musl": "4.3.3", "@tailwindcss/oxide-wasm32-wasi": "4.3.3", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3", "@tailwindcss/oxide-win32-x64-msvc": "4.3.3" } }, "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.3", "", { "os": "android", "cpu": "arm64" }, "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3", "", { "os": "linux", "cpu": "arm" }, "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.3", "", { "os": "linux", "cpu": "x64" }, "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.3", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -144,6 +213,8 @@
 
     "brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
 
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
@@ -170,13 +241,19 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "enhanced-resolve": ["enhanced-resolve@5.24.5", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A=="],
+
     "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "for-in": ["for-in@1.0.2", "", {}, "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ=="],
 
@@ -206,11 +283,19 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-object": ["is-plain-object@2.0.4", "", { "dependencies": { "isobject": "^3.0.1" } }, "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og=="],
 
     "isobject": ["isobject@3.0.1", "", {}, "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -222,6 +307,30 @@
 
     "lazy-cache": ["lazy-cache@1.0.4", "", {}, "sha512-RE2g0b5VGZsOCFOCgP7omTRYFqydmZkBwl5oNnQ1lDYC57uyO9KqNnNVxT7COSHTxrRCWVcAVOcbjk+tvh/rgQ=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "lint-staged": ["lint-staged@16.4.0", "", { "dependencies": { "commander": "^14.0.3", "listr2": "^9.0.5", "picomatch": "^4.0.3", "string-argv": "^0.3.2", "tinyexec": "^1.0.4", "yaml": "^2.8.2" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw=="],
 
     "listr2": ["listr2@9.0.5", "", { "dependencies": { "cli-truncate": "^5.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g=="],
@@ -232,7 +341,11 @@
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
     "merge-deep": ["merge-deep@3.0.3", "", { "dependencies": { "arr-union": "^3.1.0", "clone-deep": "^0.2.4", "kind-of": "^3.0.2" } }, "sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
@@ -242,9 +355,11 @@
 
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "node-gyp-build": ["node-gyp-build@3.9.0", "", { "bin": { "node-gyp-build": "./bin.js", "node-gyp-build-test": "./build-test.js", "node-gyp-build-optional": "./optional.js" } }, "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="],
 
@@ -255,6 +370,8 @@
     "oxc-parser": ["oxc-parser@0.121.0", "", { "dependencies": { "@oxc-project/types": "^0.121.0" }, "optionalDependencies": { "@oxc-parser/binding-android-arm-eabi": "0.121.0", "@oxc-parser/binding-android-arm64": "0.121.0", "@oxc-parser/binding-darwin-arm64": "0.121.0", "@oxc-parser/binding-darwin-x64": "0.121.0", "@oxc-parser/binding-freebsd-x64": "0.121.0", "@oxc-parser/binding-linux-arm-gnueabihf": "0.121.0", "@oxc-parser/binding-linux-arm-musleabihf": "0.121.0", "@oxc-parser/binding-linux-arm64-gnu": "0.121.0", "@oxc-parser/binding-linux-arm64-musl": "0.121.0", "@oxc-parser/binding-linux-ppc64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-gnu": "0.121.0", "@oxc-parser/binding-linux-riscv64-musl": "0.121.0", "@oxc-parser/binding-linux-s390x-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-gnu": "0.121.0", "@oxc-parser/binding-linux-x64-musl": "0.121.0", "@oxc-parser/binding-openharmony-arm64": "0.121.0", "@oxc-parser/binding-wasm32-wasi": "0.121.0", "@oxc-parser/binding-win32-arm64-msvc": "0.121.0", "@oxc-parser/binding-win32-ia32-msvc": "0.121.0", "@oxc-parser/binding-win32-x64-msvc": "0.121.0" } }, "sha512-ek9o58+SCv6AV7nchiAcUJy1DNE2CC5WRdBcO0mF+W4oRjNQfPO7b3pLjTHSFECpHkKGOZSQxx3hk8viIL5YCg=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
@@ -294,6 +411,8 @@
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "spark-md5": ["spark-md5@3.0.2", "", {}, "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
@@ -302,7 +421,13 @@
 
     "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -316,9 +441,27 @@
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
+    "@datadog/native-metrics/node-addon-api": ["node-addon-api@6.1.0", "", {}, "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="],
+
     "@datadog/wasm-js-rewriter/node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.2.3", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.4", "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.4" }, "bundled": true }, "sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "mixin-object/for-in": ["for-in@0.1.8", "", {}, "sha512-F0to7vbBSHP8E3l6dCjxNOLuSFAACIxFy3UehTUlG7svlXi37HHsDkyVcHo0Pq8QwrE+pXvWSVX3ZT1T9wAZ9g=="],
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -15,7 +15,6 @@ The example database is a small sampled subset (≈50 aircraft) so the app boots
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `AEROAPI_KEY` | No | FlightAware API key (fallback, not used by default) |
-| `SHEETS_API_KEY` | No | Google Sheets API key; unlocks the per-tail install-pipeline ingest (in-mod tails on `/fleet`) |
 | `PORT` | No | Server port (default: 3000) |
 | `NODE_ENV` | No | Set to "production" for production mode |
 
@@ -32,11 +31,34 @@ The example database is a small sampled subset (≈50 aircraft) so the app boots
 
 ### Development
 ```bash
-bun run dev              # Dev server with hot reload
+bun run dev              # Dev server with hot reload (recompiles CSS on source change)
 bun run start            # Production server
+bun run build:css        # Compile Tailwind → static/tailwind.css
 bun run lint             # Check code with Biome
 bun run format           # Auto-format
 ```
+
+### Styling
+
+Tailwind utilities are compiled from `src/styles/tailwind.css` by `bun run build:css`
+into `static/tailwind.css` — a build artifact, gitignored, produced by the Docker
+build (and by `dev`, `start`, `pretest`, `preview-hosts`). The server fingerprints
+it and serves it from `/static/tailwind.<hash>.css`; in production it refuses to
+boot if the file is missing, since an unstyled render fails no test.
+
+The practical consequence: a class only works if Tailwind's scanner can see it in
+`index.html` or under `src/`. Classes assembled at runtime (`` `text-${color}-500` ``)
+compile to nothing. `tests/stylesheet.test.ts` fails on any rendered class the
+scanner can't find, and separately asserts the served CSS actually contains rules
+for the utilities the pages render — a build that compiles to a valid but
+empty-of-utilities stylesheet leaves every page unstyled and would otherwise pass
+every other check.
+
+In `dev`, the recompile is **not** sequenced ahead of the server reload: `bun --watch`
+restarts the server on the same save that schedules the compile, so the server
+regularly comes up on the previous build. It absorbs that itself — outside
+production it re-reads `static/tailwind.css` whenever the file changes, so the
+compile is picked up on the next request instead of the next save.
 
 ### Data & Debugging
 ```bash

--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Rajdhani:wght@400;500;600;700&display=swap" rel="stylesheet">
 
-    <!-- Tailwind CSS via CDN -->
-    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
+    <!-- Compiled Tailwind (src/styles/tailwind.css) -->
+    {{stylesheetTag}}
 
     <style>
       * {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "ua-tracker",
   "scripts": {
-    "dev": "bun --watch server.ts",
-    "start": "bun server.ts",
+    "dev": "bun scripts/dev.ts",
+    "start": "bun run build:css && bun server.ts",
+    "build:css": "tailwindcss -i src/styles/tailwind.css -o static/tailwind.css --minify",
     "scrape": "bun run scrape.ts",
     "residential-sync": "bun run src/scripts/residential-sync.ts",
     "scrape-fr24": "PLAYWRIGHT_BROWSERS_PATH=./do_not_commit/playwright-browsers bun run src/scripts/flightradar24-scraper.ts",
@@ -21,11 +22,11 @@
     "surface-sweep": "bun run src/scripts/surface-sweep.ts",
     "seed-hawaiian": "PLAYWRIGHT_BROWSERS_PATH=./do_not_commit/playwright-browsers bun run src/scripts/seed-hawaiian.ts",
     "seed-alaska": "PLAYWRIGHT_BROWSERS_PATH=./do_not_commit/playwright-browsers bun run src/scripts/seed-alaska.ts",
-    "preview-hosts": "PLAYWRIGHT_BROWSERS_PATH=./do_not_commit/playwright-browsers bun scripts/preview-hosts.ts",
+    "preview-hosts": "bun run build:css && PLAYWRIGHT_BROWSERS_PATH=./do_not_commit/playwright-browsers bun scripts/preview-hosts.ts",
     "reset-flights": "bun run src/scripts/reset-flight-checks.ts",
+    "pretest": "bun run build:css",
     "test": "bun test tests/",
     "test:setup": "bash scripts/test-setup.sh",
-    "verify-citations": "bun run scripts/verify-citations.ts",
     "wifi-patch": "bun run src/scripts/verified-wifi-patch.ts",
     "lint": "biome check .",
     "format": "biome format --write .",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@tailwindcss/cli": "4.3.3",
     "@types/bun": "^1.2.22",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env bun
+/**
+ * Dev entrypoint: compiled Tailwind + hot-reloading server.
+ *
+ * Utilities are compiled ahead of time now (see src/styles/tailwind.css), so a
+ * class typed into a component is invisible until the CSS is rebuilt. That is
+ * the one ergonomic cost of dropping the browser JIT, and this script pays it:
+ * every change under src/ or to index.html schedules a rebuild.
+ *
+ * The rebuild is NOT sequenced ahead of the server reload and can't be — the
+ * server is a separate `bun --watch` child with its own watcher, and it
+ * restarts on the same fs event this script debounces. The server absorbs the
+ * race instead: outside production it re-reads the compiled file whenever its
+ * mtime changes (currentStylesheetTag in src/server/app.ts), so a compile
+ * landing after the restart is picked up on the next request rather than the
+ * next save. Editing index.html, which restarts nothing, works the same way.
+ *
+ * The rebuild is a one-shot CLI run rather than `tailwindcss --watch` on
+ * purpose — watch mode needs @parcel/watcher's build-from-source postinstall,
+ * which is not worth adding to a dependency chain that also installs in Docker.
+ * A full compile is ~50ms.
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const ROOT = path.join(import.meta.dir, "..");
+const TAILWIND_BIN = path.join(ROOT, "node_modules", ".bin", "tailwindcss");
+const WATCH_TARGETS = [path.join(ROOT, "src"), path.join(ROOT, "index.html")];
+
+function buildCss(): void {
+  const started = performance.now();
+  const result = spawnSync(
+    TAILWIND_BIN,
+    ["-i", "src/styles/tailwind.css", "-o", "static/tailwind.css", "--minify"],
+    { cwd: ROOT, stdio: ["ignore", "ignore", "inherit"] }
+  );
+  if (result.status !== 0) {
+    console.error("[dev] tailwind build failed — pages will render unstyled");
+    return;
+  }
+  console.log(`[dev] css rebuilt in ${Math.round(performance.now() - started)}ms`);
+}
+
+buildCss();
+
+// Coalesce the burst of events a single editor save produces into one compile.
+let pending: ReturnType<typeof setTimeout> | null = null;
+function scheduleBuild(filename: string | null): void {
+  if (filename && !/\.(tsx?|html|css)$/.test(filename)) return;
+  if (pending) clearTimeout(pending);
+  pending = setTimeout(() => {
+    pending = null;
+    buildCss();
+  }, 120);
+}
+
+for (const target of WATCH_TARGETS) {
+  if (!fs.existsSync(target)) continue;
+  fs.watch(target, { recursive: fs.statSync(target).isDirectory() }, (_event, filename) =>
+    scheduleBuild(filename)
+  );
+}
+
+const server = spawn("bun", ["--watch", "server.ts"], { cwd: ROOT, stdio: "inherit" });
+server.on("exit", (code) => process.exit(code ?? 0));
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.on(signal, () => server.kill(signal));
+}

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -352,6 +352,84 @@ for (const p of SOCIAL_IMAGE_PATHS) {
   }
 }
 
+
+/**
+ * Compiled Tailwind, fingerprinted and registered as a tenant-agnostic asset.
+ *
+ * The file is a build artifact (`bun run build:css`), never committed, so it is
+ * regenerated from whatever markup the image actually contains — a branch that
+ * adds a page can't be served a previous build's CSS. The content hash in the
+ * URL extends that guarantee to browser caches: markup and stylesheet are
+ * versioned together, which a fixed `/static/tailwind.css` under any real
+ * max-age could not do.
+ *
+ * Missing output is fatal in production. An unstyled render is invisible to
+ * every test and to health checks, so failing the boot (deploy rolls back,
+ * previous container keeps serving) is the only failure mode anyone notices.
+ */
+const STYLESHEET_PATH = path.join(STATIC_DIR, "tailwind.css");
+
+/** mtime+size of the compiled file, "" when it isn't there. */
+function stylesheetStamp(): string {
+  try {
+    const s = fs.statSync(STYLESHEET_PATH);
+    return `${s.mtimeMs}:${s.size}`;
+  } catch {
+    return "";
+  }
+}
+
+let stylesheetHref = "";
+let stylesheetTag = "";
+let registeredStamp = "";
+
+function registerStylesheet(): void {
+  const stamp = stylesheetStamp();
+  registeredStamp = stamp;
+  if (!stamp) {
+    const msg = `Compiled stylesheet missing at ${STYLESHEET_PATH} — run \`bun run build:css\``;
+    if (process.env.NODE_ENV === "production") throw new Error(msg);
+    logError(msg);
+    stylesheetHref = "";
+    stylesheetTag = "";
+    return;
+  }
+  const css = fs.readFileSync(STYLESHEET_PATH);
+  const href = `/static/tailwind.${Bun.hash(css).toString(36)}.css`;
+  // Drop the superseded URL so a stale fingerprint 404s instead of serving the
+  // build the markup no longer matches — the same contract as a fresh deploy.
+  if (stylesheetHref && stylesheetHref !== href) staticResponses.delete(stylesheetHref);
+  staticResponses.set(
+    href,
+    new Response(css, {
+      headers: {
+        ...BASE_RESPONSE_HEADERS,
+        "Content-Type": "text/css; charset=utf-8",
+        "Cache-Control": "public, max-age=31536000, immutable",
+      },
+    })
+  );
+  stylesheetHref = href;
+  stylesheetTag = `<link rel="stylesheet" href="${href}">`;
+}
+registerStylesheet();
+
+/**
+ * Production registers once at boot — the artifact cannot change under a
+ * running container, and re-statting per request would buy nothing.
+ *
+ * Dev must re-read. `bun run dev` recompiles the CSS out-of-band while this
+ * process is already running (`bun --watch` restarts on the source edit; the
+ * compile finishes after), so a boot-time capture would serve the pre-edit
+ * build until the *next* save — a newly typed utility appearing one save late
+ * is exactly the hazard compiling ahead of time introduced.
+ */
+function currentStylesheetTag(): string {
+  if (process.env.NODE_ENV === "production") return stylesheetTag;
+  if (stylesheetStamp() !== registeredStamp) registerStylesheet();
+  return stylesheetTag;
+}
+
 // A tenant whose OG card hasn't been generated yet (QR is excluded from
 // /api/fleet-summary, so generate-og-images never renders one) gets the
 // neutral hub card — never another airline's. Checked live, not at boot, so a
@@ -2177,6 +2255,7 @@ function buildBaseTemplateVars(
     ...brandVars,
     ...statVars,
     socialImagePath: resolveSocialImage(brand),
+    stylesheetTag: currentStylesheetTag(),
     html: reactHtml,
     host: site.canonicalHost,
     canonicalPath: escapeHtmlAttr(canonicalPath),

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,0 +1,34 @@
+/* Tailwind source. `bun run build:css` compiles this to static/tailwind.css,
+   which the server fingerprints and serves itself.
+
+   Everything here lands in @layer utilities (and theme/base), so the unlayered
+   rules in index.html's <style> block keep winning every name they share —
+   the same precedence the browser JIT gave them, and the reason the link tag's
+   position relative to that block does not matter.
+
+   The output is a BUILD ARTIFACT, never committed. Compiling utilities ahead of
+   time flips the old CDN invariant "any class works anywhere at runtime" into
+   "the CSS must be rebuilt whenever markup changes" — so the rebuild is wired
+   into the Docker build and `bun run dev` rather than checked in. A committed
+   .css would go stale the moment a branch adding new markup merged after it,
+   and nothing in the test suite can see unstyled HTML.
+
+   No @theme block on purpose. ~15 classes in the markup name custom colors
+   (bg-accent/20, text-subtle, placeholder-muted, …) that Tailwind has never
+   known about, so they emit nothing today and must keep emitting nothing here
+   or the visuals change. Defining those tokens is a separate, deliberate
+   change — not a side effect of moving off the CDN. */
+@import "tailwindcss";
+
+/* Explicit, so the scan can never drift with the CSS file's location. Every
+   rendered class comes from a component under src/ or from the page shell. */
+@source "../../index.html";
+@source "../../src";
+
+/* These add to Tailwind's automatic project scan rather than replacing it, so
+   tests/ is swept too — and a class-shaped string in a test file lands in the
+   shipped stylesheet. Measured: adding a `w-1/2` example to a comment in
+   tests/stylesheet.test.ts grew the artifact by 44 B of rules no page uses.
+   Excluding tests keeps the output a function of what actually renders, which
+   is what makes the build reproducible across machines. */
+@source not "../../tests";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -69,7 +69,9 @@ const probeOrigins = process.env.PASSENGER_VERIFY === "off" ? [] : PROBE_CONNECT
 const { scriptOrigins: ANALYTICS_SCRIPT_ORIGINS, connectOrigins: ANALYTICS_CONNECT_ORIGINS } =
   analyticsOrigins();
 const CONNECT_SRC = ["'self'", ...probeOrigins, ...ANALYTICS_CONNECT_ORIGINS].join(" ");
-const SCRIPT_SRC = ["'self'", "'unsafe-inline'", "https://unpkg.com", ...ANALYTICS_SCRIPT_ORIGINS]
+// No third-party script origin: Tailwind is compiled at build time and served
+// from this origin, so nothing but analytics loads code from off-site.
+const SCRIPT_SRC = ["'self'", "'unsafe-inline'", ...ANALYTICS_SCRIPT_ORIGINS]
   .filter(Boolean)
   .join(" ");
 
@@ -98,7 +100,7 @@ export const SECURITY_HEADERS = {
     ...BASE_RESPONSE_HEADERS,
     ...API_CORS_HEADERS,
     "Content-Type": "application/json",
-    "Content-Security-Policy": `default-src 'self' https://unpkg.com; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*;`,
+    "Content-Security-Policy": `default-src 'self'; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*;`,
     "Cache-Control": "no-store, max-age=0",
   },
   html: {
@@ -107,7 +109,7 @@ export const SECURITY_HEADERS = {
     // Rendered HTML varies by client IP (passenger banner/probe) — never let
     // an edge cache serve one visitor's render to another.
     "Cache-Control": "private, no-store",
-    "Content-Security-Policy": `default-src 'self' https://unpkg.com; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;`,
+    "Content-Security-Policy": `default-src 'self'; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;`,
   },
   notFound: {
     ...BASE_RESPONSE_HEADERS,
@@ -122,19 +124,6 @@ export const SECURITY_HEADERS = {
     "Content-Security-Policy":
       "default-src 'self'; style-src 'unsafe-inline' https://fonts.googleapis.com; " +
       "font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;",
-  },
-  // A 404 that still renders a real, interactive page: the html CSP (the inline
-  // lookup script needs it) with notFound's edge cache policy. /check-flight/*
-  // is an unbounded URL space — any typo, airport code or stale link lands
-  // there — and under the html variant's `private, no-store` every crawler hit
-  // was a full ReactDOMServer render at origin. Callers MUST blank the
-  // per-visitor slots (passengerProbeSnippet) before using it; anything that
-  // varies by client IP belongs on `html`.
-  notFoundHtml: {
-    ...BASE_RESPONSE_HEADERS,
-    "Content-Type": "text/html",
-    "Cache-Control": "public, s-maxage=3600, max-age=0, must-revalidate",
-    "Content-Security-Policy": `default-src 'self' https://unpkg.com; connect-src ${CONNECT_SRC}; script-src ${SCRIPT_SRC}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:;`,
   },
 };
 

--- a/tests/stylesheet.test.ts
+++ b/tests/stylesheet.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Compiled-Tailwind invariants.
+ *
+ * Dropping the browser JIT traded "any class works at runtime" for "the CSS is
+ * compiled from what the scanner can see in the sources". These tests pin the
+ * two halves of that trade: pages must load exactly one same-origin, content-
+ * hashed stylesheet and nothing third-party, and no class may reach the browser
+ * that the compiler had no way to find.
+ *
+ * The page list comes from the live sitemap, so a branch that adds a page gets
+ * covered without touching this file.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { analyticsOrigins } from "../src/airlines/registry";
+import { createApp } from "../src/server/app";
+import { bodyOf, openSnapshot, req } from "./helpers";
+
+const HOST = "unitedstarlinktracker.com";
+const ROOT = join(import.meta.dir, "..");
+// Analytics is the one sanctioned off-origin script. Read from the registry so
+// self-hosting it (or dropping it) can't turn this into a false failure.
+const ALLOWED_SCRIPT_ORIGINS = analyticsOrigins().scriptOrigins;
+
+let app: ReturnType<typeof createApp>;
+
+/** Everything Tailwind's `@source` directives scan (src/styles/tailwind.css). */
+function scannedSources(): string {
+  const parts: string[] = [readFileSync(join(ROOT, "index.html"), "utf8")];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (/\.(tsx?|css|html)$/.test(entry)) parts.push(readFileSync(full, "utf8"));
+    }
+  };
+  walk(join(ROOT, "src"));
+  return parts.join("\n");
+}
+
+/** One representative URL per top-level path shape the sitemap advertises. */
+async function sitemapPageShapes(): Promise<string[]> {
+  const { status, text } = await bodyOf(app, "/sitemap.xml", HOST);
+  expect(status).toBe(200);
+  const paths = [...text.matchAll(/<loc>https?:\/\/[^/]+([^<]*)<\/loc>/g)].map((m) => m[1] || "/");
+  expect(paths.length).toBeGreaterThan(0);
+  const byShape = new Map<string, string>();
+  for (const p of paths) {
+    const shape = p.split("/").slice(0, 2).join("/") || "/";
+    if (!byShape.has(shape)) byShape.set(shape, p);
+  }
+  return [...byShape.values()];
+}
+
+/** Class names any inline <style> in the response defines itself. */
+function inlineStyleClasses(html: string): Set<string> {
+  const out = new Set<string>();
+  for (const block of html.matchAll(/<style[^>]*>([\s\S]*?)<\/style>/g)) {
+    for (const m of block[1].matchAll(/\.(-?[A-Za-z_][\w-]*)/g)) out.add(m[1]);
+  }
+  return out;
+}
+
+function classTokens(html: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of html.matchAll(/\sclass="([^"]*)"/g)) {
+    for (const t of m[1].split(/\s+/)) if (t) out.add(t);
+  }
+  return out;
+}
+
+async function stylesheetHref(): Promise<string> {
+  const { text: home } = await bodyOf(app, "/", HOST);
+  const href = home.match(/href="(\/static\/tailwind\.[a-z0-9]+\.css)"/)?.[1];
+  expect(href).toBeTruthy();
+  return href as string;
+}
+
+/** The stylesheet the pages actually link, fetched over the app the way a
+ * browser would — not read off disk, so this pins what is delivered. */
+async function servedCss(): Promise<string> {
+  const res = await app.dispatch(req(await stylesheetHref(), HOST));
+  expect(res.status).toBe(200);
+  return await res.text();
+}
+
+/** Tailwind escapes every character outside [A-Za-z0-9_-] in a class selector:
+ * `md:grid-cols-3` → `.md\:grid-cols-3`, `w-1/2` → `.w-1\/2`,
+ * `bg-[var(--color-accent)]` → `.bg-\[var\(--color-accent\)\]`. */
+const escapedSelector = (token: string) => `.${token.replace(/[^A-Za-z0-9_-]/g, (c) => `\\${c}`)}`;
+
+const SCALED = "(p|m|px|py|pt|pb|pl|pr|mx|my|mt|mb|gap|w|h|max-w|min-h|space-x|space-y|rounded)";
+const STOCK_UTILITY = [
+  new RegExp(`^${SCALED}-(\\d+(\\.5)?|auto|full|px)$`),
+  /^(grid-cols|col-span|order|z)-\d+$/,
+  /^(flex|grid|block|hidden|inline-flex|inline-block|relative|absolute|border|underline|uppercase|truncate|italic)$/,
+  /^text-(xs|sm|base|lg|xl|[2-9]xl)$/,
+  /^font-(bold|semibold|medium|normal|mono)$/,
+  /^[a-z-]+-\[[^\]]+\]$/,
+];
+
+/**
+ * Utilities Tailwind is guaranteed to emit when extraction works, recognised by
+ * shape rather than from a hardcoded list — new markup widens the sample instead
+ * of dating this file.
+ *
+ * Custom color and font names (text-primary, bg-accent/20, font-display) are
+ * deliberately outside the set: they name tokens Tailwind has never had, they
+ * compile to nothing on purpose (see src/styles/tailwind.css), and index.html
+ * defines them itself.
+ */
+function isStockUtility(token: string): boolean {
+  const bare = token.replace(/^(sm|md|lg|xl|2xl|hover|focus):/, "");
+  return STOCK_UTILITY.some((re) => re.test(bare));
+}
+
+beforeAll(() => {
+  app = createApp(openSnapshot());
+});
+
+describe("stylesheet delivery", () => {
+  test("every page links exactly one same-origin, content-hashed stylesheet", async () => {
+    for (const path of await sitemapPageShapes()) {
+      const { status, text } = await bodyOf(app, path, HOST);
+      expect(status).toBe(200);
+      const links = [...text.matchAll(/<link[^>]+rel="stylesheet"[^>]*>/g)].map((m) => m[0]);
+      const local = links.filter((l) => l.includes("/static/tailwind."));
+      expect({ path, count: local.length }).toEqual({ path, count: 1 });
+      expect(local[0]).toMatch(/href="\/static\/tailwind\.[a-z0-9]+\.css"/);
+    }
+  });
+
+  test("no page loads script or style from a third-party origin", async () => {
+    for (const path of await sitemapPageShapes()) {
+      const { text } = await bodyOf(app, path, HOST);
+      const scriptSrcs = [...text.matchAll(/<script[^>]+src="([^"]+)"/g)].map((m) => m[1]);
+      const foreign = scriptSrcs.filter(
+        (s) => /^https?:\/\//.test(s) && !ALLOWED_SCRIPT_ORIGINS.includes(new URL(s).origin)
+      );
+      expect({ path, foreign }).toEqual({ path, foreign: [] });
+      expect(text).not.toContain("unpkg.com");
+    }
+  });
+
+  test("the hashed URL serves immutable CSS and is content-addressed", async () => {
+    const { text: home } = await bodyOf(app, "/", HOST);
+    const href = home.match(/href="(\/static\/tailwind\.[a-z0-9]+\.css)"/)?.[1];
+    expect(href).toBeTruthy();
+
+    const res = await app.dispatch(req(href as string, HOST));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("text/css");
+    expect(res.headers.get("Cache-Control")).toContain("immutable");
+    const css = await res.text();
+    expect(css.length).toBeGreaterThan(1000);
+    expect(css).toContain("@layer");
+
+    // A different fingerprint must not resolve — the URL names one build, so a
+    // deploy can never be served the previous build's CSS from a cache.
+    const stale = href?.replace(/tailwind\.[a-z0-9]+\./, "tailwind.deadbeef.");
+    expect((await app.dispatch(req(stale as string, HOST))).status).toBe(404);
+  });
+
+  // `bun run dev` compiles the CSS in a different process from the `bun --watch`
+  // server, and nothing sequences them: the server restarts on the source edit
+  // while the compile is still debounced, so it routinely boots on the previous
+  // build. A fingerprint captured once at boot would then serve the pre-edit CSS
+  // until the *next* save — a new utility appearing one save late.
+  test("outside production a recompile is served without a restart", async () => {
+    const cssPath = join(ROOT, "static", "tailwind.css");
+    const original = readFileSync(cssPath);
+    const before = await stylesheetHref();
+    try {
+      writeFileSync(cssPath, `${original}\n.compiled-css-refresh-probe{color:red}\n`);
+      const after = await stylesheetHref();
+      expect(after).not.toBe(before);
+
+      const fresh = await app.dispatch(req(after, HOST));
+      expect(fresh.status).toBe(200);
+      expect(await fresh.text()).toContain(".compiled-css-refresh-probe");
+
+      // The superseded fingerprint stops resolving, so nothing can be handed
+      // the build its markup no longer matches.
+      expect((await app.dispatch(req(before, HOST))).status).toBe(404);
+    } finally {
+      writeFileSync(cssPath, original);
+    }
+    expect(await stylesheetHref()).toBe(before);
+  });
+
+  test("CSP allows no third-party script origin beyond analytics", async () => {
+    const res = await app.dispatch(req("/", HOST));
+    const csp = res.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).not.toContain("unpkg.com");
+    const scriptSrc = csp.match(/script-src ([^;]+)/)?.[1] ?? "";
+    const remoteOrigins = scriptSrc.split(/\s+/).filter((s) => s.startsWith("http"));
+    expect(remoteOrigins).toEqual(ALLOWED_SCRIPT_ORIGINS);
+  });
+});
+
+describe("compiler coverage", () => {
+  /**
+   * The delivery tests above pass on a stylesheet that styles nothing: a build
+   * scoped to no sources (`@import "tailwindcss" source(none)`) is 4,165 bytes
+   * and contains `@layer`, clearing every length, hashing and CSP assertion
+   * while every page renders unstyled. This is the assertion that fails on it —
+   * a dropped `@source`, a broken extractor or a theme-only build all land here.
+   */
+  test("the served CSS carries rules for the utilities the pages render", async () => {
+    const css = await servedCss();
+    const sampled: string[] = [];
+    const misses: string[] = [];
+    for (const path of await sitemapPageShapes()) {
+      const { text } = await bodyOf(app, path, HOST);
+      const inline = inlineStyleClasses(text);
+      const stock = [...classTokens(text)].filter((t) => !inline.has(t) && isStockUtility(t));
+      // An empty sample would make the miss check vacuous, and a page that
+      // renders no stock utility at all is itself the regression.
+      expect({ path, sampledUtilities: stock.length > 0 }).toEqual({
+        path,
+        sampledUtilities: true,
+      });
+      sampled.push(...stock);
+      for (const t of stock) {
+        if (!css.includes(escapedSelector(t))) misses.push(`${path}: ${t}`);
+      }
+    }
+    expect(misses).toEqual([]);
+
+    // Three compilation paths that break independently — plain utilities,
+    // responsive variants, arbitrary values — must each stay in the sample, or
+    // shrinking markup could quietly narrow what the check above proves.
+    expect({
+      plain: sampled.some((t) => !t.includes(":") && !t.includes("[")),
+      variant: sampled.some((t) => /^(sm|md|lg|xl|2xl):/.test(t)),
+      arbitrary: sampled.some((t) => t.includes("[")),
+    }).toEqual({ plain: true, variant: true, arbitrary: true });
+  });
+
+  test("no rendered class is invisible to the source scanner", async () => {
+    const sources = scannedSources();
+    const misses: string[] = [];
+    for (const path of await sitemapPageShapes()) {
+      const { text } = await bodyOf(app, path, HOST);
+      const local = inlineStyleClasses(text);
+      for (const token of classTokens(text)) {
+        // A class is safe if Tailwind's scanner can find it verbatim in a file
+        // it reads, or if the page ships its own rule for it. A class built at
+        // runtime (`text-${x}-500`) satisfies neither and would silently lose
+        // its styling — that is exactly what this catches.
+        if (!sources.includes(token) && !local.has(token)) misses.push(`${path}: ${token}`);
+      }
+    }
+    expect(misses).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Compile Tailwind at build time (`bun run build:css`) and serve a fingerprinted `/static/tailwind.*.css`.
- Remove render-blocking `unpkg.com/@tailwindcss/browser@4` from `index.html` and CSP.
- Dockerfile runs `build:css`; production boot fails if the stylesheet is missing.
- Dev re-reads CSS when the artifact changes.

Surgically taken from `seo/seo-tailwind-compiled` **without** the commit that reverted PR #75. Invalid check-flight segments still get the honest 404 + form.

## Test plan
- [ ] `bun run build:css` produces `static/tailwind.css`
- [ ] HTML includes `<link rel="stylesheet" href="/static/tailwind.…">`, no unpkg script
- [ ] `/check-flight/TEST` still 404 + explanatory form (PR #75)
- [ ] `tests/stylesheet.test.ts` green