### PR TITLE
feat(extension): v2 multi-airline claim-ladder badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Bun + SQLite + server-rendered React. `server.ts` serves pages/APIs and starts b
 ## Public contracts — do not break
 
 - **`GET /api/check-flight?flight_number=UA123&date=YYYY-MM-DD`** → `{ hasStarlink: boolean, flights: [] }` with CORS for Google Flights. The Chrome extension depends on this exact shape.
+- **`GET /api/check-any-flight?flight_number=HA50&date=YYYY-MM-DD`** (hub host) — extension non-UA surface since v2; top-level `hasStarlink`, `confidence`, `probability`, `airline`, `error`, `flights`. Additive only.
 - **MCP tool names and result shapes** — clients cache schemas at connect time.
 
 ## Conventions

--- a/chrome-extension/QA-CHECKLIST.md
+++ b/chrome-extension/QA-CHECKLIST.md
@@ -1,0 +1,85 @@
+# Manual QA checklist — Google Flights Starlink Indicator
+
+The DOM-facing paths can't be unit-tested (Google Flights markup, extension
+messaging, real breakpoints). Run this checklist in a real browser before
+tagging a release. Load the unpacked extension fresh (`chrome://extensions` →
+reload) before starting.
+
+Tip: set `DEBUG = true` in `content.js` for verbose per-pass logging while
+testing; set it back before release.
+
+## Setup sanity
+
+- [ ] `chrome://extensions` shows version 2.0.0, no errors on the card
+- [ ] Service worker "Inspect views" console shows no errors on load
+- [ ] Permissions listed: only unitedstarlinktracker.com — no storage, no new hosts
+
+## United (frozen endpoint)
+
+- [ ] Search a UA-heavy route (e.g. SFO → EWR, tomorrow). Blue "Starlink" or
+      green "Starlink (installed)" badges appear on some results within a few
+      seconds
+- [ ] Search the same route ~2 weeks out. Gray "Starlink ~NN%" badges appear
+      only on flights at ≥80%; no badge on the rest
+- [ ] Hover each badge tier — tooltip explains verified / installed / predicted
+      wording and (for predictions) observation count
+- [ ] DevTools Network tab (service worker): UA lookups go to
+      `unitedstarlinktracker.com/api/check-flight`
+
+## Hawaiian / Alaska (hub endpoint)
+
+- [ ] Search HNL → LAX within ~2 days: Hawaiian results get badges; lookups go
+      to `airlinestarlinktracker.com/api/check-any-flight`
+- [ ] Search SEA → PDX within ~2 days: Alaska/Horizon E175 results get badges
+- [ ] Far-future SEA → PDX (E175 regional, AS2000+): gray "Starlink ~100%"
+      badges — Alaska's subfleet answer carries a probability past the
+      assignment window
+- [ ] Far-future SEA → LAX (mainline 737, AS1-1999): no badge — the mainline
+      subfleet is mid-rollout, far below the 80% bar
+- [ ] Far-future HNL → LAX (Hawaiian): no badge at all. HA's answer is a
+      per-type split, which carries no single probability — an honest
+      abstention, not a bug (see README "Coverage windows differ by airline")
+
+## Untracked airlines and negatives
+
+- [ ] Delta/American/JetBlue results never get a badge and never trigger
+      console errors
+- [ ] A page with zero tracked flights makes zero API requests (Network tab)
+
+## Multi-leg itineraries
+
+- [ ] A connecting itinerary where only one leg is Starlink shows no
+      "Starlink" badge (weakest-leg rule) — or, if both legs qualify, one badge
+      per card, never two
+
+## Layout and drift resilience
+
+- [ ] Desktop (≥1024px): badge sits inline after the flight times when Google's
+      current markup allows; otherwise it appears pinned to the card corner —
+      either way, never overlapping content illegibly
+- [ ] Narrow window (<1024px): corner badge form; resize across the breakpoint
+      re-renders badges without duplicates
+- [ ] Change dates via the date picker (SPA navigation, URL change): old badges
+      cleared, new results processed
+- [ ] Scroll to load more results: newly appended cards get processed
+- [ ] Page console (not the worker's) shows **zero** errors or warnings from
+      the extension during all of the above — including with DevTools "Pause on
+      exceptions" off/on
+
+## Failure honesty
+
+- [ ] Block both API hosts (DevTools → Network request blocking), reload the
+      search: no badges, no page errors. Unblock and leave the tab alone (no
+      reload, no scrolling): within ~5 minutes the extension re-runs its own
+      pass and the badges appear (cards left unsettled by a transient failure
+      are never retired, and the pass reschedules itself up to 3 times)
+- [ ] Kill the service worker (chrome://serviceworker-internals or wait for
+      idle), then interact with the page: lookups still work (worker wakes) or
+      degrade silently
+
+## Round-trip / date correctness
+
+- [ ] Round-trip search: badges on the return-leg results reflect the return
+      date, not the outbound date (per-leg dates come from the Travel Impact
+      Model attribute — verify a request in the Network tab carries the return
+      date)

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,32 +1,107 @@
 # Google Flights Starlink Indicator
 
-Chrome extension that highlights flights with Starlink WiFi on Google Flights.
+Chrome extension (Manifest V3) that badges Google Flights search results with
+the Starlink WiFi status of each flight — for United, Hawaiian, and Alaska
+Airlines.
 
-## Installation
+## Installation (development)
 
 1. Open Chrome and go to `chrome://extensions/`
 2. Enable "Developer mode" (top right)
 3. Click "Load unpacked"
 4. Select the `chrome-extension` folder
-5. Visit [Google Flights](https://www.google.com/flights) and search for flights
+5. Visit [Google Flights](https://www.google.com/travel/flights) and search for flights
 
-## Features
+Publishing to the Chrome Web Store is a separate, manual step.
 
-- Automatically detects flights with Starlink WiFi
-- Shows "✈️ Starlink" badge on equipped flights
-- Desktop: Badge appears inline after flight times
-- Tablet/Mobile: Subtle badge in top-left corner
+## What the badges mean
 
-## How it Works
+The extension never shows a bare yes/no. Every answer sits on a claim ladder,
+strongest first, and anything weaker than the last rung shows **no badge at
+all** rather than a guess:
 
-The extension queries unitedstarlinktracker.com to check if a flight's aircraft has Starlink installed, then adds a visual indicator to matching flights on Google Flights search results.
+| Badge | Meaning |
+|---|---|
+| **Starlink** (blue) | Verified — the assigned aircraft was confirmed Starlink against the airline's own site |
+| **Starlink (installed)** (green) | The assigned aircraft is Starlink-equipped per fleet data, not yet re-verified |
+| **Starlink ~92%** (gray) | No aircraft assigned yet (airlines assign ~2 days out); the percentage is this flight number's historical rate (United) or the equipped share of the subfleet that flies it (Alaska). Shown only at ≥80% with non-low confidence |
+| *no badge* | Verified non-Starlink aircraft, a prediction below the bar or of low confidence, an answer that is type-determined with no aircraft assigned yet (see below), an untracked airline, or an API that couldn't answer — silence over invention |
 
-## Privacy Policy
+Hover a badge for the full explanation, including observation counts for
+predictions.
 
-This extension:
-- Only reads flight numbers from Google Flights pages you visit
-- Sends flight numbers to unitedstarlinktracker.com to check Starlink availability
-- Does not collect or store any personal information
-- Does not track your browsing history
-- Caches flight data locally for 30 minutes to reduce API requests
-- All data processing happens locally in your browser
+### Coverage windows differ by airline
+
+Aircraft assignments only exist ~2 days out, and what fills the gap before that
+depends on the airline:
+
+- **United** — a per-flight-number history model, so predicted badges show for
+  any date the search returns.
+- **Alaska** — no per-flight history, but the subfleet a flight number belongs
+  to has one equipped share, so predicted badges show at any date for the
+  ~100%-equipped subfleets (AS800-899 on Hawaiian A330/A321neo metal, and the
+  regional E175s) and stay off for the mid-rollout mainline.
+- **Hawaiian** — Starlink is decided by aircraft type (A330/A321neo yes, 787
+  installing, 717 no) and a flight number doesn't pin the type. Beyond the ~2-day
+  assignment window there is no honest single number, so **Hawaiian results show
+  no badge until the aircraft is assigned**. Blending the types into one
+  percentage would be a guess dressed as data.
+
+## How it works
+
+- Flight numbers, legs, and dates are read from Google's own Travel Impact
+  Model data attributes when present (semantic, drift-resistant). If nothing
+  decodes out of them — the attribute is missing, or Google changed the
+  itinerary encoding — the v1 attribute and text heuristics take over, both
+  gated on the airline's name appearing in the card so a stray two-letter match
+  in Google's markup can't badge someone else's flight. An itinerary that
+  decodes and names no tracked airline is trusted as-is: no heuristics run.
+- United flights are checked against `unitedstarlinktracker.com/api/check-flight`
+  (the long-standing contract for this extension, and the only surface with the
+  near-departure FR24 fallback). Hawaiian and Alaska flights are checked
+  against the hub, `airlinestarlinktracker.com/api/check-any-flight`, which
+  resolves the marketing carrier server-side.
+- Multi-leg itineraries are badged by their weakest leg — a card is never
+  marked "Starlink" when only one leg has it.
+- Answers are cached in-memory for 30 minutes (5 minutes for transient
+  failures). At most 40 uncached lookups run per page pass.
+- A card is only retired once its answer is settled. A pass that ends with any
+  card still unsettled — an API blip, an exhausted per-pass budget — schedules
+  itself again after the short cache expires, up to three times, so a blip
+  doesn't blank the rest of the session.
+
+## Permissions
+
+- `host_permissions: unitedstarlinktracker.com` — unchanged since v1. The hub
+  API is reached with an ordinary CORS request (both APIs serve
+  `Access-Control-Allow-Origin: *`), so v2 deliberately adds **no** new host
+  permissions: adding one would disable the extension for existing users until
+  they re-approve the update.
+- No `storage`, `tabs`, or other permissions. v2 removed the unused `storage`
+  permission from v1.
+
+## Privacy (plain language)
+
+- The extension reads flight numbers and dates from Google Flights pages you
+  are already viewing. It does not read anything else on the page.
+- For each United/Hawaiian/Alaska flight it finds, it sends **only the flight
+  number and date** to unitedstarlinktracker.com or
+  airlinestarlinktracker.com to ask "does this flight have Starlink?".
+  No account data, no page contents, no URLs, no identifiers ride along.
+- It does not collect, store, or transmit any personal information.
+- It does not track your browsing history; it only runs on Google Flights.
+- Results are cached in memory in your browser for up to 30 minutes and vanish
+  when the tab or browser closes.
+- Everything else happens locally in your browser.
+
+## Development
+
+Pure logic (flight extraction, endpoint routing, response normalization,
+badge copy) lives in `lib.js` and is unit-tested from the main repo:
+
+```bash
+bun test tests/extension.test.ts
+```
+
+Content-script behavior that needs a real browser is covered by the manual
+checklist in [QA-CHECKLIST.md](QA-CHECKLIST.md) — run it before any release.

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,26 +1,45 @@
-chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-  if (request.action === "checkFlight") {
-    const { flightNumber, date } = request;
-    const url = `https://unitedstarlinktracker.com/api/check-flight?flight_number=${flightNumber}&date=${date}`;
+/**
+ * Service worker: the only place the extension talks to the network. Routing
+ * (UA → the frozen check-flight contract, others → the hub's
+ * check-any-flight) lives in lib.js so it is unit-tested in the main repo.
+ *
+ * Both APIs serve `Access-Control-Allow-Origin: *`, so no host permission
+ * beyond the original one is required — adding one would disable the
+ * extension for existing users until they re-approve the update.
+ */
 
-    console.log("[Starlink Tracker Background] Fetching:", url);
+importScripts("lib.js");
 
-    fetch(url)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error(`HTTP error! status: ${response.status}`);
-        }
-        return response.json();
-      })
-      .then((data) => {
-        console.log("[Starlink Tracker Background] API response:", data);
-        sendResponse({ success: true, data });
-      })
-      .catch((error) => {
-        console.error("[Starlink Tracker Background] API error:", error);
-        sendResponse({ success: false, error: error.message });
-      });
+const FETCH_TIMEOUT_MS = 10_000;
 
-    return true;
+chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
+  if (!request || request.action !== "checkFlight") return undefined;
+
+  const lib = globalThis.StarlinkTrackerLib;
+  const url = lib ? lib.endpointFor(request.flightNumber, request.date) : null;
+  if (!url) {
+    sendResponse({ success: false, error: "unsupported flight number or date" });
+    return undefined;
   }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  fetch(url, { signal: controller.signal })
+    .then(async (response) => {
+      const body = await response.json().catch(() => null);
+      // 400/404 bodies are settled answers ("untracked airline", bad input) —
+      // hand them to the normalizer instead of treating them as outages.
+      if (body && (response.ok || response.status === 400 || response.status === 404)) {
+        sendResponse({ success: true, data: body });
+      } else {
+        sendResponse({ success: false, status: response.status });
+      }
+    })
+    .catch((err) => {
+      sendResponse({ success: false, error: err instanceof Error ? err.message : String(err) });
+    })
+    .finally(() => clearTimeout(timer));
+
+  return true;
 });

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,326 +1,401 @@
-const DEBUG = false;
-const log = (...args) => DEBUG && console.log("[Starlink Tracker]", ...args);
+/**
+ * Google Flights content script. Finds flight cards, resolves each tracked
+ * flight to a claim-ladder answer via the background worker, and renders a
+ * compact badge for verified / installed / high-probability-predicted flights.
+ *
+ * Resilience posture: Google's class names are obfuscated and churn, so
+ * discovery leans on the semantic Travel Impact Model data attribute first
+ * and treats every class-name selector as an optional fast path. Any failure
+ * — markup drift, API outage, extension reload — degrades to "no badge",
+ * never to a wrong badge or an error surfaced to the page.
+ */
 
