### PR TITLE
fix(seo): hub free FAQ — United needs MileagePlus login

### DIFF
--- a/src/airlines/content/hub.tsx
+++ b/src/airlines/content/hub.tsx
@@ -218,12 +218,14 @@ export const content: AirlineContent = {
           q: "Is Starlink WiFi free on these airlines?",
           a: () => (
             <p>
-              Yes — United, Hawaiian, and Alaska all offer Starlink free to every passenger,
-              gate-to-gate, with no login wall or loyalty requirement. This is a deliberate contrast
-              with the paid legacy WiFi most carriers still use.
+              Starlink itself is not a paid add-on on these airlines, but access rules differ:{" "}
+              <strong>United</strong> requires a free MileagePlus login (join on the spot if
+              needed); <strong>Hawaiian</strong> and <strong>Alaska</strong> offer it to every
+              passenger with no loyalty signup. Speeds are gate-to-gate on equipped aircraft —
+              confirm on the airline&apos;s WiFi portal once you board.
             </p>
           ),
-          ld: "Yes. United, Hawaiian, and Alaska all offer Starlink WiFi free to every passenger, gate-to-gate.",
+          ld: "Starlink is not a paid add-on on United, Hawaiian, or Alaska, but access differs: United requires a free MileagePlus login; Hawaiian and Alaska have no loyalty signup. Confirm on the airline WiFi portal once you board.",
         },
       ],
     },

--- a/tests/seo-copy.test.ts
+++ b/tests/seo-copy.test.ts
@@ -104,6 +104,17 @@ describe("page copy", () => {
     ).text();
     expect(body).not.toContain('href="/route-planner"');
   });
+
+  test("hub free FAQ does not claim every airline is free with no login", async () => {
+    const body = await (
+      await app.dispatch(req("/", HUB, { headers: { Accept: "text/html" } }))
+    ).text();
+    expect(body).not.toContain("no login wall or loyalty requirement");
+    expect(body).not.toContain("free to every passenger, gate-to-gate, with no login");
+    expect(body).toContain("MileagePlus");
+    expect(body).toContain("Hawaiian");
+    expect(body).toContain("Alaska");
+  });
 });
 
 describe("/mcp content negotiation", () => {


### PR DESCRIPTION
## Summary
Hub FAQ still claimed United/Hawaiian/Alaska Starlink is free for every passenger with **no login wall or loyalty requirement**. That contradicts the United content fix (#93): United free WiFi requires a free **MileagePlus** login.

## Evidence
- Live hub homepage FAQ + FAQPage JSON-LD still said “no login wall”
- United `/is-starlink-free` and UA FAQ correctly require MileagePlus

## Changes
- `src/airlines/content/hub.tsx` — FAQ answer + `ld` string: United = MileagePlus login; Hawaiian/Alaska = no loyalty signup
- `tests/seo-copy.test.ts` — regression: hub must not claim blanket no-login free access

## Test plan
- [ ] Hub `/` FAQ “Is Starlink WiFi free…” mentions MileagePlus for United
- [ ] FAQPage JSON-LD matches visible copy
- [ ] `bun test tests/seo-copy.test.ts`
