### PR TITLE
fix(seo): route-planner title/meta for airport Starlink search intent

### DIFF
--- a/src/components/route-planner-page.tsx
+++ b/src/components/route-planner-page.tsx
@@ -111,11 +111,11 @@ export default function RoutePlannerPage({ site }: RoutePlannerPageProps) {
       <header className="relative py-5 sm:py-6 text-center mb-6">
         <a href="/" className="block">
           <h1 className="font-display text-3xl sm:text-4xl font-bold text-primary mb-2 tracking-tight hover:text-accent transition-colors">
-            Starlink Route Planner
+            Find Starlink-Equipped Flights
           </h1>
         </a>
         <p className="text-base text-secondary font-display">
-          Find the best way to fly {airlineName} with Starlink WiFi
+          Search {airlineName} flights between any two airports — ranked by Starlink coverage
         </p>
       </header>
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -2419,12 +2419,14 @@ function subPageMeta(
     };
   if (page === "route-planner")
     return {
-      siteTitle: `${short} Starlink Route Planner — Find Flights With Starlink WiFi`,
-      siteDescription: `See which ${name} routes and flights have Starlink WiFi. Compare direct flights and one-stop connections between any two cities, ranked by Starlink probability, and book the routing with coverage the whole way.`,
-      keywords: `${name} starlink route planner, which ${cfg?.iata ?? "airline"} flights have starlink, ${name} starlink routes, best route for starlink, plan starlink trip`,
-      ogTitle: `${short} Starlink Route Planner`,
-      ogDescription:
-        "Find direct flights and smart connections with the highest Starlink probability.",
+      // Tool/snippet intent — was ranking for "united starlink tracker" at
+      // pos ~1.8 with 0.27% CTR (7 clicks / 2614 impr). Lead with the job:
+      // find Starlink-equipped flights between airports.
+      siteTitle: `Find Starlink-Equipped ${short} Flights Between Airports`,
+      siteDescription: `Pick two airports to find ${name} flights and one-stop connections on Starlink-equipped aircraft. Ranked by Starlink probability and connected hours — not a brand tracker homepage.`,
+      keywords: `starlink flights between airports, ${cfg?.iata ?? "airline"} starlink route finder, find starlink equipped flights, ${name} starlink connections`,
+      ogTitle: `Find Starlink-Equipped ${short} Flights`,
+      ogDescription: `Search ${short} flights between any two airports ranked by Starlink probability and connected hours.`,
     };
   // On the hub there is no carrier, and "${short} Fleet" degenerated to
   // "Tracked Fleets Fleet"; "every ${name} aircraft" likewise read "every


### PR DESCRIPTION
## Summary
Dedicated title / meta / OG / Twitter + H1 rewrite for `/route-planner` so snippets describe **finding Starlink-equipped flights between airports**, not brand-tracker language.

## Evidence (GSC 28d)
- `/route-planner`: **7 clicks / 2614 impr / 0.27% CTR / pos ~1.8**
- Same URL cluster also ranked for `united starlink tracker` at pos ~1 with ~0.2% CTR

## Changes
- `src/server/app.ts` — `subPageMeta(..., "route-planner")` title, description, keywords, ogTitle, ogDescription
- `src/components/route-planner-page.tsx` — H1 + subhead aligned with tool intent

OG/Twitter tags reuse `ogTitle` / `ogDescription` from the same meta object (already wired in `index.html`).

## Test plan
- [ ] United `/route-planner` `<title>` leads with “Find Starlink-Equipped … Flights Between Airports”
- [ ] `og:title` / `twitter:title` match; description mentions airports / probability, not “Starlink Tracker”
- [ ] H1 reads “Find Starlink-Equipped Flights”
- [ ] Smoke: page still plans routes (no logic change)