-const flightCache = new Map();
-const CACHE_DURATION = 30 * 60 * 1000;
+(() => {
+  const lib = typeof globalThis !== "undefined" ? globalThis.StarlinkTrackerLib : null;
+  if (!lib || typeof chrome === "undefined" || !chrome.runtime) return;
 
-let processedElements = new WeakSet();
+  const DEBUG = false;
+  const log = (...args) => DEBUG && console.log("[Starlink Tracker]", ...args);
 
-function extractFlightDate() {
-  const urlElements = document.querySelectorAll("[data-travelimpactmodelwebsiteurl]");
-  for (const element of urlElements) {
-    const url = element.getAttribute("data-travelimpactmodelwebsiteurl");
-    if (url) {
-      const dateMatch = url.match(/(\d{8})$/);
-      if (dateMatch) {
-        const dateStr = dateMatch[1];
-        const formatted = `${dateStr.substring(0, 4)}-${dateStr.substring(4, 6)}-${dateStr.substring(6, 8)}`;
-        return formatted;
+  // Google Flights result-card class — an optional fast path, not a
+  // requirement: the TIM attribute anchor below survives class renames.
+  const LEGACY_CARD_SELECTOR = ".pIav2d";
+  const TIM_ATTR = "data-travelimpactmodelwebsiteurl";
+  const CARD_HINT_SELECTOR = `${LEGACY_CARD_SELECTOR},[${TIM_ATTR}]`;
+
+  // Caps a runaway pass (selector drift matching everything) before it can
+  // hammer the API; unbadged cards are retried by later passes.
+  const MAX_NEW_LOOKUPS_PER_PASS = 40;
+  const MAX_SEGMENTS_PER_CARD = 4;
+  const MAX_ATTR_SCAN_ELEMENTS = 400;
+
+  const claimCache = new Map();
+  const pendingLookups = new Map();
+  let processedElements = new WeakSet();
+  let isProcessing = false;
+
+  // ── claim lookup ───────────────────────────────────────────────────────────
+
+  /** Cached {claim, retryable} for a key, or null when absent/expired. */
+  function cachedOutcome(key) {
+    const entry = claimCache.get(key);
+    if (entry && entry.expires > Date.now()) return entry;
+    if (entry) claimCache.delete(key);
+    return null;
+  }
+
+  /** Resolves to {claim, retryable} — callers need the retryable flag to know
+   * whether a card is settled or just waiting out a transient failure. */
+  function getClaim(flightNumber, date) {
+    const key = `${flightNumber}-${date}`;
+    const cached = cachedOutcome(key);
+    if (cached) return Promise.resolve(cached);
+    const pending = pendingLookups.get(key);
+    if (pending) return pending;
+
+    const lookup = (async () => {
+      let outcome;
+      try {
+        const response = await chrome.runtime.sendMessage({
+          action: "checkFlight",
+          flightNumber,
+          date,
+        });
+        outcome = lib.claimFromResponse(response);
+      } catch (err) {
+        // Worker restart or invalidated context — honest unknown, retry soon.
+        log("lookup failed", flightNumber, err);
+        outcome = { claim: lib.unknownClaim(), retryable: true };
+      } finally {
+        pendingLookups.delete(key);
+      }
+      claimCache.set(key, {
+        claim: outcome.claim,
+        retryable: outcome.retryable,
+        expires: Date.now() + (outcome.retryable ? lib.CACHE_TTL.error : lib.CACHE_TTL.resolved),
+      });
+      return outcome;
+    })();
+    pendingLookups.set(key, lookup);
+    return lookup;
+  }
+
+  // ── page/card parsing ──────────────────────────────────────────────────────
+
+  function extractPageDate() {
+    try {
+      for (const el of document.querySelectorAll(`[${TIM_ATTR}]`)) {
+        const segments = lib.parseTimSegments(el.getAttribute(TIM_ATTR) || "");
+        if (segments.length) return segments[0].date;
+      }
+      const hashMatch = window.location.hash.match(/;d:(\d{4}-\d{2}-\d{2})/);
+      if (hashMatch) return hashMatch[1];
+    } catch {
+      // fall through to today
+    }
+    return lib.localTodayIso();
+  }
+
+  /** A stable per-result element: the enclosing <li> when there is one. */
+  function canonicalCard(el) {
+    return el.closest("li") || el;
+  }
+
+  function findFlightCards() {
+    const cards = new Set();
+    for (const el of document.querySelectorAll(CARD_HINT_SELECTOR)) {
+      cards.add(canonicalCard(el));
+    }
+    return cards;
+  }
+
+  /** Every Travel Impact Model URL carried by a card, itself included. */
+  function timUrls(card) {
+    const urls = card.hasAttribute?.(TIM_ATTR) ? [card.getAttribute(TIM_ATTR) || ""] : [];
+    for (const el of card.querySelectorAll(`[${TIM_ATTR}]`)) {
+      urls.push(el.getAttribute(TIM_ATTR) || "");
+    }
+    return urls;
+  }
+
+  function cardText(card) {
+    return `${card.innerText || ""} ${
+      card.querySelector("[aria-label]")?.getAttribute("aria-label") || ""
+    }`;
+  }
+
+  function attrFlightNumber(card, codes) {
+    const elements = card.querySelectorAll("*");
+    const scanLimit = Math.min(elements.length, MAX_ATTR_SCAN_ELEMENTS);
+    for (let i = 0; i < scanLimit; i++) {
+      for (const attr of elements[i].attributes) {
+        const flightNumber = lib.parseAttrFlightNumber(attr.value, codes);
+        if (flightNumber) return flightNumber;
       }
     }
+    return null;
   }
 
-  const hash = window.location.hash;
-  const dateMatch = hash.match(/;d:(\d{4}-\d{2}-\d{2})/);
-  if (dateMatch) {
-    return dateMatch[1];
+  /**
+   * Flight segments for one card as [{flightNumber, date|null}], most-reliable
+   * source first.
+   *
+   * A card whose itinerary data DECODED but named no tracked carrier returns []
+   * without consulting the heuristics — the itinerary already settled "not a
+   * tracked airline", and a text match on top of that would be a false positive.
+   * When nothing decodes (the attribute is absent, or Google changed the
+   * itinerary encoding) the heuristics still run: gating them on the attribute's
+   * mere presence made an encoding change silently badge nothing, which is the
+   * drift this extractor exists to survive.
+   */
+  function extractSegments(card) {
+    const tim = lib.timCardSegments(timUrls(card));
+    if (tim.parsed) return tim.segments.slice(0, MAX_SEGMENTS_PER_CARD);
+
+    // Both heuristics run behind the airline-name gate: only carriers actually
+    // named on the card may be matched out of its text or attribute soup.
+    const text = cardText(card);
+    const codes = lib.carriersNamedIn(text);
+    if (codes.length === 0) return [];
+
+    const flightNumber = attrFlightNumber(card, codes);
+    if (flightNumber) return [{ flightNumber, date: null }];
+
+    return lib
+      .extractFlightNumbersFromText(text)
+      .slice(0, MAX_SEGMENTS_PER_CARD)
+      .map((fn) => ({ flightNumber: fn, date: null }));
   }
 
-  return new Date().toISOString().split("T")[0];
-}
+  // ── badge rendering ────────────────────────────────────────────────────────
 
-async function checkFlightForStarlink(flightNumber, date) {
-  const cacheKey = `${flightNumber}-${date}`;
-  const cached = flightCache.get(cacheKey);
-  if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
-    return cached;
+  function buildBadge(claim) {
+    const colors = lib.badgeColors(claim);
+    const badge = document.createElement("span");
+    badge.className = lib.badgeClass(claim);
+    badge.title = lib.badgeTitle(claim);
+    badge.textContent = lib.badgeLabel(claim);
+    badge.style.cssText = [
+      "margin-left: 12px",
+      "display: inline-flex",
+      "align-items: center",
+      "font-size: 13px",
+      `color: ${colors.fg}`,
+      `background: ${colors.bg}`,
+      "padding: 2px 10px",
+      "border-radius: 12px",
+      "font-weight: 500",
+    ].join("; ");
+    return badge;
   }
 
-  try {
-    const response = await chrome.runtime.sendMessage({
-      action: "checkFlight",
-      flightNumber,
-      date,
-    });
-
-    if (!response.success) {
-      return { hasStarlink: false };
-    }
-
-    const hasStarlink = response.data.hasStarlink || false;
-    const confidence = response.data.confidence || (hasStarlink ? "verified" : undefined);
-    const prediction = response.data.prediction;
-
-    const result = { hasStarlink, confidence, prediction, timestamp: Date.now() };
-    flightCache.set(cacheKey, result);
-    return result;
-  } catch (error) {
-    log("Error checking flight:", flightNumber, error);
-    return { hasStarlink: false };
-  }
-}
-
-// Aircraft assignments only exist ~2 days before departure. Above this
-// historical rate we show a "likely" badge instead of nothing.
-const PREDICTION_BADGE_THRESHOLD = 0.8;
-
-// Mobile has no tooltips, so the predicted badge carries the percentage in its
-// text — "Starlink ~85%" — instead of the firm-assignment "(likely)" wording.
-function badgeLabel(confidence, prediction) {
-  if (confidence === "predicted") return `Starlink ~${Math.round(prediction.probability * 100)}%`;
-  return confidence === "likely" ? "Starlink (likely)" : "Starlink";
-}
-
-function badgeTitle(confidence, prediction) {
-  if (confidence === "predicted")
-    return `~${Math.round(prediction.probability * 100)}% of recent departures of this flight used a Starlink-equipped aircraft. United assigns the actual aircraft ~2 days before departure.`;
-  if (confidence === "likely")
-    return "Tracked as Starlink-equipped; not yet verified against united.com";
-  return "Verified Starlink WiFi";
-}
-
-function createStarlinkBadge(confidence, prediction) {
-  const likely = confidence === "likely" || confidence === "predicted";
-  const badge = document.createElement("span");
-  badge.className = `starlink-wifi-badge${likely ? " starlink-wifi-badge--likely" : ""}`;
-  badge.title = badgeTitle(confidence, prediction);
-  badge.style.cssText = `
-    margin-left: 12px;
-    display: inline-flex;
-    align-items: center;
-    font-size: 13px;
-    color: ${likely ? "#5f6368" : "#1967d2"};
-    background: ${likely ? "#f1f3f4" : "#e8f0fe"};
-    padding: 2px 10px;
-    border-radius: 12px;
-    font-weight: 500;
-  `;
-  const icon = likely
-    ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="vertical-align: -2px; margin-right: 4px;"><path d="M11 17h2v2h-2zm0-10h2v8h-2zM12 2a10 10 0 100 20 10 10 0 000-20zm0 18a8 8 0 110-16 8 8 0 010 16z"/></svg>'
-    : '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" style="vertical-align: -2px; margin-right: 4px;"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/></svg>';
-  badge.innerHTML = `${icon}${badgeLabel(confidence, prediction)}`;
-  return badge;
-}
-
-function addStarlinkBadge(card, confidence, prediction) {
-  if (card.querySelector(".starlink-wifi-badge")) return;
-
-  const badge = createStarlinkBadge(confidence, prediction);
-  const likely = confidence === "likely" || confidence === "predicted";
-  const isDesktop = window.innerWidth >= 1024;
-
-  if (isDesktop) {
+  // v1's exact insertion point, kept as a fast path while the classes exist.
+  function insertInline(card, badge) {
     const timeContainer = card.querySelector(".zxVSec.YMlIz.tPgKwe.ogfYpf");
-    if (timeContainer) {
-      const timeSpan = timeContainer.querySelector("span.mv1WYe");
-      if (timeSpan) {
-        timeSpan.parentNode.insertBefore(badge, timeSpan.nextSibling);
-        return;
-      }
+    const timeSpan = timeContainer?.querySelector("span.mv1WYe");
+    if (!timeSpan || !timeSpan.parentNode) return false;
+    timeSpan.parentNode.insertBefore(badge, timeSpan.nextSibling);
+    return true;
+  }
+
+  // Layout-independent fallback: pin to the result row's corner. Needs no
+  // knowledge of the card's internals, so it survives markup drift.
+  function insertCorner(card, badge, claim) {
+    const row = card.closest("li") || card;
+    const colors = lib.badgeColors(claim);
+    row.style.position = "relative";
+    badge.style.cssText = [
+      "position: absolute",
+      "top: -3px",
+      "left: -6px",
+      "display: inline-flex",
+      "align-items: center",
+      "font-size: 9px",
+      `color: ${colors.fg}`,
+      `background: ${colors.bg}`,
+      "padding: 1px 5px",
+      "border-radius: 8px",
+      "font-weight: 500",
+      "white-space: nowrap",
+      "z-index: 10",
+      "box-shadow: 0 1px 2px rgba(0,0,0,0.08)",
+    ].join("; ");
+    row.insertBefore(badge, row.firstChild);
+  }
+
+  function addBadge(card, claim) {
+    try {
+      if (card.querySelector(".starlink-wifi-badge")) return;
+      const badge = buildBadge(claim);
+      const wantInline = window.innerWidth >= 1024;
+      if (wantInline && insertInline(card, badge)) return;
+      insertCorner(card, badge, claim);
+    } catch (err) {
+      log("badge insert failed", err);
     }
   }
 
-  const liElement = card.closest("li");
-  if (liElement) {
-    liElement.style.position = "relative";
-    badge.style.cssText = `
-      position: absolute;
-      top: -3px;
-      left: -6px;
-      display: inline-flex;
-      align-items: center;
-      font-size: 9px;
-      color: ${likely ? "#5f6368" : "#1967d2"};
-      background: ${likely ? "rgba(241, 243, 244, 0.9)" : "rgba(232, 240, 254, 0.85)"};
-      padding: 1px 5px;
-      border-radius: 8px;
-      font-weight: 500;
-      white-space: nowrap;
-      z-index: 10;
-      box-shadow: 0 1px 2px rgba(0,0,0,0.08);
-    `;
-    badge.textContent = badgeLabel(confidence, prediction);
-    liElement.insertBefore(badge, liElement.firstChild);
+  // ── main pass ──────────────────────────────────────────────────────────────
+
+  /** True when the card needs no further passes. */
+  async function processCard(card, pageDate, budget) {
+    const segments = extractSegments(card);
+    if (segments.length === 0) {
+      // Nothing tracked here (authoritative or not) — settled for this card.
+      processedElements.add(card);
+      return true;
+    }
+
+    // Respect the per-pass network budget BEFORE marking processed, so
+    // skipped cards get picked up by a later pass.
+    for (const seg of segments) {
+      const key = `${seg.flightNumber}-${seg.date || pageDate}`;
+      if (!cachedOutcome(key) && !pendingLookups.has(key)) {
+        if (budget.remaining <= 0) return false;
+        budget.remaining--;
+      }
+    }
+
+    const outcomes = await Promise.all(
+      segments.map((seg) => getClaim(seg.flightNumber, seg.date || pageDate))
+    );
+    // Only a settled answer retires the card. Marking it processed on a
+    // transient failure would strand it unbadged for the rest of the session:
+    // nothing else clears processedElements short of an SPA navigation.
+    const settled = outcomes.every((outcome) => !outcome.retryable);
+    if (settled) processedElements.add(card);
+
+    const combined = lib.combineClaims(outcomes.map((outcome) => outcome.claim));
+    if (lib.shouldBadge(combined)) {
+      addBadge(card, combined);
+      log("badged", segments.map((s) => s.flightNumber).join("+"), combined.status);
+    }
+    return settled;
   }
-}
 
-function extractFlightNumber(card) {
-  if (processedElements.has(card)) return null;
-  const cardText = card.innerText || "";
-  const ariaLabel = card.querySelector("[aria-label]")?.getAttribute("aria-label") || "";
+  // A pass that ends with unsettled cards schedules its own retry: when the
+  // user is just sitting on a result list nothing else wakes the extension, so
+  // the short error TTL alone would never be spent. Bounded so a hard outage
+  // costs a handful of passes, not an endless poll.
+  const MAX_RETRY_PASSES = 3;
+  const RETRY_DELAY_MS = lib.CACHE_TTL.error + 5000;
+  let retryPasses = 0;
+  let retryTimer = null;
 
-  if (!cardText.includes("United") && !ariaLabel.includes("United")) return null;
+  function scheduleRetryPass() {
+    if (retryTimer !== null || retryPasses >= MAX_RETRY_PASSES) return;
+    retryPasses++;
+    // Wait past the error TTL so the retry is a fresh lookup, not a cache replay.
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      processFlights();
+    }, RETRY_DELAY_MS);
+  }
 
-  let flightNumber = null;
+  function cancelRetryPass() {
+    if (retryTimer !== null) clearTimeout(retryTimer);
+    retryTimer = null;
+    retryPasses = 0;
+  }
 
-  const allElements = card.querySelectorAll("*");
-  for (const element of allElements) {
-    for (const attr of element.attributes) {
-      if (attr.value.includes("UA-") || attr.value.includes("/UA/")) {
-        let match = attr.value.match(/\bUA-(\d{3,4})-\d{8}\b/i);
-        if (!match) match = attr.value.match(/\bUA-(\d{3,4})\b/i);
-        if (!match) match = attr.value.match(/\/UA\/(\d{3,4})\//i);
-
-        if (match) {
-          flightNumber = `UA${match[1]}`;
-          break;
+  async function processFlights() {
+    if (isProcessing) return;
+    isProcessing = true;
+    let unsettled = false;
+    try {
+      const pageDate = extractPageDate();
+      const budget = { remaining: MAX_NEW_LOOKUPS_PER_PASS };
+      const cards = findFlightCards();
+      log(`pass: ${cards.size} cards`);
+      for (const card of cards) {
+        if (processedElements.has(card)) continue;
+        try {
+          if (!(await processCard(card, pageDate, budget))) unsettled = true;
+        } catch (err) {
+          // One broken card must not stop the pass or reach the page.
+          log("card failed", err);
         }
       }
+    } catch (err) {
+      log("pass failed", err);
+    } finally {
+      isProcessing = false;
     }
-    if (flightNumber) break;
+    if (unsettled) scheduleRetryPass();
+    else cancelRetryPass();
   }
 
-  if (!flightNumber) {
-    const uaMatch = cardText.match(/\bUA\s*(\d{1,4})\b/);
-    if (uaMatch) {
-      flightNumber = `UA${uaMatch[1]}`;
-    }
-  }
+  // ── lifecycle ──────────────────────────────────────────────────────────────
 
-  return flightNumber;
-}
-
-async function processFlights() {
-  if (isProcessing) {
-    log("Already processing, skipping...");
-    return;
-  }
-
-  isProcessing = true;
-
-  try {
-    const date = extractFlightDate();
-
-    const flightCards = document.querySelectorAll(".pIav2d");
-    log(`Found ${flightCards.length} flight cards`);
-
-    let processedCount = 0;
-    let starlinkCount = 0;
-
-    for (const card of flightCards) {
-      if (processedElements.has(card)) continue;
-
-      const flightNumber = extractFlightNumber(card);
-      if (!flightNumber) continue;
-
-      log(`Found flight number: ${flightNumber}`);
-      processedElements.add(card);
-      processedCount++;
-
-      const { hasStarlink, confidence, prediction } = await checkFlightForStarlink(
-        flightNumber,
-        date
-      );
-      if (hasStarlink) {
-        starlinkCount++;
-        addStarlinkBadge(card, confidence);
-        if (!DEBUG) console.log(`✈️ ${flightNumber} has Starlink WiFi (${confidence})`);
-      } else if (
-        prediction &&
-        prediction.probability >= PREDICTION_BADGE_THRESHOLD &&
-        prediction.confidence !== "low"
-      ) {
-        starlinkCount++;
-        addStarlinkBadge(card, "predicted", prediction);
-        if (!DEBUG)
-          console.log(
-            `✈️ ${flightNumber} likely Starlink (${Math.round(prediction.probability * 100)}%, ${prediction.n_observations} obs)`
-          );
-      }
-    }
-
-    if (processedCount > 0 && !DEBUG) {
-      console.log(
-        `[Starlink Tracker] Processed ${processedCount} UA flights, ${starlinkCount} have Starlink`
-      );
-    }
-  } finally {
-    isProcessing = false;
-  }
-}
-
-function debounce(func, wait) {
-  let timeout;
-  return function executedFunction(...args) {
-    const later = () => {
+  function debounce(fn, wait) {
+    let timeout;
+    return (...args) => {
       clearTimeout(timeout);
-      func(...args);
+      timeout = setTimeout(() => fn(...args), wait);
     };
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-  };
-}
-
-function reprocessAllFlights() {
-  for (const badge of document.querySelectorAll(".starlink-wifi-badge")) {
-    badge.remove();
   }
 
-  processedElements = new WeakSet();
-
-  processFlights();
-}
-
-let isProcessing = false;
-
-function initialize() {
-  setTimeout(processFlights, 1000);
-  const debouncedProcess = debounce(() => {
-    if (!isProcessing) {
-      processFlights();
+  function reprocessAllFlights() {
+    try {
+      for (const badge of document.querySelectorAll(".starlink-wifi-badge")) {
+        badge.remove();
+      }
+    } catch {
+      // removal is cosmetic; keep going
     }
-  }, 2000);
+    processedElements = new WeakSet();
+    cancelRetryPass();
+    processFlights();
+  }
 
-  const observer = new MutationObserver((mutations) => {
-    if (isProcessing) return;
-    const hasNewFlights = mutations.some((mutation) => {
-      return Array.from(mutation.addedNodes).some((node) => {
-        return (
-          node.nodeType === 1 &&
-          (node.classList?.contains("pIav2d") || node.querySelector?.(".pIav2d"))
+  function initialize() {
+    setTimeout(processFlights, 1000);
+    const debouncedProcess = debounce(processFlights, 2000);
+
+    const looksLikeFlightNode = (node) =>
+      node.nodeType === 1 &&
+      (node.matches?.(CARD_HINT_SELECTOR) || node.querySelector?.(CARD_HINT_SELECTOR) != null);
+
+    const observer = new MutationObserver((mutations) => {
+      try {
+        if (isProcessing) return;
+        const hasNewFlights = mutations.some((mutation) =>
+          Array.from(mutation.addedNodes).some(looksLikeFlightNode)
         );
-      });
+        if (hasNewFlights) debouncedProcess();
+      } catch {
+        // observer callbacks must never throw into the page
+      }
     });
+    observer.observe(document.body, { childList: true, subtree: true });
 
-    if (hasNewFlights) {
-      debouncedProcess();
-    }
-  });
+    // Badge placement differs across the desktop/mobile breakpoint.
+    let lastWidth = window.innerWidth;
+    window.addEventListener(
+      "resize",
+      debounce(() => {
+        const wasDesktop = lastWidth >= 1024;
+        lastWidth = window.innerWidth;
+        if (wasDesktop !== lastWidth >= 1024) reprocessAllFlights();
+      }, 500)
+    );
 
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-    attributes: false,
-    characterData: false,
-  });
+    // SPA navigation never fires load events — poll the URL.
+    let lastUrl = location.href;
+    setInterval(() => {
+      if (location.href !== lastUrl) {
+        lastUrl = location.href;
+        processedElements = new WeakSet();
+        // A new search gets a fresh retry budget.
+        cancelRetryPass();
+        setTimeout(processFlights, 1000);
+      }
+    }, 1000);
+  }
 
-  let lastWidth = window.innerWidth;
-  const handleResize = debounce(() => {
-    const currentWidth = window.innerWidth;
-    const wasDesktop = lastWidth >= 1024;
-    const isDesktop = currentWidth >= 1024;
-
-    if (wasDesktop !== isDesktop) {
-      lastWidth = currentWidth;
-      reprocessAllFlights();
-    }
-  }, 500);
-
-  window.addEventListener("resize", handleResize);
-
-  let lastUrl = location.href;
-  setInterval(() => {
-    const url = location.href;
-    if (url !== lastUrl) {
-      lastUrl = url;
-      processedElements = new WeakSet();
-      setTimeout(processFlights, 1000);
-    }
-  }, 1000);
-}
-
-if (document.readyState === "loading") {
-  document.addEventListener("DOMContentLoaded", initialize);
-} else {
-  initialize();
-}
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initialize);
+  } else {
+    initialize();
+  }
+})();

--- a/chrome-extension/lib.js
+++ b/chrome-extension/lib.js
@@ -1,0 +1,416 @@
+const StarlinkTrackerLib = (() => {
+  const API_BASES = Object.freeze({
+    united: "https://unitedstarlinktracker.com",
+    hub: "https://airlinestarlinktracker.com",
+  });
+
+  /**
+   * Marketing carriers the tracker answers for. `marker` gates the free-text
+   * fallback extractor: a bare "AS 123" in prose is only trusted when the
+   * airline's name also appears in the card.
+   */
+  const TRACKED_CARRIERS = Object.freeze({
+    UA: Object.freeze({ iata: "UA", airlineName: "United", marker: "United" }),
+    HA: Object.freeze({ iata: "HA", airlineName: "Hawaiian", marker: "Hawaiian" }),
+    AS: Object.freeze({ iata: "AS", airlineName: "Alaska", marker: "Alaska" }),
+  });
+
+  const CARRIER_CODES = Object.freeze(Object.keys(TRACKED_CARRIERS));
+  const CARRIER_ALT = CARRIER_CODES.join("|");
+
+  const FLIGHT_NUMBER_RE = new RegExp(`^(${CARRIER_ALT})\\d{1,4}$`);
+  const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+  function detectCarrier(flightNumber) {
+    if (typeof flightNumber !== "string") return null;
+    const m = flightNumber.toUpperCase().match(FLIGHT_NUMBER_RE);
+    return m ? m[1] : null;
+  }
+
+  function isValidDate(date) {
+    return typeof date === "string" && DATE_RE.test(date);
+  }
+
+  /**
+   * Which endpoint answers a flight number.
+   *
+   * UA stays on the frozen per-airline /api/check-flight: it is the contract
+   * maintained for this extension, and it is the only surface with the FR24
+   * near-departure fallback (the hub disables reverse tail lookups) — moving
+   * UA to the hub would silently degrade answers for the majority carrier.
+   * Everything else goes to the hub's /api/check-any-flight, the designated
+   * cross-carrier surface (resolves the marketing carrier server-side and
+   * reports untracked carriers as a 200 error body).
+   */
+  function endpointFor(flightNumber, date) {
+    const carrier = detectCarrier(flightNumber);
+    if (!carrier || !isValidDate(date)) return null;
+    const fn = flightNumber.toUpperCase();
+    const query = `flight_number=${encodeURIComponent(fn)}&date=${encodeURIComponent(date)}`;
+    return carrier === "UA"
+      ? `${API_BASES.united}/api/check-flight?${query}`
+      : `${API_BASES.hub}/api/check-any-flight?${query}`;
+  }
+
+  // ── flight extraction ──────────────────────────────────────────────────────
+
+  // Google's Travel Impact Model link data: itinerary segments of the form
+  // ORIGIN,DEST,CARRIER,NUMBER,YYYYMMDD (comma or dash separated). This is the
+  // most drift-resistant hook on the page — it is semantic data Google itself
+  // consumes, unlike the obfuscated class names.
+  const TIM_SEGMENT_RE = /([A-Z]{3})[-,]([A-Z]{3})[-,]([A-Z][A-Z0-9])[-,](\d{1,4})[-,](\d{8})/g;
+
+  function timDateToIso(yyyymmdd) {
+    return `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+  }
+
+  /** All itinerary segments in a Travel Impact Model URL — any carrier. */
+  function parseTimSegments(url) {
+    if (typeof url !== "string") return [];
+    const segments = [];
+    const seen = new Set();
+    for (const m of url.matchAll(TIM_SEGMENT_RE)) {
+      const flightNumber = `${m[3]}${m[4]}`;
+      const key = `${flightNumber}-${m[5]}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      segments.push({
+        origin: m[1],
+        destination: m[2],
+        carrier: m[3],
+        flightNumber,
+        date: timDateToIso(m[5]),
+      });
+    }
+    return segments;
+  }
+
+  /**
+   * Tracked segments across every Travel Impact Model URL on one card.
+   *
+   * `parsed` says whether ANY itinerary segment decoded, foreign carriers
+   * included. That is the difference between the two empty results: an
+   * itinerary that decoded and named no tracked carrier is an authoritative
+   * "not ours" (heuristics would only add false positives), while nothing
+   * decoding at all means the hook itself drifted and the heuristics are the
+   * only thing left.
+   */
+  function timCardSegments(urls) {
+    const segments = [];
+    let parsed = false;
+    for (const url of Array.isArray(urls) ? urls : []) {
+      for (const seg of parseTimSegments(url)) {
+        parsed = true;
+        if (!detectCarrier(seg.flightNumber)) continue;
+        if (segments.some((s) => s.flightNumber === seg.flightNumber && s.date === seg.date)) {
+          continue;
+        }
+        segments.push({ flightNumber: seg.flightNumber, date: seg.date });
+      }
+    }
+    return { parsed, segments };
+  }
+
+  /**
+   * Tracked carriers whose airline name appears in a card's text. This is the
+   * evidence gate both heuristic extractors run behind: "AS" and "HA" are
+   * ordinary English tokens, and Google's obfuscated attribute soup is full of
+   * two-letter fragments, so a code match only counts when the airline is
+   * actually named on the card.
+   */
+  function carriersNamedIn(text) {
+    if (typeof text !== "string" || text.length === 0) return [];
+    return CARRIER_CODES.filter((code) => text.includes(TRACKED_CARRIERS[code].marker));
+  }
+
+  // Attribute forms observed in Google Flights markup: "UA-123-20250101",
+  // "UA-123", "/UA/123/". Generalized from the v1 UA-only patterns; compiled
+  // per code set (three of them at most) rather than per attribute value.
+  const attrPatternCache = new Map();
+
+  function attrPatterns(codes) {
+    const key = codes.join("|");
+    let patterns = attrPatternCache.get(key);
+    if (!patterns) {
+      patterns = [
+        new RegExp(`\\b(${key})-(\\d{1,4})-\\d{8}\\b`),
+        new RegExp(`\\b(${key})-(\\d{1,4})\\b`),
+        new RegExp(`/(${key})/(\\d{1,4})/`),
+      ];
+      attrPatternCache.set(key, patterns);
+    }
+    return patterns;
+  }
+
+  /**
+   * First flight number for one of `allowedCodes` in an attribute value, or
+   * null. `allowedCodes` is required and fails closed: an ungated scan over
+   * every attribute of a card matches things like "…;AS-12;…" in Google's
+   * internal payloads and would badge a foreign carrier's card with a real
+   * lookup for an unrelated flight.
+   */
+  function parseAttrFlightNumber(value, allowedCodes) {
+    if (typeof value !== "string" || value.length > 4096) return null;
+    if (!Array.isArray(allowedCodes)) return null;
+    const codes = allowedCodes.filter((code) => CARRIER_CODES.includes(code));
+    if (codes.length === 0) return null;
+    // Substring prefilter before the regex loop: this runs over every attribute
+    // of every element in a card, and the patterns can only match around
+    // "XX-" or "/XX/".
+    if (!codes.some((code) => value.includes(`${code}-`) || value.includes(`/${code}/`))) {
+      return null;
+    }
+    for (const re of attrPatterns(codes)) {
+      const m = value.match(re);
+      if (m) return `${m[1]}${m[2]}`;
+    }
+    return null;
+  }
+
+  /**
+   * Last-resort extraction from visible card text. Case-sensitive and gated on
+   * the airline name appearing in the card (see carriersNamedIn).
+   */
+  function extractFlightNumbersFromText(text) {
+    const found = [];
+    for (const code of carriersNamedIn(text)) {
+      const re = new RegExp(`\\b${code}\\s?(\\d{1,4})\\b`, "g");
+      for (const m of text.matchAll(re)) {
+        const fn = `${code}${m[1]}`;
+        if (!found.includes(fn)) found.push(fn);
+        if (found.length >= 4) return found;
+      }
+    }
+    return found;
+  }
+
+  // ── claim ladder ───────────────────────────────────────────────────────────
+
+  const PREDICTION_CONFIDENCES = Object.freeze(["high", "medium", "low"]);
+
+  function unknownClaim() {
+    return {
+      status: "unknown",
+      probability: null,
+      predictionConfidence: null,
+      nObservations: null,
+      airline: null,
+    };
+  }
+
+  /**
+   * Map an API payload onto the claim ladder. Handles both wire shapes —
+   * /api/check-flight (structured `prediction` object, ladder `confidence`)
+   * and /api/check-any-flight (top-level `probability`, predictor-grade
+   * `confidence`) — plus anything unexpected, which lands on `unknown`.
+   * `hasStarlink: false` is a verified negative on both surfaces; null/absent
+   * means "no assignment yet", never no.
+   *
+   * A probability with a non-prediction grade (`confidence: "type"` — the
+   * registry-derived subfleet answer for carriers with no flight-history
+   * model) stays on the predicted rung with a null grade: the number is real,
+   * but it is not a history grade and must not be dressed up as one.
+   */
+  function normalizeClaim(payload) {
+    const claim = unknownClaim();
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) return claim;
+    if (typeof payload.airline === "string") claim.airline = payload.airline;
+    if (payload.error !== undefined) return claim;
+
+    if (payload.hasStarlink === true) {
+      claim.status = payload.confidence === "verified" ? "verified" : "installed";
+      return claim;
+    }
+    if (payload.hasStarlink === false) {
+      claim.status = "no_starlink";
+      return claim;
+    }
+
+    const prediction =
+      payload.prediction && typeof payload.prediction === "object" ? payload.prediction : null;
+    const probability = prediction ? prediction.probability : payload.probability;
+    if (typeof probability === "number" && Number.isFinite(probability)) {
+      claim.status = "predicted";
+      claim.probability = Math.min(1, Math.max(0, probability));
+      const grade = prediction ? prediction.confidence : payload.confidence;
+      if (PREDICTION_CONFIDENCES.includes(grade)) claim.predictionConfidence = grade;
+      if (prediction && typeof prediction.n_observations === "number") {
+        claim.nObservations = prediction.n_observations;
+      }
+      return claim;
+    }
+    return claim;
+  }
+
+  /**
+   * Claim from a background-worker response envelope. A transport failure is
+   * retryable (short cache); a parsed answer — even "untracked airline" — is
+   * settled and cached at full TTL.
+   */
+  function claimFromResponse(response) {
+    if (
+      response &&
+      response.success === true &&
+      response.data &&
+      typeof response.data === "object"
+    ) {
+      return { claim: normalizeClaim(response.data), retryable: false };
+    }
+    return { claim: unknownClaim(), retryable: true };
+  }
+
+  const CLAIM_RANK = Object.freeze({
+    verified: 4,
+    installed: 3,
+    predicted: 2,
+    no_starlink: 1,
+    unknown: 0,
+  });
+
+  const GRADE_RANK = Object.freeze({ high: 0, medium: 1, low: 2 });
+
+  /**
+   * Combine per-segment claims for a multi-leg itinerary: the weakest rung
+   * wins, so a card is never badged "Starlink" when only one leg has it. For
+   * predicted legs the lowest probability and weakest grade carry through —
+   * tracked separately, because the least-likely leg is not necessarily the
+   * least-trusted one. Inheriting the min-probability leg's grade let a
+   * high-probability/low-confidence leg (which shouldBadge suppresses on its
+   * own) ride a sibling leg's "high" into a badge.
+   *
+   * An ungraded prediction (fleet/subfleet penetration, which carries a
+   * probability but no history grade) leaves the grade alone: it is not
+   * evidence of weakness, and it must not manufacture a grade either.
+   */
+  function combineClaims(claims) {
+    if (!Array.isArray(claims) || claims.length === 0) return unknownClaim();
+    let weakest = claims[0];
+    for (const claim of claims.slice(1)) {
+      if (CLAIM_RANK[claim.status] < CLAIM_RANK[weakest.status]) weakest = claim;
+    }
+    if (weakest.status !== "predicted") return { ...weakest };
+    let combined = weakest;
+    let grade = null;
+    let gradeRank = -1;
+    for (const claim of claims) {
+      if (claim.status !== "predicted") continue;
+      if (claim.probability < combined.probability) combined = claim;
+      const rank = GRADE_RANK[claim.predictionConfidence];
+      if (rank !== undefined && rank > gradeRank) {
+        gradeRank = rank;
+        grade = claim.predictionConfidence;
+      }
+    }
+    return { ...combined, predictionConfidence: grade };
+  }
+
+  // Aircraft assignments only exist ~2 days out; above this historical rate a
+  // "likely" badge beats silence, below it silence beats a coin-flip badge.
+  const PREDICTION_BADGE_THRESHOLD = 0.8;
+
+  function shouldBadge(claim) {
+    if (!claim) return false;
+    if (claim.status === "verified" || claim.status === "installed") return true;
+    return (
+      claim.status === "predicted" &&
+      typeof claim.probability === "number" &&
+      claim.probability >= PREDICTION_BADGE_THRESHOLD &&
+      claim.predictionConfidence !== "low"
+    );
+  }
+
+  // ── badge copy ─────────────────────────────────────────────────────────────
+
+  function roundPct(probability) {
+    return Math.round(probability * 100);
+  }
+
+  function badgeLabel(claim) {
+    if (claim.status === "predicted") return `Starlink ~${roundPct(claim.probability)}%`;
+    if (claim.status === "installed") return "Starlink (installed)";
+    return "Starlink";
+  }
+
+  function badgeTitle(claim) {
+    const airline = claim.airline ? ` (${claim.airline})` : "";
+    if (claim.status === "predicted") {
+      const obs =
+        typeof claim.nObservations === "number" && claim.nObservations > 0
+          ? ` (${claim.nObservations} recent departure${claim.nObservations === 1 ? "" : "s"} observed)`
+          : "";
+      return (
+        `~${roundPct(claim.probability)}% chance this flight gets a Starlink-equipped ` +
+        `aircraft${obs}${airline}. Airlines assign the actual aircraft ~2 days before departure.`
+      );
+    }
+    if (claim.status === "installed") {
+      return `Aircraft is Starlink-equipped per fleet data${airline} — not yet verified against the airline's site.`;
+    }
+    return `Verified Starlink WiFi${airline}`;
+  }
+
+  function badgeClass(claim) {
+    return `starlink-wifi-badge starlink-wifi-badge--${claim.status}`;
+  }
+
+  // Predicted/installed render in muted tones so an unverified claim never
+  // carries verified visual weight.
+  const BADGE_COLORS = Object.freeze({
+    verified: Object.freeze({ fg: "#1967d2", bg: "#e8f0fe" }),
+    installed: Object.freeze({ fg: "#188038", bg: "#e6f4ea" }),
+    predicted: Object.freeze({ fg: "#5f6368", bg: "#f1f3f4" }),
+  });
+
+  function badgeColors(claim) {
+    return BADGE_COLORS[claim.status] || BADGE_COLORS.predicted;
+  }
+
+  // ── caching policy ─────────────────────────────────────────────────────────
+
+  // Settled answers hold for the browsing session's practical span; transport
+  // failures retry soon so an API blip doesn't blank a whole search session.
+  const CACHE_TTL = Object.freeze({
+    resolved: 30 * 60 * 1000,
+    error: 5 * 60 * 1000,
+  });
+
+  /** Today in the user's timezone — flight searches are local-date shaped. */
+  function localTodayIso(now = new Date()) {
+    const y = now.getFullYear();
+    const m = String(now.getMonth() + 1).padStart(2, "0");
+    const d = String(now.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+  }
+
+  return {
+    API_BASES,
+    TRACKED_CARRIERS,
+    CACHE_TTL,
+    PREDICTION_BADGE_THRESHOLD,
+    detectCarrier,
+    isValidDate,
+    endpointFor,
+    parseTimSegments,
+    timCardSegments,
+    carriersNamedIn,
+    parseAttrFlightNumber,
+    extractFlightNumbersFromText,
+    unknownClaim,
+    normalizeClaim,
+    claimFromResponse,
+    combineClaims,
+    shouldBadge,
+    badgeLabel,
+    badgeTitle,
+    badgeClass,
+    badgeColors,
+    localTodayIso,
+  };
+})();
+
+if (typeof module !== "undefined" && typeof module.exports !== "undefined") {
+  module.exports = StarlinkTrackerLib;
+}
+if (typeof globalThis !== "undefined") {
+  globalThis.StarlinkTrackerLib = StarlinkTrackerLib;
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,9 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Google Flights Starlink Indicator",
-  "version": "1.4.0",
-  "description": "Highlights flights with Starlink WiFi on Google Flights",
-  "permissions": ["storage"],
+  "version": "2.0.0",
+  "description": "Shows which United, Hawaiian, and Alaska flights have Starlink WiFi on Google Flights — verified, installed, or predicted.",
   "host_permissions": ["https://unitedstarlinktracker.com/*"],
   "background": {
     "service_worker": "background.js"
@@ -11,7 +10,7 @@
   "content_scripts": [
     {
       "matches": ["https://www.google.com/flights/*", "https://www.google.com/travel/flights/*"],
-      "js": ["content.js"],
+      "js": ["lib.js", "content.js"],
       "css": ["styles.css"],
       "run_at": "document_idle"
     }

--- a/chrome-extension/styles.css
+++ b/chrome-extension/styles.css
@@ -1,21 +1,33 @@
+/* Claim-ladder badge tiers. Inline styles set the same colors defensively
+ * (Google Flights styling is aggressive); these classes are the declarative
+ * source of truth and the hook for the hover affordance. */
+
 .starlink-wifi-badge {
   display: inline-flex !important;
   align-items: center;
   margin-left: 8px;
   padding: 4px 10px;
-  background-color: #0064e0;
-  color: white;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 500;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
   white-space: nowrap;
   vertical-align: middle;
-  animation: fadeIn 0.3s ease-in;
+  animation: starlink-badge-fade-in 0.3s ease-in;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
-.starlink-wifi-badge--likely {
+.starlink-wifi-badge--verified {
+  background-color: #e8f0fe;
+  color: #1967d2;
+}
+
+.starlink-wifi-badge--installed {
+  background-color: #e6f4ea;
+  color: #188038;
+}
+
+.starlink-wifi-badge--predicted {
   background-color: #f1f3f4;
   color: #5f6368;
 }
@@ -25,11 +37,7 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
 }
 
-.starlink-wifi-badge svg {
-  flex-shrink: 0;
-}
-
-@keyframes fadeIn {
+@keyframes starlink-badge-fade-in {
   from {
     opacity: 0;
     transform: scale(0.8);
@@ -40,28 +48,9 @@
   }
 }
 
-.pIav2d .starlink-wifi-badge {
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.sSHqwe + .starlink-wifi-badge {
-  margin-left: 12px;
-}
-
-.Ak5kof .starlink-wifi-badge,
-.Ir0Voe .starlink-wifi-badge {
-  flex-shrink: 0;
-}
-
 @media (max-width: 768px) {
   .starlink-wifi-badge {
     font-size: 11px;
     padding: 3px 8px;
-  }
-
-  .starlink-wifi-badge svg {
-    width: 14px;
-    height: 14px;
   }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -177,8 +177,19 @@ docker run -p 3000:3000 -v /path/to/data:/srv/ua-starlink-tracker ua-starlink-tr
 
 ## Chrome Extension Compatibility
 
-The `/api/check-flight` endpoint powers the [Chrome extension](https://chromewebstore.google.com/detail/google-flights-starlink-i/jjfljoifenkfdbldliakmmjhdkbhehoi). Maintain backwards compatibility:
+Two endpoints power the [Chrome extension](https://chromewebstore.google.com/detail/google-flights-starlink-i/jjfljoifenkfdbldliakmmjhdkbhehoi). Installed copies update on Google's schedule, not ours, so both shapes are backwards-compatible-only — add keys, never rename or drop them.
+
+`/api/check-flight` (per-airline hosts) — United lookups:
 
 - Accept `flight_number` and `date` query parameters
 - Return `hasStarlink` (boolean) and `flights` (array)
 - Include CORS headers for Google Flights domains
+
+`/api/check-any-flight` (hub host only) — Hawaiian/Alaska and any future carrier. The extension (`chrome-extension/lib.js`, `normalizeClaim`) reads exactly these top-level keys:
+
+- `hasStarlink` — `true` / `false` / `null`. `false` means a *verified* negative; `null` means "no assignment yet", never "no".
+- `confidence` — `"verified"` separates the verified rung from the installed rung on a `true`; predictor grades `"high" | "medium" | "low"`; `"type"` marks a registry-derived answer.
+- `probability` — 0–1, top-level (NOT nested under `prediction`). Present on prediction and no_model penetration answers; absence keeps type-split answers off the badge.
+- `airline` — display name for badge tooltips.
+- `error` — settled answer body (untracked carrier / bad input), not an outage.
+- `flights` — array; present on every branch.

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1006,6 +1006,8 @@ const apiCheckAnyFlight: Handler = async ({ req, url, reader, getReader, tenant 
           hasStarlink: null,
           airline: cfg.name,
           confidence: "type",
+          // Additive top-level `probability` for the extension claim ladder.
+          ...(verdict.answer.kind === "penetration" ? { probability: verdict.answer.pen.pct } : {}),
           reason: describeCarrierPrediction(cfg, verdict.answer),
           flights: [],
         }),

--- a/tests/extension.test.ts
+++ b/tests/extension.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Chrome extension v2 logic + cross-contract tests.
+ *
+ * The extension's pure logic (chrome-extension/lib.js) normalizes every API
+ * payload into a claim-ladder answer before rendering. Unit tests pin that
+ * mapping; the dispatch tests feed the normalizer REAL responses from the
+ * frozen /api/check-flight contract and the hub's /api/check-any-flight, so
+ * a wire-shape change that would break the shipped extension fails here.
+ * Assertions are shape-based — they must survive snapshot data drift.
+ */
+
+import type { Database } from "bun:sqlite";
+import { beforeAll, describe, expect, test } from "bun:test";
+import extLib from "../chrome-extension/lib.js";
+import { createApp } from "../src/server/app";
+import { airportLocalDate } from "../src/utils/airport-tz";
+import { jsonOf, openSnapshot } from "./helpers";
+
+const UA_HOST = "unitedstarlinktracker.com";
+const HUB_HOST = "airlinestarlinktracker.com";
+
+const CLAIM_STATUSES = ["verified", "installed", "predicted", "no_starlink", "unknown"];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Endpoint routing
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("extension endpoint routing", () => {
+  test("UA stays on the frozen per-airline check-flight contract", () => {
+    const url = extLib.endpointFor("UA123", "2026-06-01");
+    expect(url).toStartWith(`https://${UA_HOST}/api/check-flight?`);
+    expect(url).toContain("flight_number=UA123");
+    expect(url).toContain("date=2026-06-01");
+  });
+
+  test("non-UA tracked carriers route to the hub's check-any-flight", () => {
+    for (const fn of ["HA50", "AS2402"]) {
+      const url = extLib.endpointFor(fn, "2026-06-01");
+      expect(url).toStartWith(`https://${HUB_HOST}/api/check-any-flight?`);
+      expect(url).toContain(`flight_number=${fn}`);
+    }
+  });
+
+  test("untracked carriers and malformed input never produce a URL", () => {
+    expect(extLib.endpointFor("DL123", "2026-06-01")).toBeNull();
+    expect(extLib.endpointFor("UA12345", "2026-06-01")).toBeNull();
+    expect(extLib.endpointFor("UA123", "06/01/2026")).toBeNull();
+    expect(extLib.endpointFor("UA123", "2026-06-01x")).toBeNull();
+    expect(extLib.endpointFor(null, "2026-06-01")).toBeNull();
+  });
+
+  test("lowercase input is normalized before hitting the wire", () => {
+    expect(extLib.endpointFor("ua123", "2026-06-01")).toContain("flight_number=UA123");
+    expect(extLib.detectCarrier("ha50")).toBe("HA");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Flight extraction
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Travel Impact Model URL parsing", () => {
+  test("parses comma- and dash-separated itinerary segments", () => {
+    for (const sep of [",", "-"]) {
+      const url = `https://travelimpactmodel.org/lookup/flight?itinerary=${["SFO", "EWR", "UA", "1234", "20260601"].join(sep)}`;
+      const segments = extLib.parseTimSegments(url);
+      expect(segments).toHaveLength(1);
+      expect(segments[0]).toEqual({
+        origin: "SFO",
+        destination: "EWR",
+        carrier: "UA",
+        flightNumber: "UA1234",
+        date: "2026-06-01",
+      });
+    }
+  });
+
+  test("multi-leg itineraries yield one segment per leg, deduped", () => {
+    const url =
+      "https://x/flight?itinerary=SFO,DEN,UA,500,20260601,DEN,EWR,UA,1500,20260601,DEN,EWR,UA,1500,20260601";
+    const segments = extLib.parseTimSegments(url);
+    expect(segments).toHaveLength(2);
+    expect(segments.map((s: { flightNumber: string }) => s.flightNumber)).toEqual([
+      "UA500",
+      "UA1500",
+    ]);
+  });
+
+  test("carries untracked carriers through (caller filters)", () => {
+    const segments = extLib.parseTimSegments("https://x/flight?itinerary=JFK,LAX,B6,623,20260601");
+    expect(segments).toHaveLength(1);
+    expect(segments[0].carrier).toBe("B6");
+    expect(extLib.detectCarrier(segments[0].flightNumber)).toBeNull();
+  });
+
+  test("garbage in, empty array out — never throws", () => {
+    for (const bad of [null, undefined, 42, "", "no segments here", "UA,123"]) {
+      expect(extLib.parseTimSegments(bad)).toEqual([]);
+    }
+  });
+});
+
+describe("per-card itinerary aggregation", () => {
+  const tim = (itinerary: string) => `https://travelimpactmodel.org/lookup/flight?${itinerary}`;
+
+  test("decoded segments are authoritative, tracked or not", () => {
+    const ours = extLib.timCardSegments([tim("itinerary=SFO,EWR,UA,123,20260601")]);
+    expect(ours.parsed).toBe(true);
+    expect(ours.segments).toEqual([{ flightNumber: "UA123", date: "2026-06-01" }]);
+
+    // Decoded and foreign: parsed stays true so the caller skips the
+    // heuristics rather than text-matching a competitor's card.
+    const theirs = extLib.timCardSegments([tim("itinerary=JFK,LAX,B6,623,20260601")]);
+    expect(theirs.parsed).toBe(true);
+    expect(theirs.segments).toEqual([]);
+  });
+
+  test("an itinerary encoding that no longer decodes falls back, it does not settle", () => {
+    // The attribute is present and the flight IS United; only the separator
+    // changed. Reporting parsed:false is what keeps the heuristics available.
+    const drifted = extLib.timCardSegments([tim("itinerary=SFO.EWR.UA.123.20260601")]);
+    expect(drifted.parsed).toBe(false);
+    expect(drifted.segments).toEqual([]);
+    expect(extLib.timCardSegments([]).parsed).toBe(false);
+    expect(extLib.timCardSegments(null).parsed).toBe(false);
+  });
+
+  test("legs repeated across elements are deduped", () => {
+    const url = tim("itinerary=SFO,DEN,UA,500,20260601,DEN,EWR,UA,1500,20260601");
+    const both = extLib.timCardSegments([url, url]);
+    expect(both.segments.map((s: { flightNumber: string }) => s.flightNumber)).toEqual([
+      "UA500",
+      "UA1500",
+    ]);
+  });
+});
+
+describe("attribute and text extraction fallbacks", () => {
+  const ALL = ["UA", "HA", "AS"];
+
+  test("attribute forms: XX-NNNN-YYYYMMDD, XX-NNNN, /XX/NNNN/", () => {
+    expect(extLib.parseAttrFlightNumber("foo UA-1234-20260601 bar", ALL)).toBe("UA1234");
+    expect(extLib.parseAttrFlightNumber("HA-50", ALL)).toBe("HA50");
+    expect(extLib.parseAttrFlightNumber("/booking/AS/118/details", ALL)).toBe("AS118");
+    expect(extLib.parseAttrFlightNumber("DL-1234-20260601", ALL)).toBeNull();
+    expect(extLib.parseAttrFlightNumber("", ALL)).toBeNull();
+    expect(extLib.parseAttrFlightNumber(null, ALL)).toBeNull();
+  });
+
+  test("attribute extraction is gated on the carriers named in the card", () => {
+    // Google's obfuscated attribute soup is full of two-letter fragments. Only
+    // an airline the card actually names may be matched out of it.
+    expect(extLib.parseAttrFlightNumber("data-jsdata=deferred;AS-12;x", ["UA"])).toBeNull();
+    expect(extLib.parseAttrFlightNumber("/gws/HA/9/img", ["UA"])).toBeNull();
+    expect(extLib.parseAttrFlightNumber("data-jsdata=deferred;AS-12;x", ["AS"])).toBe("AS12");
+    // Fails closed: no gate supplied, no match, ever.
+    expect(extLib.parseAttrFlightNumber("foo UA-1234-20260601 bar")).toBeNull();
+    expect(extLib.parseAttrFlightNumber("foo UA-1234-20260601 bar", [])).toBeNull();
+    expect(extLib.parseAttrFlightNumber("foo UA-1234-20260601 bar", ["DL"])).toBeNull();
+  });
+
+  test("carriersNamedIn is the shared airline-name gate", () => {
+    expect(extLib.carriersNamedIn("United · UA 1234 · 5h 30m")).toEqual(["UA"]);
+    expect(extLib.carriersNamedIn("Alaska/Hawaiian codeshare")).toEqual(["HA", "AS"]);
+    expect(extLib.carriersNamedIn("Delta · DL 456")).toEqual([]);
+    expect(extLib.carriersNamedIn(null)).toEqual([]);
+  });
+
+  test("text extraction requires the airline-name marker", () => {
+    expect(extLib.extractFlightNumbersFromText("United · UA 1234 · 5h 30m")).toEqual(["UA1234"]);
+    expect(extLib.extractFlightNumbersFromText("Alaska AS2402 nonstop")).toEqual(["AS2402"]);
+    // "AS 123" without "Alaska" in the card is a common-word trap, not a flight.
+    expect(extLib.extractFlightNumbersFromText("listed AS 123 options")).toEqual([]);
+    expect(extLib.extractFlightNumbersFromText("Delta DL 456 nonstop")).toEqual([]);
+    expect(extLib.extractFlightNumbersFromText("")).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Claim normalization (unit)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("claim normalization", () => {
+  test("check-flight shapes map onto the ladder", () => {
+    expect(
+      extLib.normalizeClaim({ hasStarlink: true, confidence: "verified", flights: [] })
+    ).toMatchObject({ status: "verified" });
+    expect(
+      extLib.normalizeClaim({ hasStarlink: true, confidence: "likely", flights: [] })
+    ).toMatchObject({ status: "installed" });
+    expect(
+      extLib.normalizeClaim({ hasStarlink: false, confidence: "verified", flights: [] })
+    ).toMatchObject({ status: "no_starlink" });
+
+    const predicted = extLib.normalizeClaim({
+      hasStarlink: null,
+      confidence: "predicted",
+      prediction: { probability: 0.92, confidence: "high", n_observations: 14 },
+      flights: [],
+    });
+    expect(predicted).toEqual({
+      status: "predicted",
+      probability: 0.92,
+      predictionConfidence: "high",
+      nObservations: 14,
+      airline: null,
+    });
+  });
+
+  test("check-any-flight shapes map onto the ladder (top-level probability)", () => {
+    const predicted = extLib.normalizeClaim({
+      hasStarlink: null,
+      airline: "Alaska Airlines",
+      probability: 0.85,
+      confidence: "medium",
+      reason: "x",
+      flights: [],
+    });
+    expect(predicted).toMatchObject({
+      status: "predicted",
+      probability: 0.85,
+      predictionConfidence: "medium",
+      airline: "Alaska Airlines",
+    });
+
+    // Type-level answers carry no probability — honest unknown, not a badge.
+    const typeOnly = extLib.normalizeClaim({
+      hasStarlink: null,
+      airline: "Hawaiian Airlines",
+      confidence: "type",
+      reason: "determined by aircraft type",
+      flights: [],
+    });
+    expect(typeOnly.status).toBe("unknown");
+  });
+
+  test("hostile or drifted payloads land on unknown, never a yes", () => {
+    for (const payload of [
+      null,
+      undefined,
+      [],
+      "yes",
+      { error: "Airline not tracked. Tracked: UA, HA, AS" },
+      { hasStarlink: "true" },
+      { hasStarlink: null, prediction: { probability: "0.9" } },
+      { hasStarlink: null, probability: Number.NaN },
+      {},
+    ]) {
+      expect(extLib.normalizeClaim(payload).status).toBe("unknown");
+    }
+    // Out-of-range probabilities clamp instead of rendering ~150%.
+    expect(extLib.normalizeClaim({ hasStarlink: null, probability: 1.5 }).probability).toBe(1);
+  });
+
+  test("transport failures are retryable; parsed answers are settled", () => {
+    expect(extLib.claimFromResponse({ success: false, error: "timeout" })).toEqual({
+      claim: extLib.unknownClaim(),
+      retryable: true,
+    });
+    expect(extLib.claimFromResponse(undefined).retryable).toBe(true);
+    const settled = extLib.claimFromResponse({ success: true, data: { error: "not tracked" } });
+    expect(settled.retryable).toBe(false);
+    expect(settled.claim.status).toBe("unknown");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Badging policy
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("badging policy", () => {
+  const predicted = (probability: number, predictionConfidence = "high") => ({
+    ...extLib.unknownClaim(),
+    status: "predicted",
+    probability,
+    predictionConfidence,
+  });
+
+  test("verified and installed always badge; negatives and unknowns never do", () => {
+    expect(extLib.shouldBadge({ ...extLib.unknownClaim(), status: "verified" })).toBe(true);
+    expect(extLib.shouldBadge({ ...extLib.unknownClaim(), status: "installed" })).toBe(true);
+    expect(extLib.shouldBadge({ ...extLib.unknownClaim(), status: "no_starlink" })).toBe(false);
+    expect(extLib.shouldBadge(extLib.unknownClaim())).toBe(false);
+    expect(extLib.shouldBadge(null)).toBe(false);
+  });
+
+  test("predictions badge only at ≥ threshold with non-low confidence", () => {
+    expect(extLib.shouldBadge(predicted(0.92))).toBe(true);
+    expect(extLib.shouldBadge(predicted(extLib.PREDICTION_BADGE_THRESHOLD))).toBe(true);
+    expect(extLib.shouldBadge(predicted(0.79))).toBe(false);
+    expect(extLib.shouldBadge(predicted(0.95, "low"))).toBe(false);
+  });
+
+  test("multi-leg combine: the weakest leg wins", () => {
+    const verified = { ...extLib.unknownClaim(), status: "verified" };
+    const installed = { ...extLib.unknownClaim(), status: "installed" };
+    expect(extLib.combineClaims([verified, installed]).status).toBe("installed");
+    expect(extLib.combineClaims([verified, extLib.unknownClaim()]).status).toBe("unknown");
+    expect(
+      extLib.combineClaims([verified, { ...extLib.unknownClaim(), status: "no_starlink" }]).status
+    ).toBe("no_starlink");
+    const combined = extLib.combineClaims([predicted(0.95), predicted(0.82)]);
+    expect(combined.status).toBe("predicted");
+    expect(combined.probability).toBe(0.82);
+    expect(extLib.combineClaims([]).status).toBe("unknown");
+  });
+
+  test("multi-leg combine: probability and confidence grade are both worst-case", () => {
+    // The least-likely leg is not necessarily the least-trusted one. Inheriting
+    // the min-probability leg's grade laundered a low-confidence leg — which
+    // shouldBadge suppresses on its own — into a badge via its sibling.
+    const mixed = extLib.combineClaims([predicted(0.95, "low"), predicted(0.88, "high")]);
+    expect(mixed.probability).toBe(0.88);
+    expect(mixed.predictionConfidence).toBe("low");
+    expect(extLib.shouldBadge(mixed)).toBe(false);
+    expect(extLib.shouldBadge(predicted(0.95, "low"))).toBe(false);
+
+    expect(extLib.combineClaims([predicted(0.9, "high"), predicted(0.95, "medium")])).toMatchObject(
+      {
+        probability: 0.9,
+        predictionConfidence: "medium",
+      }
+    );
+    // An ungraded prediction (registry/subfleet answer) neither weakens a
+    // graded sibling nor invents a grade of its own.
+    expect(
+      extLib.combineClaims([predicted(0.99, null), predicted(0.9, "high")]).predictionConfidence
+    ).toBe("high");
+    expect(
+      extLib.combineClaims([predicted(0.99, null), predicted(0.9, null)]).predictionConfidence
+    ).toBeNull();
+  });
+
+  test("badge copy states the rung, never a bare boolean", () => {
+    expect(extLib.badgeLabel({ ...extLib.unknownClaim(), status: "verified" })).toBe("Starlink");
+    expect(extLib.badgeLabel({ ...extLib.unknownClaim(), status: "installed" })).toBe(
+      "Starlink (installed)"
+    );
+    expect(extLib.badgeLabel(predicted(0.876))).toBe("Starlink ~88%");
+    expect(extLib.badgeTitle({ ...extLib.unknownClaim(), status: "installed" })).toContain(
+      "not yet verified"
+    );
+    const title = extLib.badgeTitle({ ...predicted(0.876), nObservations: 3 });
+    expect(title).toContain("~88%");
+    expect(title).toContain("3 recent departures");
+    expect(extLib.badgeClass(predicted(0.9))).toContain("starlink-wifi-badge--predicted");
+  });
+
+  test("localTodayIso yields a YYYY-MM-DD in local time", () => {
+    expect(extLib.localTodayIso()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(extLib.localTodayIso(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cross-contract: normalizer × real API responses
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("extension normalizer against live handler responses", () => {
+  let db: Database;
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    db = openSnapshot();
+    app = createApp(db);
+  });
+
+  // Past date sits outside FR24's lookup window, so no network is attempted.
+  test("UA frozen endpoint: prediction branch normalizes to a predicted claim", async () => {
+    const body = await jsonOf(
+      app,
+      "/api/check-flight?flight_number=UA1234&date=2024-01-15",
+      UA_HOST
+    );
+    const claim = extLib.normalizeClaim(body);
+    expect(claim.status).toBe("predicted");
+    expect(claim.probability).toBeGreaterThanOrEqual(0);
+    expect(claim.probability).toBeLessThanOrEqual(1);
+    expect(["high", "medium", "low"]).toContain(claim.predictionConfidence);
+    expect(typeof claim.nObservations).toBe("number");
+  });
+
+  test.each([
+    ["HA9999", "HNL", 1774200000],
+    ["AS118", "SEA", 1774200000],
+  ])(
+    "hub check-any-flight: %s canary normalizes to a firm-yes rung",
+    async (flightNumber, airport, departureTime) => {
+      const date =
+        airportLocalDate(airport, departureTime) ??
+        new Date(departureTime * 1000).toISOString().slice(0, 10);
+      const body = await jsonOf(
+        app,
+        `/api/check-any-flight?flight_number=${flightNumber}&date=${date}`,
+        HUB_HOST
+      );
+      const claim = extLib.normalizeClaim(body);
+      expect(["verified", "installed"]).toContain(claim.status);
+      expect(typeof claim.airline).toBe("string");
+      expect(extLib.shouldBadge(claim)).toBe(true);
+    }
+  );
+
+  // Carriers with no flight-history model answer from the registry instead. A
+  // single-subfleet answer carries a probability the ladder can read; a
+  // per-type split carries none, and must stay off the badge rather than blend
+  // "always yes" types with "never" ones.
+  test("hub registry answers: a probability badges, its absence abstains", async () => {
+    for (const fn of ["AS850", "AS2402", "HA50"]) {
+      const body = await jsonOf(
+        app,
+        `/api/check-any-flight?flight_number=${fn}&date=2024-06-01`,
+        HUB_HOST
+      );
+      const claim = extLib.normalizeClaim(body);
+      if (body.probability === undefined) {
+        expect(claim.status, fn).toBe("unknown");
+        expect(extLib.shouldBadge(claim), fn).toBe(false);
+        continue;
+      }
+      expect(claim.status, fn).toBe("predicted");
+      expect(claim.probability, fn).toBeGreaterThanOrEqual(0);
+      expect(claim.probability, fn).toBeLessThanOrEqual(1);
+      // "type" is not a history grade and must never be dressed up as one.
+      expect(claim.predictionConfidence, fn).toBeNull();
+    }
+  });
+
+  test("hub check-any-flight: untracked carrier settles as unknown (no badge)", async () => {
+    for (const fn of ["DL123", "QR9999"]) {
+      const body = await jsonOf(
+        app,
+        `/api/check-any-flight?flight_number=${fn}&date=2026-06-01`,
+        HUB_HOST
+      );
+      const claim = extLib.normalizeClaim(body);
+      expect(claim.status).toBe("unknown");
+      expect(extLib.shouldBadge(claim)).toBe(false);
+    }
+  });
+
+  test("every normalized status stays inside the ladder vocabulary", async () => {
+    const bodies = await Promise.all([
+      jsonOf(app, "/api/check-flight?flight_number=UA1&date=2024-06-01", UA_HOST),
+      jsonOf(app, "/api/check-any-flight?flight_number=HA50&date=2024-06-01", HUB_HOST),
+      jsonOf(app, "/api/check-any-flight?flight_number=AS2402&date=2024-06-01", HUB_HOST),
+    ]);
+    for (const body of bodies) {
+      expect(CLAIM_STATUSES).toContain(extLib.normalizeClaim(body).status);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Partial land of `roadmap/extension-v2` onto current main (API surgery).

**Included**
- Full `chrome-extension/` v2 (lib.js, content.js, background, styles, manifest, README, QA checklist)
- `tests/extension.test.ts`
- Additive top-level `probability` on hub `/api/check-any-flight` `no_model` penetration answers
- Docs for the check-any-flight contract

**Deferred (need Cloud Agent — conflicts with main `renderSubPage` / #75 / prediction land)**
- `invalidHeadline` + document-title alignment for other-carrier 404s
- `renderSubPage` opts rewrite (`edgeCacheable` / `omitPageStructuredData`)
- Rendering tests that assert omitted WebPage JSON-LD on 404s

Self-canonical noindex for invalid check-flight URLs is in #95 instead.

## Test plan
- [ ] `tests/extension.test.ts`
- [ ] Manual: Google Flights badge on UA + HA/AS
- [ ] `/api/check-any-flight` penetration answers include top-level `probability`