### PR TITLE
fix(seo): permalink titles drop retired routes; show last-seen

### DIFF
--- a/src/components/check-flight-page.tsx
+++ b/src/components/check-flight-page.tsx
@@ -8,6 +8,8 @@ export interface FlightRouteFact {
   arrival_airport: string;
   times: number;
   dur_sec: number | null;
+  /** Newest evidence for this leg (unix seconds); null when the row carries none. */
+  last_seen_at: number | null;
 }
 
 export interface FlightUpcomingDeparture {
@@ -90,6 +92,15 @@ function flightSummary(flight: FlightFacts): string {
   return `Pick a date below for a live answer based on the aircraft assigned to ${flightNumber}.`;
 }
 
+/** The list is ordered by how recently each leg was seen, so the date is the
+ * evidence behind the order — and the honest hedge on the heading's present
+ * tense, since a leg's silence is what makes it a route the number *flew*.
+ * A future timestamp is a corrupt row, not a date to show. */
+function lastSeenLabel(sec: number | null): string | null {
+  if (!sec || sec * 1000 > Date.now()) return null;
+  return `last seen ${fmtDay(sec)}`;
+}
+
 function FlightFactBlocks({ flight }: { flight: FlightFacts }) {
   const fn = flight.flightNumber;
   const hasHistory =
@@ -102,29 +113,33 @@ function FlightFactBlocks({ flight }: { flight: FlightFacts }) {
             Routes {fn} flies
           </h2>
           <div className="space-y-2">
-            {flight.routes.map((r) => (
-              <div
-                key={`${r.departure_airport}-${r.arrival_airport}`}
-                className="flex items-center justify-between gap-3 text-sm font-mono"
-              >
-                <span className="text-secondary">
-                  {r.departure_airport} → {r.arrival_airport}
-                  {r.dur_sec ? (
-                    <span className="text-muted"> · {fmtDuration(r.dur_sec)}</span>
-                  ) : null}
-                  <span className="text-muted">
-                    {" "}
-                    · seen {r.times} time{r.times === 1 ? "" : "s"}
-                  </span>
-                </span>
-                <a
-                  href={`/route-planner/${r.departure_airport}/${r.arrival_airport}`}
-                  className="text-accent hover:underline text-xs whitespace-nowrap"
+            {flight.routes.map((r) => {
+              const lastSeen = lastSeenLabel(r.last_seen_at);
+              return (
+                <div
+                  key={`${r.departure_airport}-${r.arrival_airport}`}
+                  className="flex items-center justify-between gap-3 text-sm font-mono"
                 >
-                  Plan this route →
-                </a>
-              </div>
-            ))}
+                  <span className="text-secondary">
+                    {r.departure_airport} → {r.arrival_airport}
+                    {r.dur_sec ? (
+                      <span className="text-muted"> · {fmtDuration(r.dur_sec)}</span>
+                    ) : null}
+                    <span className="text-muted">
+                      {" "}
+                      · seen {r.times} time{r.times === 1 ? "" : "s"}
+                    </span>
+                    {lastSeen ? <span className="text-muted"> · {lastSeen}</span> : null}
+                  </span>
+                  <a
+                    href={`/route-planner/${r.departure_airport}/${r.arrival_airport}`}
+                    className="text-accent hover:underline text-xs whitespace-nowrap"
+                  >
+                    Plan this route →
+                  </a>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}

--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -2453,48 +2453,131 @@ export interface FlightRoutePair {
   dur_sec: number | null;
   /** 1 when the leg appears in the live schedule window, 0 when it is only history. */
   scheduled: number;
+  /** Newest evidence for this leg (unix seconds); null when the row carries no timestamp. */
+  last_seen_at: number | null;
 }
 
-/** Route pairs a flight number flies, currently-scheduled legs first and
- * most-flown within that — the accumulated flight_routes cache unioned with the
- * live upcoming_flights window (which covers legs the cache hasn't recorded yet).
+/** Grace period: a leg silent for less than this is not discounted at all.
  *
- * Ordering leads with `scheduled` rather than raw frequency because
+ * Sized against how last_seen_at is actually produced, which is NOT "whenever the
+ * leg is on the schedule": cacheFlightRoute is reached only from updateFlights and
+ * the MCP FR24 lookup, and every updateFlights caller iterates a Starlink-equipped
+ * roster (flight-updater over starlink_planes, fleet-discovery's confirmed
+ * branches). A leg re-stamps only when one of the ~33% of UA tails that carry
+ * Starlink happens to be assigned to it inside the ~47h window (546/1651
+ * fleet-wide, 202/1146 mainline, measured 2026-08-29).
+ *
+ * That per-day stamping rate varies by subfleet — mainline is the worst case at
+ * 17.6%, express is far denser — so the grace period is sized off the worst case
+ * and is therefore conservative for everything else: at 17.6% a daily leg goes a
+ * full week unstamped 26% of the time (0.824^7) but a full month only 0.3% of the
+ * time (0.824^30). A week-long window would demote live mainline routes on
+ * ordinary sampling gaps; a month does not. */
+const ROUTE_GRACE_SEC = 30 * 24 * 60 * 60;
+
+/** Past the grace period, each of these halves a leg's evidence.
+ *
+ * Deliberately slower than the sampling model alone justifies — at 17.6% daily
+ * stamping two months of silence already runs ~1e-5 against "still flown daily"
+ * (0.824^60) — because the two error directions are not symmetric: seen_count
+ * only ever grows, so wrongly demoting a live leg corrects itself the next time a
+ * Starlink tail draws it, while wrongly promoting a dead one persists. */
+const ROUTE_STALE_HALF_LIFE_SEC = 15 * 24 * 60 * 60;
+
+/** Floor on the staleness discount: how much of a silent leg's evidence survives,
+ * however long the silence runs. Without it, staleness alone eventually decides
+ * and a lone sighting titles the page — the failure the discount exists to avoid.
+ * With it, a leg still being seen leads a silent one only on evidence of its own:
+ * it needs more than an eighth of the silent leg's observations. */
+const ROUTE_MIN_STALE_WEIGHT = 1 / 8;
+
+const MAX_ROUTE_PAIRS = 4;
+
+/** Route pairs a flight number flies, scheduled legs first and best-evidenced
+ * within that — the accumulated flight_routes cache unioned with the live
+ * upcoming_flights window (which covers legs the cache hasn't recorded yet).
+ *
+ * Evidence is frequency discounted by silence, not frequency alone, because
  * flight_routes.seen_count accumulates for the life of a flight number. When a
- * number is reassigned to a new city pair, the retired leg keeps out-counting
- * the current one indefinitely, so callers that take routes[0] as "the" route —
- * page titles, meta descriptions, Flight JSON-LD — would advertise a route the
- * flight no longer flies. */
+ * number is reassigned to a new city pair, the retired leg keeps out-counting the
+ * current one indefinitely, so callers that take routes[0] as "the" route — page
+ * titles, meta descriptions, Flight JSON-LD — would advertise a route the flight
+ * no longer flies.
+ *
+ * A live upcoming_flights row is proof of currency and wins outright. Failing
+ * that (the window only reaches ~47h ahead, so a number with no near-term
+ * assignment has none), route-cache staleness discounts frequency:
+ * score = times x weight(silence), weight decaying from 1 to
+ * ROUTE_MIN_STALE_WEIGHT. Staleness is measured from `now`, never from the
+ * number's own freshest leg — anchored to the number, some leg is always "recent"
+ * by construction and a single diversion recorded an hour ago would outrank the
+ * daily route.
+ *
+ * A discount rather than a tier because a tier is a knife edge: with a binary
+ * cutoff a page's title, meta description and JSON-LD flip the instant a leg
+ * crosses 30 days unstamped, no matter how lopsided the counts, and flip back on
+ * the next stamp. Discounting makes the promoted leg pay for the promotion in its
+ * own observations, and makes the crossing gradual instead of instantaneous:
+ * between the grace period and the floor the weight ramps down, so legs whose
+ * counts are close change places while lopsided ones never do.
+ *
+ * Demotes rather than filters — a hard cutoff would leave cold-tail permalinks
+ * with no route at all for the title and JSON-LD. */
 export function getFlightRoutePairs(
   db: Database,
   variants: string[],
-  airline?: AirlineFilter
+  airline?: AirlineFilter,
+  now = Math.floor(Date.now() / 1000)
 ): FlightRoutePair[] {
   const placeholders = variants.map(() => "?").join(",");
   const upcoming = withAirline(
     `SELECT departure_airport, arrival_airport, COUNT(*) AS times,
             CAST(AVG(arrival_time - departure_time) AS INTEGER) AS dur_sec,
-            1 AS scheduled
+            1 AS scheduled, MAX(last_updated) AS last_seen_at
      FROM upcoming_flights WHERE flight_number IN (${placeholders})`,
     airline,
     "",
     [...variants]
   );
-  return db
+  const rows = db
     .query(
       `SELECT departure_airport, arrival_airport, SUM(times) AS times, MAX(dur_sec) AS dur_sec,
-              MAX(scheduled) AS scheduled
+              MAX(scheduled) AS scheduled, MAX(last_seen_at) AS last_seen_at
        FROM (
          SELECT origin AS departure_airport, destination AS arrival_airport,
-                seen_count AS times, duration_sec AS dur_sec, 0 AS scheduled
+                seen_count AS times, duration_sec AS dur_sec, 0 AS scheduled,
+                last_seen_at
          FROM flight_routes WHERE flight_number IN (${placeholders})
          UNION ALL
          ${upcoming.sql} GROUP BY departure_airport, arrival_airport
        )
+       -- An origin that equals its destination is a source artifact (returns and
+       -- diversions come back logged as A->A), never a route. Dropping it here
+       -- keeps it out of titles and JSON-LD, and out of the /route-planner/A/A
+       -- link the permalink builds per row, which 404s by design.
+       WHERE departure_airport <> arrival_airport
        GROUP BY departure_airport, arrival_airport
-       ORDER BY scheduled DESC, times DESC LIMIT 4`
+       ORDER BY scheduled DESC, times DESC`
     )
     .all(...variants, ...upcoming.params) as FlightRoutePair[];
+
+  // A timestamp ahead of now is corrupt, not fresh (the test snapshot carries one
+  // dated 2036). Counted as evidence it would pin a junk row to routes[0] forever,
+  // since no amount of elapsed time ever catches up to it — so it counts as none.
+  const silence = (r: FlightRoutePair) => {
+    const t = r.last_seen_at ?? 0;
+    return t > now ? now : now - t;
+  };
+  const score = (r: FlightRoutePair) => {
+    if (r.scheduled === 1) return r.times;
+    const stale = Math.max(0, silence(r) - ROUTE_GRACE_SEC);
+    const weight = Math.max(2 ** (-stale / ROUTE_STALE_HALF_LIFE_SEC), ROUTE_MIN_STALE_WEIGHT);
+    return r.times * weight;
+  };
+
+  return rows
+    .sort((a, b) => b.scheduled - a.scheduled || score(b) - score(a) || b.times - a.times)
+    .slice(0, MAX_ROUTE_PAIRS);
 }
 
 export interface FlightHistorySummary {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -361,7 +361,6 @@ for (const p of SOCIAL_IMAGE_PATHS) {
   }
 }
 
-
 /**
  * Compiled Tailwind, fingerprinted and registered as a tenant-agnostic asset.
  *

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2640,7 +2640,7 @@ const checkFlightPage: Handler = (ctx) => {
       "/check-flight",
       { ...subPageMeta(ctx, "check-flight"), robotsMeta: "noindex, nofollow" },
       { invalid },
-      { edgeCacheable404: true }
+      404
     );
   if (parsed.kind === "invalid") {
     const query = echoQuery(parsed.raw);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2492,11 +2492,17 @@ function buildFlightFacts(
 ): FlightFacts {
   const history = reader.getFlightHistorySummary(variants);
   // Airport codes feed markup and JSON-LD; only use rows that look like real
-  // IATA/ICAO codes.
+  // IATA/ICAO codes. Each row also renders a /route-planner/{from}/{to} link,
+  // which parseRoutePath rejects when the two match, so a same-airport row would
+  // put a guaranteed 404 in the page — getFlightRoutePairs drops those, and this
+  // keeps the invariant local to the code that builds the link.
   const routes = reader
     .getFlightRoutePairs(variants)
     .filter(
-      (r) => AIRPORT_CODE_RE.test(r.departure_airport) && AIRPORT_CODE_RE.test(r.arrival_airport)
+      (r) =>
+        AIRPORT_CODE_RE.test(r.departure_airport) &&
+        AIRPORT_CODE_RE.test(r.arrival_airport) &&
+        r.departure_airport !== r.arrival_airport
     );
   const now = Math.floor(Date.now() / 1000);
   const upcoming = reader

--- a/tests/flight-route-pairs.test.ts
+++ b/tests/flight-route-pairs.test.ts
@@ -7,10 +7,20 @@
  * JSON-LD), so a currently-scheduled leg must sort ahead of a heavier historical
  * one — otherwise every permalink for a reassigned flight advertises a route it
  * no longer flies.
+ *
+ * The live upcoming_flights window only reaches ~47h ahead, so most permalinks
+ * have no scheduled leg at all and fall through to the route cache. These cover
+ * that fallback too, where silence only *discounts* frequency: last_seen_at
+ * stamps just when a Starlink-equipped tail happens to draw the leg, so silence
+ * is noisy evidence and a leg has to out-earn the discount to take routes[0].
+ * The negative cases below — a lone sighting against hundreds, a heavy leg one
+ * second past the grace period, legs that are all ancient, corrupt future
+ * timestamps — matter as much as the reassignment case: each is a way the
+ * ordering could invent a wrong title for a permalink main gets right.
  */
 
 import { describe, expect, test } from "bun:test";
-import { cacheFlightRoute, getFlightRoutePairs } from "../src/database/database";
+import { getFlightRoutePairs } from "../src/database/database";
 import { makeSyntheticDb, utc } from "./helpers";
 
 function seedReassignedFlight() {
@@ -98,52 +108,177 @@ describe("getFlightRoutePairs ordering", () => {
   });
 });
 
-/**
- * The cacheFlightRoute write edge.
- *
- * flight_routes is written from caller-supplied lookup input (MCP/API) and
- * enumerated by the sitemap, so this guard is the only thing standing between
- * an arbitrary caller string and an advertised permalink the router 404s. It
- * is also the only thing that can silently DROP a real operating-carrier
- * callsign — nothing prunes this table, so an over-tight predicate degrades a
- * carrier's route coverage invisibly. Both directions are pinned here: the
- * guard was previously deletable with the whole suite still green.
- */
-describe("cacheFlightRoute write-edge validation", () => {
-  const persisted = (fn: string): boolean => {
-    const db = makeSyntheticDb();
-    cacheFlightRoute(db, fn, "SFO", "EWR", 18000, utc("2026-08-01T00:00:00Z"));
-    const row = db.query("SELECT 1 FROM flight_routes WHERE flight_number = ?").get(fn) as unknown;
-    db.close();
-    return row !== null;
-  };
+const DAY = 86400;
 
-  // Real callsign shapes observed in production flight_routes. The suffixed
-  // ICAO form is 3.5% of rows and the sole source of most Qatar route pairs;
-  // dropping it would skew airlineServesAirports, which gates inferred_absent.
-  test.each([
-    ["UA1340", "marketing IATA"],
-    ["SKW4726", "operating-carrier ICAO"],
-    ["QTR16A", "ICAO with disambiguating suffix"],
-    ["SKW302M", "ICAO with disambiguating suffix"],
-    ["UAL353T", "ICAO with disambiguating suffix"],
-    ["ASH611A", "ICAO with disambiguating suffix"],
-    ["MX69A", "short IATA with suffix"],
-  ])("persists %s (%s)", (fn) => {
-    expect(persisted(fn)).toBe(true);
+function seedCachedRoute(
+  db: ReturnType<typeof makeSyntheticDb>,
+  flightNumber: string,
+  origin: string,
+  destination: string,
+  seenCount: number,
+  lastSeenAt: number
+) {
+  db.run(
+    `INSERT INTO flight_routes
+       (flight_number, origin, destination, duration_sec, first_seen_at, last_seen_at, seen_count)
+     VALUES (?, ?, ?, 7200, ?, ?, ?)`,
+    [flightNumber, origin, destination, lastSeenAt - 200 * DAY, lastSeenAt, seenCount]
+  );
+}
+
+describe("getFlightRoutePairs staleness discount", () => {
+  // The shape behind the stale-title report: no near-term assignment, so every
+  // leg is history-only and the scheduled tier can't break the tie. Counts and
+  // airports here are illustrative, not transcribed from any live row.
+  const now = utc("2026-08-29T12:00:00Z");
+
+  test("a long-retired leg loses routes[0] to the leg that replaced it", () => {
+    const db = makeSyntheticDb();
+    // A reassigned number: the old pair stopped being flown eight months ago but
+    // keeps its lifetime count forever, while the pair that replaced it has been
+    // accumulating since. Silence that long discounts the old leg to its floor,
+    // an eighth, which the replacement's 40 observations clear.
+    seedCachedRoute(db, "UA800", "IAH", "EWR", 240, now - 240 * DAY);
+    seedCachedRoute(db, "UA800", "EWR", "SFO", 40, now - 3 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA800"], "UA", now);
+
+    expect(rows[0].departure_airport).toBe("EWR");
+    expect(rows[0].arrival_airport).toBe("SFO");
+    expect(rows[0].scheduled).toBe(0);
+    expect(rows[0].times).toBeLessThan(rows[1].times);
+    // Demoted, never dropped: the page still lists the number's route history,
+    // and a cold-tail permalink always has a route to put in its title.
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["SFO", "EWR"]);
+    db.close();
   });
 
-  // Junk the guard exists to keep out of the sitemap. UA63986 is the row that
-  // actually leaked: five digits, real data behind it, and a hard 404.
-  test.each([
-    ["UA63986", "over the router's 4-digit permalink cap"],
-    ["A0ACFF", "ICAO hex transponder address"],
-    ["N217HA", "tail number, not a flight number"],
-    ["B1", "no flight digits"],
-    ["K4035", "single-letter prefix"],
-    ["SKWW5424", "doubled carrier prefix"],
-    ["", "empty"],
-  ])("rejects %s (%s)", (fn) => {
-    expect(persisted(fn)).toBe(false);
+  test("frequency still decides between legs that are both current", () => {
+    const db = makeSyntheticDb();
+    // A one-off diversion seen most recently must not outrank the daily leg.
+    seedCachedRoute(db, "UA88", "ORD", "LHR", 300, now - 2 * DAY);
+    seedCachedRoute(db, "UA88", "ORD", "SNN", 1, now - 3600);
+    const rows = getFlightRoutePairs(db, ["UA88"], "UA", now);
+
+    expect(rows[0].arrival_airport).toBe("LHR");
+    expect(rows.every((r) => r.last_seen_at !== null)).toBe(true);
+    db.close();
+  });
+
+  test("a merely stale heavy leg still outranks a one-off seen minutes ago", () => {
+    const db = makeSyntheticDb();
+    // A gap of days proves nothing: last_seen_at stamps only when a Starlink tail
+    // draws this leg, which at mainline penetration skips a daily route for a week
+    // about a quarter of the time. Inside the grace period nothing is discounted,
+    // so the 300 observations decide — a diversion must not become the page title.
+    seedCachedRoute(db, "UA89", "ORD", "LHR", 300, now - 10 * DAY);
+    seedCachedRoute(db, "UA89", "ORD", "SNN", 1, now - 3600);
+    const rows = getFlightRoutePairs(db, ["UA89"], "UA", now);
+
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["LHR", "SNN"]);
+    db.close();
+  });
+
+  test("crossing the grace period doesn't flip the title on the clock alone", () => {
+    // The failure a hard cutoff has: one second of elapsed time swapping a page's
+    // title, meta description and JSON-LD, then swapping back on the next stamp.
+    // The discount starts at zero, so the two sides of the boundary must agree.
+    const across = [now - 30 * DAY + 1, now - 30 * DAY - 1].map((lastSeen) => {
+      const db = makeSyntheticDb();
+      seedCachedRoute(db, "UA91", "ATL", "EWR", 82, lastSeen);
+      seedCachedRoute(db, "UA91", "ORD", "DCA", 3, now - 2 * DAY);
+      const rows = getFlightRoutePairs(db, ["UA91"], "UA", now);
+      db.close();
+      return rows.map((r) => `${r.departure_airport}-${r.arrival_airport}`);
+    });
+
+    expect(across[0]).toEqual(["ATL-EWR", "ORD-DCA"]);
+    expect(across[1]).toEqual(across[0]);
+  });
+
+  test("a lone sighting never unseats a leg with orders more evidence", () => {
+    const db = makeSyntheticDb();
+    // The commonest production shape: a heavy leg silent for months against a
+    // single stray observation inside the grace period. The discount bottoms out
+    // at an eighth, so 116 observations survive as 14.5 and the stray stays put —
+    // one sighting is not evidence that the other 116 stopped happening.
+    seedCachedRoute(db, "UA92", "LAX", "SLC", 116, now - 100 * DAY);
+    seedCachedRoute(db, "UA92", "DTW", "DEN", 1, now - 20 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA92"], "UA", now);
+
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["SLC", "DEN"]);
+    db.close();
+  });
+
+  test("an ancient heavy leg still outranks a lighter, less ancient one", () => {
+    const db = makeSyntheticDb();
+    // Staleness must never decide on its own. Measured from the number's own
+    // freshest leg instead of from `now`, the SNN row would be "current" by
+    // construction and would take the title on one observation.
+    seedCachedRoute(db, "UA90", "ORD", "LHR", 300, now - 200 * DAY);
+    seedCachedRoute(db, "UA90", "ORD", "SNN", 1, now - 40 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA90"], "UA", now);
+
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["LHR", "SNN"]);
+    db.close();
+  });
+
+  test("a leg whose origin equals its destination never reaches the caller", () => {
+    const db = makeSyntheticDb();
+    // Returns and diversions come back logged as A->A. Left in, such a row can
+    // title a permalink "(MIA -> MIA)", emit JSON-LD with identical departure and
+    // arrival airports, and link to /route-planner/MIA/MIA, which 404s by design.
+    seedCachedRoute(db, "UA93", "MIA", "MIA", 1, now - 15 * DAY);
+    seedCachedRoute(db, "UA93", "FAB", "ORD", 12, now - 37 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA93"], "UA", now);
+
+    expect(rows.map((r) => r.departure_airport)).toEqual(["FAB"]);
+    db.close();
+  });
+
+  test("a future-dated last_seen_at counts as no evidence, not the freshest", () => {
+    const db = makeSyntheticDb();
+    // The snapshot carries a row dated 2036. Scored as fresh it would outrank
+    // every real leg forever, since no cutoff ever catches up to it.
+    seedCachedRoute(db, "UA100", "EWR", "TLV", 1, utc("2036-08-19T04:59:55Z"));
+    seedCachedRoute(db, "UA100", "EWR", "FCO", 90, now - 2 * DAY);
+    seedCachedRoute(db, "UA100", "IAD", "MUC", 400, now - 120 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA100"], "UA", now);
+
+    expect(rows[0].arrival_airport).toBe("FCO");
+    expect(rows[rows.length - 1].arrival_airport).toBe("TLV");
+    db.close();
+  });
+
+  test("a future-dated leg with no fresh sibling doesn't sort first", () => {
+    const db = makeSyntheticDb();
+    // The cold-tail shape the fix exists for: nothing is inside the window, so a
+    // corrupt row is the only thing a naive freshness test could call current.
+    seedCachedRoute(db, "UA101", "EWR", "TLV", 1, utc("2036-08-19T04:59:55Z"));
+    seedCachedRoute(db, "UA101", "IAH", "EWR", 165, now - 40 * DAY);
+    seedCachedRoute(db, "UA101", "EWR", "SFO", 8, now - 45 * DAY);
+    const rows = getFlightRoutePairs(db, ["UA101"], "UA", now);
+
+    expect(rows[0].arrival_airport).not.toBe("TLV");
+    expect(rows.map((r) => r.arrival_airport)).toEqual(["EWR", "SFO", "TLV"]);
+    db.close();
+  });
+
+  test("a scheduled leg still wins over a fresher history-only leg", () => {
+    const db = makeSyntheticDb();
+    seedCachedRoute(db, "UA5547", "DEN", "XWA", 415, now - 3600);
+    const dep = now + 6 * 3600;
+    db.run(
+      `INSERT INTO upcoming_flights
+         (tail_number, flight_number, departure_airport, arrival_airport,
+          departure_time, arrival_time, last_updated, airline)
+       VALUES ('N77777', 'UA5547', 'SDF', 'ORD', ?, ?, ?, 'UA')`,
+      [dep, dep + 5400, now]
+    );
+    const rows = getFlightRoutePairs(db, ["UA5547"], "UA", now);
+
+    expect(rows[0].departure_airport).toBe("SDF");
+    expect(rows[0].scheduled).toBe(1);
+    expect(rows[0].last_seen_at).toBe(now);
+    db.close();
   });
 });

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -228,3 +228,57 @@ describe("flight permalink gate + normalization", () => {
     );
   });
 });
+
+/**
+ * "Routes {fn} flies" is present tense over a list ordered by how recently each
+ * leg was seen, and the top row is what the title, meta description and Flight
+ * JSON-LD advertise. A row without its date asserts a currency the ordering
+ * itself does not claim, so the date is what makes the heading honest.
+ */
+describe("flight permalink route rows carry their evidence date", () => {
+  const HOST = "unitedstarlinktracker.com";
+  let app: ReturnType<typeof createApp>;
+  let reader: ReturnType<ReturnType<typeof createReaderFactory>>;
+
+  beforeAll(() => {
+    const db = openSnapshot();
+    app = createApp(db);
+    reader = createReaderFactory(db)("UA");
+  });
+
+  // React SSR splits interpolated text with <!-- --> markers.
+  const plain = (html: string) => html.replaceAll("<!-- -->", "");
+
+  test("a leg with a real timestamp renders its last-seen date", async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const fn = reader
+      .getSitemapFlights()
+      .map((f) => f.flight_number)
+      .find((n) => {
+        const top = reader.getFlightRoutePairs([n])[0];
+        return top !== undefined && top.last_seen_at !== null && top.last_seen_at <= now;
+      });
+    expect(fn).toMatch(/^UA\d{1,4}$/);
+
+    const html = plain(await (await app.dispatch(req(`/check-flight/${fn}`, HOST))).text());
+    const seen = html.match(/· seen \d+ times?/g) ?? [];
+    expect(seen.length).toBeGreaterThan(0);
+    // One date per row, not one for the block.
+    expect((html.match(/· last seen \w{3} \d{1,2}, \d{4}/g) ?? []).length).toBe(seen.length);
+  });
+
+  test("no route row ever renders a date in the future", async () => {
+    // A last_seen_at ahead of now is a corrupt row (the snapshot carries one
+    // dated 2036); showing it would date a leg to a flight that hasn't happened.
+    for (const { flight_number } of reader.getSitemapFlights().slice(0, 12)) {
+      const html = plain(
+        await (await app.dispatch(req(`/check-flight/${flight_number}`, HOST))).text()
+      );
+      for (const m of html.matchAll(/· last seen (\w{3} \d{1,2}, \d{4})/g)) {
+        expect(Date.parse(`${m[1]} UTC`), `${flight_number}: ${m[1]}`).toBeLessThanOrEqual(
+          Date.now()
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Trimmed land of `seo/seo-permalink-titles` onto current main (API surgery; no full branch merge).

- **Keep:** route-staleness discount so permalink titles/meta/JSON-LD stop advertising retired legs; `last_seen_at` on route rows + UI; same-airport filter; tests.
- **Skip from source:** nothing else was on that branch beyond these wins.

## Test plan
- [ ] `tests/flight-route-pairs.test.ts` — staleness discount cases
- [ ] `tests/rendering.test.ts` — last-seen date rendering
- [ ] Spot-check a reassigned flight permalink title vs main