### PR TITLE
fix(seo): stop hub/tool pages cannibalizing brand tracker SERPs

### DIFF
--- a/src/airlines/registry.ts
+++ b/src/airlines/registry.ts
@@ -746,11 +746,14 @@ export function looksLikeValidTailNumber(tail: string): boolean {
 // sites — its copy deliberately avoids "<airline> starlink tracker" phrasing
 // so it never outranks its own tenants on their brand queries.
 export const HUB_BRAND: PageBrand = {
-  title: "Airline Starlink Tracker",
-  tagline: "Which airlines have Starlink WiFi — every rollout, compared",
+  // H1 must stay comparison-intent — "Airline Starlink Tracker" competed with
+  // unitedstarlinktracker.com for "united starlink tracker" (Hub ~4% CTR vs
+  // United ~86% on the same impressions).
+  title: "Which Airlines Have Starlink WiFi?",
+  tagline: "Compare every Starlink rollout — United, Hawaiian, Alaska, and more",
   siteTitle: "Starlink WiFi by Airline — Which Airlines Have Starlink in 2026?",
   description:
-    "The list of airlines with Starlink WiFi and where each rollout stands: United and Alaska tracked live tail-by-tail, Hawaiian's completed fleet, and more carriers as they launch. Compare fleet counts and percent equipped side by side.",
+    "Compare airlines with Starlink WiFi side by side: United and Alaska tracked live tail-by-tail, Hawaiian's completed fleet, and more carriers as they launch. Fleet counts and percent equipped, not a single-airline tracker.",
   ogTitle: "Which Airlines Have Starlink WiFi? — Full List & Comparison",
   ogDescription:
     "Every airline with Starlink WiFi, compared: fleet counts, percent equipped, and rollout status — with live per-aircraft tracking where available.",

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1526,6 +1526,18 @@ export function hubUrlFamilies(
   };
 }
 
+/**
+ * Hub /airlines/{slug} pages for carriers that already have a live dedicated
+ * tracker (unitedstarlinktracker.com, alaskastarlinktracker.com, …) duplicate
+ * brand SERPs at ~4% CTR while the brand host converts at ~86%. Those pages
+ * stay reachable for hub visitors (CTA → live tracker) but are noindex and
+ * omitted from the hub sitemap so Google consolidates on the brand host.
+ * Carriers without a live tenant (Hawaiian today) keep a normal indexable hub page.
+ */
+export function hubAirlinePageIndexable(cfg: AirlineConfig): boolean {
+  return !siteForAirline(cfg.code, true);
+}
+
 const robotsTxt: Handler = ({ site }) => {
   // /mcp is deliberately SEO'd where mcpPage is on: GET serves HTML (crawlers
   // only GET), POST is the JSON-RPC protocol and invisible to robots. So the
@@ -1587,7 +1599,7 @@ const sitemap: Handler = (ctx) => {
   // Each hub airline page's lastmod is that airline's own data freshness, not
   // the hub-wide max — an airline without a stamp yet omits lastmod rather
   // than borrowing another airline's.
-  const airlineEntries = hubUrls.trackedAirlines.map((cfg) => ({
+  const airlineEntries = hubUrls.trackedAirlines.filter(hubAirlinePageIndexable).map((cfg) => ({
     path: `/airlines/${airlineSlug(cfg)}`,
     changefreq: "daily",
     priority: "0.7",
@@ -2403,18 +2415,22 @@ function subPageMeta(
   const short = cfg?.shortName ?? "Tracked Fleets";
   if (page === "check-flight")
     return {
-      siteTitle: `Does My ${short} Flight Have Starlink? Check Any Flight — Live`,
-      siteDescription: `Does my flight have Starlink? Enter ${/^[aeiou]/i.test(short) ? "an" : "a"} ${short} flight number and date for a live answer — verified within ~2 days of departure, predicted from 12,000+ past flights.`,
-      keywords: `does my flight have starlink, does my ${short.toLowerCase()} flight have starlink, check ${cfg?.iata ?? "airline"} flight starlink, ${name} wifi check`,
-      ogTitle: `Does My ${short} Flight Have Starlink?`,
-      ogDescription: `Check any ${short} flight by number and date — live answer for whether your aircraft has free Starlink WiFi.`,
+      // Tool intent — avoid soaking "united starlink tracker" brand impressions
+      // (check-flight previously sat at ~2% CTR on that query at position ~1).
+      siteTitle: `Check a ${short} Flight for Starlink WiFi — Flight Number Lookup`,
+      siteDescription: `Enter ${/^[aeiou]/i.test(short) ? "an" : "a"} ${short} flight number and date for a live Starlink answer — verified near departure, with a probability estimate earlier from past assignments.`,
+      keywords: `check ${cfg?.iata ?? "airline"} flight starlink, does my ${short.toLowerCase()} flight have starlink, ${name} flight wifi lookup, starlink flight checker`,
+      ogTitle: `Check a ${short} Flight for Starlink`,
+      ogDescription: `Flight-number lookup for ${short} Starlink WiFi — live answer by date when assignments publish.`,
     };
   if (page === "routes")
     return {
-      siteTitle: `Where ${short} Starlink Is Flying Today — Live Routes | ${brand.title}`,
+      // Drop "| ${brand.title}" — that appended the brand-tracker name into the
+      // SERP title and pulled brand impressions onto a 0.25% CTR utility page.
+      siteTitle: `${short} Starlink Flights Today — Live Routes by Departure`,
       siteDescription: `Every ${name} departure scheduled on a Starlink-equipped aircraft over the next 48 hours, grouped by route and counted from live tail assignments.`,
-      keywords: `${name} starlink routes, which routes have starlink, ${cfg?.iata ?? "airline"} starlink flights today, starlink wifi routes`,
-      ogTitle: `Where ${short} Starlink Is Flying Today`,
+      keywords: `${name} starlink routes today, ${cfg?.iata ?? "airline"} starlink departures, live starlink routes, starlink wifi flights today`,
+      ogTitle: `${short} Starlink Flights Today`,
       ogDescription: `Live count of ${name} departures on Starlink-equipped aircraft by route, next 48 hours.`,
     };
   if (page === "route-planner")
@@ -2432,11 +2448,11 @@ function subPageMeta(
   const fleetLead = cfg ? `${short} Fleet` : "Tracked Fleets";
   const fleetOf = cfg ? `${name} aircraft` : "aircraft from every tracked airline";
   return {
-    siteTitle: `${fleetLead} Starlink Rollout — Every Tail Number, Every WiFi Provider`,
-    siteDescription: `See every ${fleetOf} at once, colored by WiFi provider. Track which aircraft types are done and how many Starlink planes are in the air right now.`,
-    keywords: `${name} fleet starlink, wifi by aircraft, starlink rollout progress, tail number wifi`,
-    ogTitle: `${fleetLead} Starlink Rollout`,
-    ogDescription: "Every tail number, colored by WiFi provider.",
+    siteTitle: `${fleetLead} WiFi Map — Starlink vs Other Providers by Tail`,
+    siteDescription: `Browse every ${fleetOf}, colored by WiFi provider. See which types still lack Starlink and how many equipped planes are flying right now.`,
+    keywords: `${name} fleet wifi map, starlink by tail number, aircraft wifi provider, ${short.toLowerCase()} starlink fleet`,
+    ogTitle: `${fleetLead} WiFi Map`,
+    ogDescription: "Every tail number, colored by WiFi provider — Starlink vs legacy systems.",
   };
 }
 
@@ -3120,21 +3136,32 @@ const airlineDetailPage: Handler = (ctx) => {
     const redirect = canonicalOrRedirect(airlineSlug(cfg));
     if (redirect) return redirect;
     const overview = airlineOverview(ctx.getReader, cfg);
+    const liveTracker = siteForAirline(cfg.code, true);
+    const indexable = hubAirlinePageIndexable(cfg);
     return renderSubPage(
       ctx,
       AirlineDetailPage,
       `/airlines/${airlineSlug(cfg)}`,
       {
-        siteTitle: `${cfg.name} Starlink WiFi — Rollout Status & Fleet Progress`,
-        siteDescription: `Where the ${cfg.name} Starlink rollout stands: ${cfg.rollout.phaseNote} Fleet counts and percent equipped, updated continuously.`,
-        keywords: `${cfg.name.toLowerCase()} starlink, does ${cfg.shortName.toLowerCase()} have starlink, ${cfg.shortName.toLowerCase()} starlink wifi, ${cfg.shortName.toLowerCase()} starlink rollout`,
-        ogTitle: `${cfg.name} Starlink WiFi — Rollout Status`,
+        // Comparison-hub framing — avoid "<airline> starlink tracker" titles that
+        // cannibalize the live brand host on brand SERPs.
+        siteTitle: indexable
+          ? `${cfg.name} Starlink WiFi — Rollout Status Compared Across Airlines`
+          : `${cfg.name} Starlink on the Hub — See the Full Tracker for Flight Checks`,
+        siteDescription: indexable
+          ? `Where the ${cfg.name} Starlink rollout stands beside other carriers: ${cfg.rollout.phaseNote} Fleet counts and percent equipped, updated continuously.`
+          : `Hub snapshot of the ${cfg.name} Starlink rollout (${cfg.rollout.phaseNote}). For flight checks and the live tracker, use ${liveTracker!.canonicalHost}.`,
+        keywords: indexable
+          ? `${cfg.name.toLowerCase()} starlink rollout, ${cfg.shortName.toLowerCase()} starlink compared, airlines with starlink wifi`
+          : `${cfg.name.toLowerCase()} starlink compared, ${cfg.shortName.toLowerCase()} starlink hub`,
+        ogTitle: `${cfg.name} Starlink — Hub Comparison Snapshot`,
         ogDescription: cfg.rollout.phaseNote,
+        ...(indexable ? {} : { robotsMeta: "noindex, follow" }),
       },
       { overview, facts: factsForCode(cfg.code), phases: passengerPhases(cfg.code) },
       200,
-      // Same stamp the sitemap gives this URL: this airline's own data
-      // freshness, not the request clock.
+      // Same stamp the sitemap gives this URL when indexable; noindex pages still
+      // use the airline's data freshness for WebPage dateModified consistency.
       stampedIso(ctx.getReader(cfg.code).getLastUpdatedRaw())
     );
   }

--- a/tests/airlines-pages.test.ts
+++ b/tests/airlines-pages.test.ts
@@ -24,7 +24,7 @@ import {
 } from "../src/airlines/rollout-facts";
 import { factsHeadline } from "../src/components/airlines-page";
 import { createReaderFactory } from "../src/database/reader";
-import { createApp, hubUrlFamilies } from "../src/server/app";
+import { createApp, hubAirlinePageIndexable, hubUrlFamilies } from "../src/server/app";
 import { openSnapshot, req } from "./helpers";
 
 let app: ReturnType<typeof createApp>;
@@ -246,15 +246,19 @@ describe("hub /airlines/{slug} facts pages (content-level roster)", () => {
 });
 
 describe("sitemaps", () => {
-  test("hub sitemap advertises the index, every tracked airline, and every facts page", async () => {
+  test("hub sitemap advertises the index, indexable tracked airlines, and every facts page", async () => {
     const res = await get("/sitemap.xml", hub.canonicalHost);
     expect(res.status).toBe(200);
     const xml = await res.text();
     expect(xml).toContain(`<loc>https://${hub.canonicalHost}/airlines</loc>`);
     for (const cfg of trackedRoster()) {
-      expect(xml, cfg.code).toContain(
-        `<loc>https://${hub.canonicalHost}/airlines/${airlineSlug(cfg)}</loc>`
-      );
+      const loc = `<loc>https://${hub.canonicalHost}/airlines/${airlineSlug(cfg)}</loc>`;
+      if (hubAirlinePageIndexable(cfg)) {
+        expect(xml, cfg.code).toContain(loc);
+      } else {
+        // Live brand trackers own those SERPs — hub page stays reachable but unadvertised.
+        expect(xml, cfg.code).not.toContain(loc);
+      }
     }
     for (const entry of contentOnlyFacts()) {
       expect(xml, entry.slug).toContain(
@@ -286,9 +290,13 @@ describe("sitemaps", () => {
         .find((b) => b.includes(`<loc>https://${hub.canonicalHost}${path}</loc>`));
       return block?.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1];
     };
+    // Only sitemap-advertised roster URLs — noindex hub airline pages (live
+    // brand trackers) are deliberately absent from the sitemap.
     const paths = [
       ...contentOnlyFacts().map((e) => `/airlines/${e.slug}`),
-      ...trackedRoster().map((cfg) => `/airlines/${airlineSlug(cfg)}`),
+      ...trackedRoster()
+        .filter(hubAirlinePageIndexable)
+        .map((cfg) => `/airlines/${airlineSlug(cfg)}`),
     ];
     let checked = 0;
     let unstamped = 0;
@@ -324,8 +332,8 @@ describe("sitemaps", () => {
   });
 
   // An /airlines/{slug} that serves 200 while nothing advertises it is an
-  // orphan: indexable, unreachable, and invisible to the only lists a
-  // maintainer edits. Unpublishing an airline has to take its page with it.
+  // orphan — unless it is a deliberate noindex handoff to a live brand tracker
+  // (United/Alaska today). Unpublishing an airline still has to take its page.
   test("no /airlines page serves outside the sitemap's population", async () => {
     const xml = await (await get("/sitemap.xml", hub.canonicalHost)).text();
     for (const entry of AIRLINE_FACTS) {
@@ -333,6 +341,18 @@ describe("sitemaps", () => {
         `<loc>https://${hub.canonicalHost}/airlines/${entry.slug}</loc>`
       );
       const res = await get(`/airlines/${entry.slug}`, hub.canonicalHost);
+      const liveHandoff =
+        entry.trackedCode != null &&
+        !hubAirlinePageIndexable(AIRLINES[entry.trackedCode] as AirlineConfig);
+      if (liveHandoff) {
+        expect(res.status, entry.slug).toBe(200);
+        expect(advertised, `${entry.slug} should not be sitemap-advertised`).toBe(false);
+        const body = await res.text();
+        expect(body, entry.slug).toContain("noindex");
+        const byIata = await get(`/airlines/${entry.iata.toLowerCase()}`, hub.canonicalHost);
+        expect(byIata.status, entry.iata).toBe(301);
+        continue;
+      }
       expect(
         res.status === 200,
         `${entry.slug}: served=${res.status} advertised=${advertised}`

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1197,10 +1197,12 @@ describe("SEO meta", () => {
     expect(parsed.mainEntity.length).toBeGreaterThan(3);
   });
 
-  test("/check-flight title leads with the question and short brand name", async () => {
+  test("/check-flight title leads with tool intent and short brand name", async () => {
     const html = await getHtml("/check-flight");
     const title = html.match(/<title>([^<]+)<\/title>/)?.[1] ?? "";
-    expect(title.startsWith("Does My United Flight Have Starlink?")).toBe(true);
+    // Tool-intent lead — avoid soaking "united starlink tracker" brand SERPs.
+    expect(title.startsWith("Check a United Flight for Starlink")).toBe(true);
+    expect(title).not.toContain("United Airlines Starlink Tracker");
     expect(title).not.toContain("{{");
   });
 

--- a/tests/isolation.test.ts
+++ b/tests/isolation.test.ts
@@ -81,7 +81,7 @@ describe("tenant resolution", () => {
     expect(hubManifest.status).toBe(200);
 
     expect(await uaManifest.json()).toMatchObject({ name: "United Airlines Starlink Tracker" });
-    expect(await hubManifest.json()).toMatchObject({ name: "Airline Starlink Tracker" });
+    expect(await hubManifest.json()).toMatchObject({ name: "Which Airlines Have Starlink WiFi?" });
   });
 });
 


### PR DESCRIPTION
## Summary
Stop hub + tool pages from soaking **airline-brand tracker** impressions at near-zero CTR. Hub H1/title and live-tracker hub airline pages were competing with United/Alaska brand hosts; tool page titles still read like brand trackers.

## Evidence (GSC 28d)
- Query `united starlink tracker`: **United 2301c / 86% CTR** vs **Hub 109c / 4% CTR** (near-identical impressions)
- United tool pages on the same brand query: `/check-flight` ~2% CTR, `/fleet` ~1.3%, `/routes` ~0.25% (titles included brand-tracker framing; `/routes` even appended `| United Airlines Starlink Tracker`)

## Changes
- `src/airlines/registry.ts` — `HUB_BRAND` H1/title → comparison intent (“Which Airlines Have Starlink WiFi?”)
- `src/server/app.ts`
  - `hubAirlinePageIndexable()` — hub `/airlines/{slug}` for carriers with a **live** dedicated tracker → `noindex,follow` + omitted from hub sitemap (Hawaiian without live tenant stays indexable)
  - Hub airline detail titles reframed as comparison / handoff copy
  - Tool titles for `/check-flight`, `/fleet`, `/routes` rewritten toward tool intent (route-planner left for a dedicated PR)
- `tests/airlines-pages.test.ts` — sitemap / orphan / freshness expectations updated for the live-tracker handoff

## Out of scope
- `/route-planner` title/meta (separate PR)
- Cross-host `<link rel="canonical">` (would need `index.html` + PageMeta plumbing)

## Test plan
- [ ] Hub `/` H1 is comparison-intent, not “Airline Starlink Tracker”
- [ ] Hub `/airlines/united` and `/airlines/alaska`: `noindex,follow`; absent from hub sitemap; still 200 with tracker CTA
- [ ] Hub `/airlines/hawaiian` remains indexable + in sitemap
- [ ] United `/check-flight`, `/fleet`, `/routes` titles no longer end with brand-tracker name
- [ ] `bun test tests/airlines-pages.test.ts tests/meta-surfaces.test.ts`

## Additional test pins (post-CI)
- `tests/integration.test.ts` — `/check-flight` title → tool-intent lead
- `tests/isolation.test.ts` — hub webmanifest name → new HUB_BRAND.title

## Merge note
Conflicts with #99 on `src/server/app.ts` (`subPageMeta`). Merge one, rebase the other.
