### PR TITLE
fix(seo): self-canonical check-flight noindex + confidence floor

### DIFF
--- a/src/scripts/starlink-predictor.ts
+++ b/src/scripts/starlink-predictor.ts
@@ -121,7 +121,53 @@ const DEFAULT_CONFIG: ModelConfig = {
 // 5/10/20/30/40d half-lives in the rolling backtest; 30d is the Brier optimum.
 const ASSIGNMENT_HALF_LIFE_DAYS = 30;
 
-const confidenceFor = (n: number) => (n >= 5 ? "high" : n >= 2 ? "medium" : "low") as const;
+type Confidence = "high" | "medium" | "low";
+
+const confidenceFor = (n: number): Confidence => (n >= 5 ? "high" : n >= 2 ? "medium" : "low");
+
+/** The smallest raw sample each tier admits — what the published label is
+ * promising, and the count the age rules are asked about. */
+const TIER_MIN_DRAWS: Record<Confidence, number> = { low: 1, medium: 2, high: 5 };
+
+/**
+ * Below this share of the smoothed posterior a flight's own history has
+ * stopped moving the number: the estimate is (s + α·prior)/(w + α), so once
+ * the decayed weight `w` is worth under 5% of that denominator what ships is
+ * the family prior wearing a flight number. Expressed against α rather than
+ * hardcoded so it tracks a priorStrength re-sweep.
+ */
+const DEAD_EVIDENCE_SHARE = 0.05;
+const deadEvidenceWeight = (priorStrength: number) =>
+  (priorStrength * DEAD_EVIDENCE_SHARE) / (1 - DEAD_EVIDENCE_SHARE);
+
+/** One half-life: past it each draw is worth under half a fresh one, which is
+ * the point where the label should hedge rather than vouch for the sample. */
+const STALE_DECAY = 0.5;
+
+/**
+ * Confidence for the decayed model, as a function of the count printed beside
+ * it and the AGE of the evidence — never of `count × age`.
+ *
+ * 1. The count sets the tier — the same tiering the label has always meant.
+ * 2. Staleness costs at most one tier. A sample whose draws are each worth
+ *    under half a fresh one is hedged to "medium"; it never drops to "low"
+ *    while its evidence still moves the number, because "17 observations (low
+ *    confidence)" reads as a bug and made the Chrome extension suppress a 98%
+ *    call at the point of booking.
+ * 3. Dead evidence is dead, asked of the tier's minimum sample rather than the
+ *    whole n, so a large stale sample that still moves the number stays medium.
+ */
+function decayedConfidence(
+  decayedWeight: number,
+  rawCount: number,
+  priorStrength: number
+): Confidence {
+  const raw = confidenceFor(rawCount);
+  if (raw === "low") return "low";
+  const freshness = decayedWeight / rawCount;
+  if (freshness * TIER_MIN_DRAWS[raw] < deadEvidenceWeight(priorStrength)) return "low";
+  return freshness < STALE_DECAY ? "medium" : raw;
+}
 
 /** Subfleet cold-start install rate: all we know with no usable history. */
 function coldPrior(flightNumber: string, config: ModelConfig): number {
@@ -230,7 +276,7 @@ function buildTypeAwarePredict(
     predictions.set(flightNumber, {
       flight_number: flightNumber,
       probability: smoothedRate(f.s, f.n, prior, config.priorStrength),
-      confidence: confidenceFor(f.n),
+      confidence: decayedConfidence(f.n, f.raw, config.priorStrength),
       method: "flight_history_smoothed",
       n_observations: f.raw,
     });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -361,7 +361,6 @@ for (const p of SOCIAL_IMAGE_PATHS) {
   }
 }
 
-
 /**
  * Compiled Tailwind, fingerprinted and registered as a tenant-agnostic asset.
  *
@@ -2614,7 +2613,6 @@ function flightPageMeta(
     pageJsonLd,
   };
 }
-
 
 /** Meta for a URL that isn't a flight number. Reuses the conversion page's
  * title/description when the segment is garbage; that would stamp thousands of

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2615,6 +2615,41 @@ function flightPageMeta(
   };
 }
 
+
+/** Meta for a URL that isn't a flight number. Reuses the conversion page's
+ * title/description when the segment is garbage; that would stamp thousands of
+ * noindex responses with the page that has to rank. Title tracks the H1 instead,
+ * and the page self-canonicalizes so its noindex lands on the URL it is actually about. */
+function invalidFlightMeta(ctx: RequestContext, reason: InvalidFlightQuery["reason"]): PageMeta {
+  const short = tenantConfig(ctx.tenant)?.shortName;
+  const carrier = short ? `${short} ` : "";
+  const lead = reason === "other-carrier" ? `Not a ${carrier}Flight Number` : "Not a Flight Number";
+  return {
+    siteTitle: `${lead} — Check a ${carrier}Flight for Starlink`,
+    siteDescription: `That isn't a ${carrier}flight number. Enter a flight number and date to check whether your aircraft has free Starlink WiFi.`,
+    keywords: `check ${carrier.toLowerCase()}flight starlink, does my flight have starlink`,
+    ogTitle: lead,
+    ogDescription: `Enter a ${carrier}flight number and date to check for Starlink WiFi.`,
+    robotsMeta: "noindex, nofollow",
+  };
+}
+
+/** Meta for a well-formed flight number we hold no rows for. Same rule as
+ * invalidFlightMeta, and a far larger URL space than it: every UA number a
+ * crawler can enumerate lands here, so canonicalizing them onto /check-flight
+ * pointed thousands of noindex responses at the conversion page. Self-canonical
+ * instead, with a title that names the flight rather than reusing the hub's. */
+function unknownFlightMeta(flightNumber: string, cfg: AirlineConfig): PageMeta {
+  return {
+    siteTitle: `${flightNumber} — No Starlink Data Yet`,
+    siteDescription: `We have no schedule data for ${cfg.name} ${flightNumber} yet. Enter the flight number and date below to check for free Starlink WiFi.`,
+    keywords: `${flightNumber} starlink, does ${flightNumber} have wifi`,
+    ogTitle: `${flightNumber} — No Starlink Data Yet`,
+    ogDescription: `Check ${cfg.name} ${flightNumber} for Starlink WiFi.`,
+    robotsMeta: "noindex, follow",
+  };
+}
+
 const checkFlightPage: Handler = (ctx) => {
   if (ctx.req.method !== "GET" && ctx.req.method !== "HEAD") return methodNotAllowed();
   if (!ctx.site.features.checkFlightPage) {
@@ -2628,14 +2663,19 @@ const checkFlightPage: Handler = (ctx) => {
   // the homepage form navigates here with whatever was typed) still 404s, but
   // renders the real page with a notice and the working lookup form instead of
   // the bare not-found document.
+  // A segment that isn't a flight number still 404s, but renders the real page
+  // with a notice and the working lookup form. Self-canonical: a noindex response
+  // that canonicalizes to /check-flight aims the noindex at the conversion page.
+  // Pass numeric 404 (not an opts object) so renderSubPage applies notFoundHtml
+  // edge caching — restores #75 after a bad land of united-content.
   const invalidPage = (invalid: InvalidFlightQuery) =>
     renderSubPage(
       ctx,
       CheckFlightPage,
-      "/check-flight",
-      { ...subPageMeta(ctx, "check-flight"), robotsMeta: "noindex, nofollow" },
+      ctx.url.pathname,
+      invalidFlightMeta(ctx, invalid.reason),
       { invalid },
-      { edgeCacheable404: true }
+      404
     );
   if (parsed.kind === "invalid") {
     const query = echoQuery(parsed.raw);
@@ -2666,17 +2706,15 @@ const checkFlightPage: Handler = (ctx) => {
     // FR24 fallback can still answer a real flight outside our schedule
     // window, and the homepage form + permalink replaceState both mint these
     // URLs — so serve the interactive generic page instead of dead-ending.
-    // noindex + canonical to /check-flight keeps it out of the index (the
-    // sitemap never advertises ungated flights).
+    // noindex keeps it out of the index (the sitemap never advertises ungated
+    // flights), and the canonical stays on this URL so the noindex lands here
+    // rather than on the conversion page.
     if (!reader.flightNumberHasData(variants)) {
       return renderSubPage(
         ctx,
         CheckFlightPage,
-        "/check-flight",
-        {
-          ...subPageMeta(ctx, "check-flight"),
-          robotsMeta: "noindex, follow",
-        },
+        ctx.url.pathname,
+        unknownFlightMeta(fn, cfg),
         // noindex but follow: hand the crawler somewhere real to go.
         { popular: reader.getPopularFlights() }
       );

--- a/tests/rendering.test.ts
+++ b/tests/rendering.test.ts
@@ -107,7 +107,7 @@ describe("canonical / og:url / WebPage JSON-LD claim the page path", () => {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Flight permalinks: existence gate (no data → interactive soft page, noindex,
-// canonical to /check-flight — the client-side FR24 lookup can still answer;
+// self-canonical — the client-side FR24 lookup can still answer;
 // malformed/other-carrier segments hard-404) and URL normalization (one
 // canonical spelling per flight, everything else 301).
 // ─────────────────────────────────────────────────────────────────────────────
@@ -137,13 +137,14 @@ describe("flight permalink gate + normalization", () => {
     ghostFlight = `UA${n}`;
   });
 
-  test("valid-format flight with no data → 200 soft page, noindex, canonical to /check-flight", async () => {
+  test("valid-format flight with no data → 200 soft page, noindex, self-canonical", async () => {
     const res = await app.dispatch(req(`/check-flight/${ghostFlight}`, HOST));
     expect(res.status).toBe(200);
     const html = await res.text();
     expect(html.match(/<meta name="robots" content="([^"]+)"/)?.[1]).toContain("noindex");
+    // Self-canonical: aiming noindex at /check-flight would mark the conversion page.
     expect(html.match(/<link rel="canonical" href="([^"]+)"/)?.[1]).toBe(
-      `https://${HOST}/check-flight`
+      `https://${HOST}/check-flight/${ghostFlight}`
     );
     // The interactive lookup form still serves — the URL is not a dead end.
     expect(html).toContain('id="check-flight-form"');


### PR DESCRIPTION
## Summary
Trimmed land of `seo/seo-prediction-calibration` onto current main.

**Included**
- Self-canonical noindex for invalid + ungated `/check-flight/*` (stop aiming noindex at the conversion page)
- Restore numeric `404` status on invalid pages (fixes `#75` regression from `#93` which passed `{ edgeCacheable404: true }` into `status`)
- Predictor `decayedConfidence`: stop labeling large stale samples as low confidence

**Deferred from source (need Cloud Agent / fuller rebase)**
- Type-aware airframe pricing rework, MCP/API prediction copy surfaces, larger calibration test suite, observation-count inventing fixes beyond the confidence floor

## Test plan
- [ ] `/check-flight/TEST` returns 404, self-canonical, noindex, cached headers
- [ ] Ungated flight URL self-canonical with flight-named title
- [ ] Predictor: large stale sample is medium not low